### PR TITLE
feat: unit system refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@
       "__init__.py" = ["F403"]
       "docs/conf.py" = ["A001", "INP001"]
       "noxfile.py" = ["T20"]
-      "tests/**" = ["ANN", "S101", "T20"]
+      "tests/**" = ["ANN", "S101", "SLF001", "T20"]
 
     [tool.ruff.lint.isort]
       combine-as-imports = true

--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -10,7 +10,7 @@ from ._unxt import (
 )
 from ._unxt.quantity import *
 from ._version import version as __version__
-from .unitsystems import AbstractUnitSystem, UnitSystem, unitsystem
+from .unitsystems import AbstractUnitSystem, unitsystem
 
 # isort: split
 from . import _interop  # noqa: F401  # register interop
@@ -20,7 +20,6 @@ __all__ = [
     # units systems
     "unitsystems",  # module
     "AbstractUnitSystem",  # base class
-    "UnitSystem",  # main user-facing class
     "unitsystem",  # convenience constructor
 ]
 __all__ += quantity.__all__

--- a/src/unxt/_interop/unxt_interop_gala/unitsystems.py
+++ b/src/unxt/_interop/unxt_interop_gala/unitsystems.py
@@ -9,16 +9,42 @@ from gala.units import (  # pylint: disable=import-error
 )
 from plum import dispatch
 
-from unxt.unitsystems import DimensionlessUnitSystem, UnitSystem, dimensionless
+from unxt.unitsystems import AbstractUnitSystem, DimensionlessUnitSystem, dimensionless
 
 
 @dispatch
-def unitsystem(value: GalaUnitSystem, /) -> UnitSystem:
-    usys = UnitSystem(*value._core_units)  # noqa: SLF001
-    usys._registry = value._registry  # noqa: SLF001
-    return usys
+def unitsystem(value: GalaUnitSystem, /) -> AbstractUnitSystem:
+    """Return a `gala.units.UnitSystem` as a `unxt.AbstractUnitSystem`.
+
+    Examples
+    --------
+    >>> from gala.units import UnitSystem
+    >>> import astropy.units as u
+    >>> usys = UnitSystem(u.km, u.s, u.Msun, u.radian)
+
+    >>> from unxt import unitsystem
+    >>> unitsystem(usys)
+    LTMAUnitSystem(length=Unit("km"), time=Unit("s"),
+                   mass=Unit("solMass"), angle=Unit("rad"))
+
+    """
+    # Create a new unit system instance, and possibly class.
+    return unitsystem(*value._core_units)  # noqa: SLF001
 
 
 @dispatch  # type: ignore[no-redef]
 def unitsystem(_: GalaDimensionlessUnitSystem, /) -> DimensionlessUnitSystem:
+    """Return a `gala.units.DimensionlessUnitSystem` as a `unxt.DimensionlessUnitSystem`.
+
+    Examples
+    --------
+    >>> from gala.units import DimensionlessUnitSystem
+    >>> import astropy.units as u
+    >>> usys = DimensionlessUnitSystem()
+
+    >>> from unxt import unitsystem
+    >>> unitsystem(usys)
+    DimensionlessUnitSystem()
+
+    """  # noqa: E501
     return dimensionless

--- a/src/unxt/_unxt/unitsystems/base.py
+++ b/src/unxt/_unxt/unitsystems/base.py
@@ -57,6 +57,10 @@ def parse_field_names_and_dimensions(
         field_names.append(get_dimension_name(name))
         dimensions.append(f_dims[0])
 
+    if len(set(dimensions)) < len(dimensions):
+        msg = "Some dimensions are repeated."
+        raise ValueError(msg)
+
     return tuple(field_names), tuple(dimensions)
 
 

--- a/src/unxt/_unxt/unitsystems/base.py
+++ b/src/unxt/_unxt/unitsystems/base.py
@@ -1,72 +1,168 @@
 """Tools for representing systems of units using ``astropy.units``."""
 
-__all__ = ["AbstractUnitSystem"]
+__all__ = ["AbstractUnitSystem", "UNITSYSTEMS_REGISTRY"]
 
 from collections.abc import Iterator
-from typing import ClassVar, Union, cast
+from dataclasses import dataclass, is_dataclass
+from types import MappingProxyType
+from typing import ClassVar, get_args, get_type_hints
 
 import astropy.units as u
+from astropy.units import PhysicalType as Dimension
 from astropy.units.physical import _physical_unit_mapping
 
-from unxt._unxt.quantity.base import AbstractQuantity
-from unxt._unxt.typing_ext import Unit
+from .utils import get_dimension_name, is_annotated
+from unxt._unxt.typing_ext import Unit as UnitT
+
+Unit = u.UnitBase
+
+_UNITSYSTEMS_REGISTRY: dict[tuple[Dimension, ...], type["AbstractUnitSystem"]] = {}
+UNITSYSTEMS_REGISTRY = MappingProxyType(_UNITSYSTEMS_REGISTRY)
 
 
+@dataclass(frozen=True, slots=True, eq=True)
 class AbstractUnitSystem:
     """Represents a system of units.
 
-    This class behaves like a dictionary with keys set by physical types (i.e. "length",
-    "velocity", "energy", etc.). If a unit for a particular physical type is not
-    specified on creation, a composite unit will be created with the base units. See the
-    examples below for some demonstrations.
+    This class behaves like a dictionary with keys set by physical types (i.e.
+    "length", "velocity", "energy", etc.). If a unit for a particular physical
+    type is not specified on creation, a composite unit will be created with the
+    base units. See the examples below for some demonstrations.
+
+    Examples
+    --------
+    If only base units are specified, any physical type specified as a key to
+    this object will be composed out of the base units::
+
+    >>> from unxt import unitsystem
+    >>> import astropy.units as u
+    >>> usys = unitsystem(u.m, u.s, u.kg, u.radian)
+    >>> usys
+    LTMAUnitSystem(length=Unit("m"), time=Unit("s"), mass=Unit("kg"), angle=Unit("rad"))
+
+    >>> usys["velocity"]
+    Unit("m / s")
+
+    This unit system defines energy::
+
+    >>> usys = unitsystem(u.m, u.s, u.kg, u.radian, u.erg)
+    >>> usys["energy"]
+    Unit("erg")
+
+    This is useful for Galactic dynamics where lengths and times are usually
+    given in terms of ``kpc`` and ``Myr``, but velocities are often specified in
+    ``km/s``::
+
+    >>> usys = unitsystem(u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s)
+    >>> usys["velocity"]
+    Unit("km / s")
+
+    Unit systems can be hashed:
+
+    >>> isinstance(hash(usys), int)
+    True
+
+    And iterated over:
+
+    >>> [x for x in usys]
+    [Unit("kpc"), Unit("Myr"), Unit("solMass"), Unit("rad"), Unit("km / s")]
+
+    With length equal to the number of base units
+
+    >>> len(usys)
+    5
 
     """
 
-    _core_units: list[Unit]
-    _registry: dict[u.PhysicalType, Unit]
+    # ===============================================================
+    # Class-level
 
-    _required_dimensions: ClassVar[list[u.PhysicalType]]  # do in subclass
+    _base_field_names: ClassVar[tuple[str, ...]]
+    _base_dimensions: ClassVar[tuple[Dimension, ...]]
 
-    def __init__(
-        self,
-        units: Union[Unit, u.Quantity, AbstractQuantity, "AbstractUnitSystem"],
-        *args: Unit | u.Quantity | AbstractQuantity,
-    ) -> None:
-        if isinstance(units, AbstractUnitSystem):
-            if len(args) > 0:
-                msg = (
-                    "If passing in a AbstractUnitSystem, "
-                    "cannot pass in additional units."
-                )
-                raise ValueError(msg)
+    def __init_subclass__(cls) -> None:
+        if is_dataclass(cls) and not (  # type: ignore[redundant-expr]
+            cls.__dataclass_params__.frozen  # type: ignore[attr-defined]  # pylint: disable=no-member
+            and hasattr(cls, "__slots__")
+        ):
+            msg = f"{cls.__name__} must have frozen=slots=True"
+            raise TypeError(msg)
 
-            self._registry = units._registry.copy()  # noqa: SLF001
-            self._core_units = units._core_units  # noqa: SLF001
+        # Register class with a tuple of it's dimensions.
+        # This requires processing the type hints, not the dataclass fields
+        # since those are made after the original class is defined.
+        type_hints = get_type_hints(cls, include_extras=True)
+
+        field_names = []
+        dimensions_ = []
+        for name, type_hint in type_hints.items():
+            # Check it's Annotated
+            if not is_annotated(type_hint):
+                continue
+
+            # Get the arguments to Annotated
+            origin, *f_args = get_args(type_hint)
+
+            # Check that the first argument is a UnitBase
+            if not issubclass(origin, Unit):
+                continue
+
+            # Need for one of the arguments to be a PhysicalType
+            f_dims = [x for x in f_args if isinstance(x, Dimension)]
+            if not f_dims:
+                msg = f"Field {name} must be an Annotated with a dimension."
+                raise TypeError(msg)
+            if len(f_dims) > 1:
+                msg = f"Field {name} must be an Annotated with only one dimension."
+                raise TypeError(msg)
+
+            field_names.append(get_dimension_name(name))
+            dimensions_.append(f_dims[0])
+
+        dimensions = tuple(dimensions_)  # freeze
+
+        # Check the unitsystem is not already registered
+        if dimensions in _UNITSYSTEMS_REGISTRY:
+            # If `make_dataclass(slots=True)` then the class is made twice, the
+            # second time adding the `__slots__` attribute
+            if is_dataclass(cls) and "__slots__" in cls.__dict__:  # type: ignore[redundant-expr]
+                return
+
+            msg = f"Unit system with dimensions {dimensions} already exists."
+            raise ValueError(msg)
+
+        # Add attributes to the class
+        cls._base_field_names = tuple(field_names)
+        cls._base_dimensions = dimensions
+
+        # Register the class
+        # If `make_dataclass(slots=True)` then the class is made twice, the
+        # second time adding the `__slots__` attribute
+        if is_dataclass(cls) and "__slots__" not in cls.__dict__:  # type: ignore[redundant-expr]
             return
 
-        units = (units, *args)
+        _UNITSYSTEMS_REGISTRY[dimensions] = cls
 
-        self._registry = {}
-        for unit in units:
-            unit_ = (  # TODO: better detection of allowed unit base classes
-                unit if isinstance(unit, u.UnitBase) else u.def_unit(f"{unit!s}", unit)
-            )
-            if unit_.physical_type in self._registry:
-                msg = f"Multiple units passed in with type {unit_.physical_type!r}"
-                raise ValueError(msg)
-            self._registry[unit_.physical_type] = unit_
+    # ===============================================================
+    # Instance-level
 
-        self._core_units = []
-        for phys_type in self._required_dimensions:
-            if phys_type not in self._registry:
-                msg = f"You must specify a unit for the physical type {phys_type!r}"
-                raise ValueError(msg)
-            self._core_units.append(self._registry[phys_type])
+    def __post_init__(self) -> None:
+        pass
 
-    def __getitem__(self, key: str | u.PhysicalType) -> u.UnitBase:
+    @property  # TODO: classproperty
+    def base_dimensions(self) -> tuple[Dimension, ...]:
+        """Dimensions required for the unit system."""
+        return self._base_dimensions
+
+    @property
+    def base_units(self) -> tuple[UnitT, ...]:
+        """List of core units."""
+        return tuple(getattr(self, k) for k in self._base_field_names)
+
+    def __getitem__(self, key: Dimension | str) -> UnitT:
         key = u.get_physical_type(key)
-        if key in self._required_dimensions:
-            return self._registry[key]
+        if key in self.base_dimensions:
+            return getattr(self, get_dimension_name(key))
 
         unit = None
         for k, v in _physical_unit_mapping.items():
@@ -78,41 +174,17 @@ class AbstractUnitSystem:
             msg = f"Physical type '{key}' doesn't exist in unit registry."
             raise ValueError(msg)
 
-        unit = unit.decompose(self._core_units)
+        unit = unit.decompose(self.base_units)
         unit._scale = 1.0  # noqa: SLF001
         return unit
 
     def __len__(self) -> int:
         # Note: This is required for q.decompose(usys) to work, where q is a Quantity
-        return len(self._core_units)
+        return len(self.base_dimensions)
 
-    def __iter__(self) -> Iterator[Unit]:
-        yield from self._core_units
+    def __iter__(self) -> Iterator[UnitT]:
+        yield from self.base_units
 
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}({', '.join(map(str, self._core_units))})"
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, AbstractUnitSystem):
-            return NotImplemented
-        return bool(self._registry == other._registry)
-
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
-
-    def __hash__(self) -> int:
-        """Hash the unit system."""
-        return hash(tuple(self._core_units) + tuple(self._required_dimensions))
-
-    def preferred(self, key: str | u.PhysicalType) -> Unit:
-        """Return the preferred unit for a given physical type."""
-        key = u.get_physical_type(key)
-        if key in self._registry:
-            return self._registry[key]
-        return self[key]
-
-    def as_preferred(self, quantity: AbstractQuantity | u.Quantity) -> AbstractQuantity:
-        """Convert a quantity to the preferred unit for this unit system."""
-        unit = self.preferred(quantity.unit.physical_type)
-        # Note that it's necessary to
-        return cast(AbstractQuantity, quantity.to(unit))
+    def __str__(self) -> str:
+        fs = ", ".join(map(str, self._base_field_names))
+        return f"{type(self).__name__}({fs})"

--- a/src/unxt/_unxt/unitsystems/builtin.py
+++ b/src/unxt/_unxt/unitsystems/builtin.py
@@ -1,0 +1,66 @@
+"""Built-in unit systems."""
+
+from __future__ import annotations
+
+__all__ = ["DimensionlessUnitSystem", "LTMAUnitSystem", "LTMAVUnitSystem"]
+
+from dataclasses import dataclass
+from typing import Annotated, TypeAlias, final
+
+import astropy.units as u
+from astropy.units import dimensionless_unscaled
+
+from . import builtin_dimensions as ud  # noqa: TCH001
+from .base import AbstractUnitSystem
+
+Unit: TypeAlias = u.UnitBase
+
+_dimless_insts: dict[type[DimensionlessUnitSystem], DimensionlessUnitSystem] = {}
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class DimensionlessUnitSystem(AbstractUnitSystem):
+    """A unit system with only dimensionless units."""
+
+    dimensionless: Annotated[Unit, ud.dimensionless] = dimensionless_unscaled
+
+    def __new__(cls) -> DimensionlessUnitSystem:
+        # Check if instance already exists
+        if cls in _dimless_insts:
+            return _dimless_insts[cls]
+        # Create new instance and cache it
+        self = object.__new__(cls)
+        _dimless_insts[cls] = self
+        return self
+
+    def __post_init__(self) -> None:
+        if self.dimensionless is not dimensionless_unscaled:
+            msg = "DimensionlessUnitSystem must have a dimensionless unit"
+            raise ValueError(msg)
+
+    def __repr__(self) -> str:
+        return "DimensionlessUnitSystem()"
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class LTMAUnitSystem(AbstractUnitSystem):
+    """Length, time, mass, angle unit system."""
+
+    length: Annotated[Unit, ud.length]
+    time: Annotated[Unit, ud.time]
+    mass: Annotated[Unit, ud.mass]
+    angle: Annotated[Unit, ud.angle]
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class LTMAVUnitSystem(AbstractUnitSystem):
+    """Length, time, mass, angle, speed unit system."""
+
+    length: Annotated[Unit, ud.length]
+    time: Annotated[Unit, ud.time]
+    mass: Annotated[Unit, ud.mass]
+    angle: Annotated[Unit, ud.angle]
+    speed: Annotated[Unit, ud.speed]

--- a/src/unxt/_unxt/unitsystems/builtin.py
+++ b/src/unxt/_unxt/unitsystems/builtin.py
@@ -6,6 +6,7 @@ __all__ = ["DimensionlessUnitSystem", "LTMAUnitSystem", "LTMAVUnitSystem"]
 
 from dataclasses import dataclass
 from typing import Annotated, TypeAlias, final
+from typing_extensions import override
 
 import astropy.units as u
 from astropy.units import dimensionless_unscaled
@@ -34,13 +35,12 @@ class DimensionlessUnitSystem(AbstractUnitSystem):
         _dimless_insts[cls] = self
         return self
 
-    def __post_init__(self) -> None:
-        if self.dimensionless is not dimensionless_unscaled:
-            msg = "DimensionlessUnitSystem must have a dimensionless unit"
-            raise ValueError(msg)
-
     def __repr__(self) -> str:
         return "DimensionlessUnitSystem()"
+
+    @override
+    def __str__(self) -> str:
+        return self.__repr__()
 
 
 @final

--- a/src/unxt/_unxt/unitsystems/builtin_dimensions.py
+++ b/src/unxt/_unxt/unitsystems/builtin_dimensions.py
@@ -1,0 +1,12 @@
+"""Built-in dimensions."""
+
+__all__: list[str] = []
+
+import astropy.units as u
+
+dimensionless = u.get_physical_type("dimensionless")
+length = u.get_physical_type("length")
+mass = u.get_physical_type("mass")
+time = u.get_physical_type("time")
+speed = u.get_physical_type("speed")
+angle = u.get_physical_type("angle")

--- a/src/unxt/_unxt/unitsystems/compare.py
+++ b/src/unxt/_unxt/unitsystems/compare.py
@@ -1,0 +1,13 @@
+"""Comparison functions."""
+
+__all__ = ["equivalent"]
+
+from plum import dispatch
+
+from .base import AbstractUnitSystem
+
+
+@dispatch  # type: ignore[misc]
+def equivalent(a: AbstractUnitSystem, b: AbstractUnitSystem, /) -> bool:
+    """Check if two unit systems are equivalent."""
+    return set(a.base_dimensions) == set(b.base_dimensions)

--- a/src/unxt/_unxt/unitsystems/realizations.py
+++ b/src/unxt/_unxt/unitsystems/realizations.py
@@ -1,4 +1,4 @@
-"""Tools for representing systems of units using ``astropy.units``."""
+"""Realizations of unit systems."""
 
 __all__ = [
     # unit system instance
@@ -9,20 +9,19 @@ __all__ = [
     "NAMED_UNIT_SYSTEMS",
 ]
 
-
 import astropy.units as u
 
 from .base import AbstractUnitSystem
-from .core import DimensionlessUnitSystem, UnitSystem
+from .builtin import DimensionlessUnitSystem, LTMAUnitSystem, LTMAVUnitSystem
 
-# define galactic unit system
-galactic = UnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km / u.s)  # pylint: disable=no-member
-
-# solar system units
-solarsystem = UnitSystem(u.au, u.M_sun, u.yr, u.radian)  # pylint: disable=no-member
-
-# dimensionless
+# Dimensionless. This is a singleton.
 dimensionless = DimensionlessUnitSystem()
+
+# Galactic unit system
+galactic = LTMAVUnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km / u.s)  # pylint: disable=no-member
+
+# Solar system units
+solarsystem = LTMAUnitSystem(u.au, u.yr, u.Msun, u.radian)  # pylint: disable=no-member
 
 
 NAMED_UNIT_SYSTEMS: dict[str, AbstractUnitSystem] = {

--- a/src/unxt/_unxt/unitsystems/utils.py
+++ b/src/unxt/_unxt/unitsystems/utils.py
@@ -1,107 +1,108 @@
-"""Tools for representing systems of units using ``astropy.units``."""
+"""Unit system utils."""
 
-__all__ = ["unitsystem"]
+__all__: list[str] = []
 
+import re
+from typing import (  # type: ignore[attr-defined]
+    Annotated,
+    Any,
+    TypeGuard,
+    _AnnotatedAlias,
+)
 
-import astropy.units as u
+from astropy.units import PhysicalType as Dimension
 from plum import dispatch
 
-from .base import AbstractUnitSystem
-from .core import DimensionlessUnitSystem, UnitSystem
-from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
-from unxt._unxt.quantity.base import AbstractQuantity
+from .builtin_dimensions import speed
 from unxt._unxt.typing_ext import Unit
 
+AnnotationType = type(Annotated[int, "_"])
 
-@dispatch
-def unitsystem(units: AbstractUnitSystem, /) -> AbstractUnitSystem:
-    """Convert a UnitSystem or tuple of arguments to a UnitSystem.
+
+def is_annotated(hint: Any) -> TypeGuard[_AnnotatedAlias]:
+    """Check if a type hint is an `Annotated` type.
 
     Examples
     --------
+    >>> from unxt._unxt.unitsystems.utils import is_annotated
+
+    >>> is_annotated(int)
+    False
+
+    >>> from typing import Annotated
+    >>> is_annotated(Annotated[int, "2"])
+    True
+
+    """
+    return type(hint) is AnnotationType  # pylint: disable=unidiomatic-typecheck
+
+
+# ------------------------------------
+
+
+@dispatch.abstract
+def get_dimension_name(pt: Any, /) -> str:
+    """Get the dimension name from the object."""
+    raise NotImplementedError  # pragma: no cover
+
+
+@dispatch  # type: ignore[no-redef]
+def get_dimension_name(pt: str, /) -> str:
+    """Return the dimension name.
+
+    Note that this does not check for the existence of that dimension.
+
+    Examples
+    --------
+    >>> from unxt._unxt.unitsystems.utils import get_dimension_name
+
+    >>> get_dimension_name("length")
+    'length'
+
+    >>> get_dimension_name("not real")
+    'not real'
+
+    """
+    # A regex search to match anything that's not a letter or a whitespace.
+    if re.search(r"[^a-zA-Z_ ]", pt):
+        msg = "Input contains non-letter characters"
+        raise ValueError(msg)
+
+    return pt
+
+
+@dispatch  # type: ignore[no-redef]
+def get_dimension_name(pt: Dimension, /) -> str:
+    """Return the dimension name from a dimension.
+
+    Examples
+    --------
+    >>> from unxt._unxt.unitsystems.utils import get_dimension_name
     >>> import astropy.units as u
-    >>> from unxt.unitsystems import UnitSystem, unitsystem
-    >>> usys = UnitSystem(u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s)
-    >>> usys
-    UnitSystem(kpc, Myr, solMass, rad)
+    >>> get_dimension_name(u.get_physical_type("length"))
+    'length'
 
-    >>> unitsystem(usys)
-    UnitSystem(kpc, Myr, solMass, rad)
+    >>> get_dimension_name(u.get_physical_type("speed"))
+    'speed'
 
     """
-    return units
+    # Note: this is not deterministic b/c ``_physical_type`` is a set
+    #       that's why the `if` statement is needed.
+    if pt == speed:
+        return "speed"
+    return get_dimension_name(next(iter(pt._physical_type)))  # noqa: SLF001
 
 
 @dispatch  # type: ignore[no-redef]
-def unitsystem(
-    units: (
-        tuple[Unit | u.Quantity | AbstractQuantity, ...]
-        | list[Unit | u.Quantity | AbstractQuantity]
-    ),
-    /,
-) -> AbstractUnitSystem:
-    """Convert a UnitSystem or tuple of arguments to a UnitSystem.
+def get_dimension_name(pt: Unit, /) -> str:
+    """Return the dimension name from a unit.
 
     Examples
     --------
+    >>> from unxt._unxt.unitsystems.utils import get_dimension_name
     >>> import astropy.units as u
-    >>> from unxt.unitsystems import UnitSystem, unitsystem
-
-    >>> unitsystem((u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s))
-    UnitSystem(kpc, Myr, solMass, rad)
-
-    >>> unitsystem([u.kpc, u.Myr, u.Msun, u.radian, u.km/u.s])
-    UnitSystem(kpc, Myr, solMass, rad)
+    >>> get_dimension_name(u.km)
+    'length'
 
     """
-    return UnitSystem(*units) if len(units) > 0 else dimensionless
-
-
-@dispatch  # type: ignore[no-redef]
-def unitsystem(_: None, /) -> DimensionlessUnitSystem:
-    """Dimensionless unit system from None.
-
-    Examples
-    --------
-    >>> from unxt.unitsystems import unitsystem
-    >>> unitsystem(None)
-    DimensionlessUnitSystem()
-
-    """
-    return dimensionless
-
-
-@dispatch  # type: ignore[no-redef]
-def unitsystem(unit0: Unit, /, *units: Unit) -> UnitSystem:
-    """Convert a set of arguments to a UnitSystem.
-
-    Examples
-    --------
-    >>> import astropy.units as u
-    >>> from unxt.unitsystems import UnitSystem, unitsystem
-
-    >>> unitsystem(u.kpc, u.Myr, u.Msun, u.radian)
-    UnitSystem(kpc, Myr, solMass, rad)
-
-    """
-    return UnitSystem(unit0, *units)
-
-
-@dispatch  # type: ignore[no-redef]
-def unitsystem(name: str, /) -> AbstractUnitSystem:
-    """Return unit system from name.
-
-    Examples
-    --------
-    >>> from unxt.unitsystems import unitsystem
-    >>> unitsystem("galactic")
-    UnitSystem(kpc, Myr, solMass, rad)
-
-    >>> unitsystem("solarsystem")
-    UnitSystem(AU, yr, solMass, rad)
-
-    >>> unitsystem("dimensionless")
-    DimensionlessUnitSystem()
-
-    """
-    return NAMED_UNIT_SYSTEMS[name]
+    return get_dimension_name(pt.physical_type)

--- a/src/unxt/_unxt/unitsystems/utils.py
+++ b/src/unxt/_unxt/unitsystems/utils.py
@@ -62,6 +62,10 @@ def get_dimension_name(pt: str, /) -> str:
     >>> get_dimension_name("not real")
     'not real'
 
+    >>> try: get_dimension_name("*62")
+    ... except ValueError as e: print(e)
+    Input contains non-letter characters
+
     """
     # A regex search to match anything that's not a letter or a whitespace.
     if re.search(r"[^a-zA-Z_ ]", pt):

--- a/src/unxt/unitsystems.py
+++ b/src/unxt/unitsystems.py
@@ -1,7 +1,9 @@
-"""Tools for representing systems of units using ``astropy.units``."""
+"""Tools for representing systems of units."""
 
-from ._unxt.unitsystems import base, core, realizations, utils
+from ._unxt.unitsystems import base, builtin, compare, core, realizations, utils
 from ._unxt.unitsystems.base import *  # noqa: F403
+from ._unxt.unitsystems.builtin import *  # noqa: F403
+from ._unxt.unitsystems.compare import *  # noqa: F403
 from ._unxt.unitsystems.core import *  # noqa: F403
 from ._unxt.unitsystems.realizations import *  # noqa: F403
 from ._unxt.unitsystems.utils import *  # noqa: F403
@@ -9,8 +11,10 @@ from ._unxt.unitsystems.utils import *  # noqa: F403
 __all__: list[str] = []
 __all__ += base.__all__
 __all__ += core.__all__
+__all__ += builtin.__all__
 __all__ += realizations.__all__
+__all__ += compare.__all__
 __all__ += utils.__all__
 
 # Clean up namespace
-del base, core, utils, realizations
+del base, builtin, compare, core, utils, realizations

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -87,16 +87,16 @@ def test_parametric():
     """Test the parametric strategy."""
     # Inferred
     q = Quantity(1, u.m)
-    (dimensions,) = q._type_parameter  # noqa: SLF001
+    (dimensions,) = q._type_parameter
     assert dimensions == u.get_physical_type(u.m)
 
     # Explicit
     q = Quantity["length"](1, u.m)
-    (dimensions,) = q._type_parameter  # noqa: SLF001
+    (dimensions,) = q._type_parameter
     assert dimensions == u.get_physical_type(u.m)
 
     q = Quantity["length"](jnp.ones((1, 2)), u.m)
-    (dimensions,) = q._type_parameter  # noqa: SLF001
+    (dimensions,) = q._type_parameter
     assert dimensions == u.get_physical_type(u.m)
 
     # type-checks


### PR DESCRIPTION
This PR refactors the unit systems to be more class-based, allowing for static analysis of the unit systems. For users the focus shifts from the `UnitSystem` class to the `unitsystem` function which can dynamically create new unit systems classes, or use statically-defined ones.

Features:
- dataclass constructions
- static analysis
