### PR TITLE
fix: promotion in Distance

### DIFF
--- a/src/unxt/_base.py
+++ b/src/unxt/_base.py
@@ -19,6 +19,7 @@ from astropy.units import (
 )
 from jax.numpy import dtype as DType  # noqa: N812
 from jaxtyping import Array, ArrayLike, Shaped
+from plum import add_promotion_rule
 from quax import ArrayValue
 from typing_extensions import Self
 
@@ -398,6 +399,12 @@ def constructor(
     The `value` is converted to the new `unit`.
     """
     return cls(xp.asarray(value.to_value(unit), dtype=dtype), unit)
+
+
+# -----------------------------------------------
+# Promotion rules
+
+add_promotion_rule(AbstractQuantity, AbstractQuantity, AbstractQuantity)
 
 
 # ===============================================================

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -25,8 +25,6 @@ from jaxtyping import Array, ArrayLike
 from plum import promote
 from quax import register as register_
 
-import quaxed.array_api as xp
-
 from ._base import AbstractQuantity, can_convert_unit
 from ._core import AbstractParametricQuantity, Quantity
 from ._distance import Distance
@@ -2318,6 +2316,21 @@ def _integer_pow_p(x: AbstractQuantity, *, y: Any) -> AbstractQuantity:
     return type_np(x)(value=lax.integer_pow(x.value, y), unit=x.unit**y)
 
 
+@register(lax.integer_pow_p)
+def _integer_pow_p_d(x: Distance, *, y: Any) -> Quantity:
+    """Integer power of a Distance.
+
+    Examples
+    --------
+    >>> from unxt import Distance
+    >>> q = Distance(2, "m")
+    >>> q ** 3
+    Quantity['volume'](Array(8, dtype=int32), unit='m3')
+
+    """
+    return Quantity(value=lax.integer_pow(x.value, y), unit=x.unit**y)
+
+
 # ==============================================================================
 
 
@@ -2700,25 +2713,29 @@ def _pow_p_qq(
 
 
 @register(lax.pow_p)
-def _pow_p_qf(x: AbstractQuantity, y: ArrayLike | int | float) -> AbstractQuantity:
+def _pow_p_qf(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
     return type_np(x)(value=lax.pow(x.value, y), unit=x.unit**y)
 
 
 @register(lax.pow_p)
-def _pow_p_d(x: Distance, y: Any) -> Quantity:
+def _pow_p_d(
+    x: Distance,
+    y: ArrayLike | AbstractParametricQuantity["dimensionless"],
+) -> Quantity:
     """Power of a Distance by redispatching to Quantity.
 
     Examples
     --------
+    >>> import math
     >>> from unxt import Distance
 
-    >>> q1 = Distance(10, "m")
-    >>> y = 3
+    >>> q1 = Distance(10.0, "m")
+    >>> y = 3.0
     >>> q1 ** y
     Quantity["volume"](Array(1000, dtype=int32), unit='m3')
 
     """
-    return xp.pow(Quantity(x.value, x.unit), y)  # TODO: better call to power
+    return Quantity(x.value, x.unit) ** y  # TODO: better call to power
 
 
 # ==============================================================================

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -2718,10 +2718,7 @@ def _pow_p_qf(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
 
 
 @register(lax.pow_p)
-def _pow_p_d(
-    x: Distance,
-    y: ArrayLike | AbstractParametricQuantity["dimensionless"],
-) -> Quantity:
+def _pow_p_d(x: Distance, y: ArrayLike) -> Quantity:
     """Power of a Distance by redispatching to Quantity.
 
     Examples

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -22,8 +22,10 @@ from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
 from jax._src.typing import Shape
 from jax.core import Primitive
 from jaxtyping import Array, ArrayLike
-from plum import convert, promote
+from plum import promote
 from quax import register as register_
+
+import quaxed.array_api as xp
 
 from ._base import AbstractQuantity, can_convert_unit
 from ._core import AbstractParametricQuantity, Quantity
@@ -2716,7 +2718,7 @@ def _pow_p_d(x: Distance, y: Any) -> Quantity:
     Quantity["volume"](Array(1000, dtype=int32), unit='m3')
 
     """
-    return convert(x, Quantity) ** y  # TODO: better call to power
+    return xp.pow(Quantity(x.value, x.unit), y)  # TODO: better call to power
 
 
 # ==============================================================================
@@ -2886,7 +2888,7 @@ def _rem_p(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(10, "m")
     >>> q2 = Quantity(3, "m")
     >>> q1 % q2
-    Quantity['length'](Array(1, dtype=int32), unit='m')
+    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
 
     >>> from unxt import Distance
     >>> q1 = Distance(10, "m")

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -1681,7 +1681,7 @@ def _dot_general_dd(
     Quantity['length'](Array([0, 1, 0], dtype=int32), unit='m')
 
     """
-    return type_np(lhs)(
+    return Quantity(
         lax.dot_general_p.bind(
             lhs.value,
             rhs.value,
@@ -2880,7 +2880,7 @@ def _rem_p(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = UncheckedQuantity(10, "m")
     >>> q2 = UncheckedQuantity(3, "m")
     >>> q1 % q2
-    UncheckedQuantity(Array(1, dtype=int32), unit='m')
+    UncheckedQuantity(Array(1, dtype=int32, ...), unit='m')
 
     >>> from unxt import Quantity
     >>> q1 = Quantity(10, "m")
@@ -2892,7 +2892,7 @@ def _rem_p(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Distance(10, "m")
     >>> q2 = Quantity(3, "m")
     >>> q1 % q2
-    Distance(Array(1, dtype=int32), unit='m')
+    Distance(Array(1, dtype=int32, ...), unit='m')
 
     """
     return replace(x, value=lax.rem(x.value, y.to_value(x.unit)))

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -22,7 +22,7 @@ from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
 from jax._src.typing import Shape
 from jax.core import Primitive
 from jaxtyping import Array, ArrayLike
-from plum import promote
+from plum import convert, promote
 from quax import register as register_
 
 from ._base import AbstractQuantity, can_convert_unit

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -22,6 +22,7 @@ from jax._src.lax.slicing import GatherDimensionNumbers, GatherScatterMode
 from jax._src.typing import Shape
 from jax.core import Primitive
 from jaxtyping import Array, ArrayLike
+from plum import promote
 from quax import register as register_
 
 from ._base import AbstractQuantity, can_convert_unit
@@ -1437,7 +1438,8 @@ def _div_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
 
     """
     unit = Unit(x.unit / y.unit)
-    return type_np(x)(lax.div(x.value, y.value), unit=unit)
+    xp, yp = promote(x, y)
+    return type_np(xp)(lax.div(xp.value, yp.value), unit=unit)
 
 
 @register(lax.div_p)

--- a/src/unxt/_register_primitives.py
+++ b/src/unxt/_register_primitives.py
@@ -2729,7 +2729,7 @@ def _pow_p_d(x: Distance, y: ArrayLike) -> Quantity:
     >>> q1 = Distance(10.0, "m")
     >>> y = 3.0
     >>> q1 ** y
-    Quantity["volume"](Array(1000, dtype=int32), unit='m3')
+    Quantity['volume'](Array(1000., dtype=float32, ...), unit='m3')
 
     """
     return Quantity(x.value, x.unit) ** y  # TODO: better call to power


### PR DESCRIPTION
Operations on Distance don't necessarily result in a distance. We need to promote quantities to the correct type. This PR handles promotion through a mixture of specific dispatch rules and `plum.promote` with new promotion and conversion rules for AbstractQuantity and Distance.