### PR TITLE
fix: roll back preferred units

### DIFF
--- a/src/unxt/_unxt/unitsystems/base.py
+++ b/src/unxt/_unxt/unitsystems/base.py
@@ -3,14 +3,13 @@
 __all__ = ["AbstractUnitSystem", "UNITSYSTEMS_REGISTRY"]
 
 from collections.abc import Iterator
-from dataclasses import KW_ONLY, dataclass, field
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import ClassVar, get_args, get_type_hints
 
 import astropy.units as u
 from astropy.units import PhysicalType as Dimension
 from astropy.units.physical import _physical_unit_mapping
-from xmmutablemap import ImmutableMap
 
 from .utils import get_dimension_name, is_annotated
 from unxt._unxt.typing_ext import Unit as UnitT
@@ -147,23 +146,6 @@ class AbstractUnitSystem:
     # ===============================================================
     # Instance-level
 
-    _: KW_ONLY
-    preferred_units: ImmutableMap[Dimension, Unit] = field(
-        default_factory=ImmutableMap,
-        repr=False,  # NOTE: should turn on when eqx.Module.__repr__ is customizable
-    )
-
-    def __post_init__(self) -> None:
-        # Check the preferred units.
-        # 1. keys are dimensions  # TODO: will be moved to a converter
-        assert all(isinstance(k, Dimension) for k in self.preferred_units)  # noqa: S101
-        # 2. values are units   # TODO: will be moved to a converter
-        assert all(isinstance(v, Unit) for v in self.preferred_units.values())  # noqa: S101
-        # 3. dimensions are not in the base dimensions
-        if any(k in self.base_dimensions for k in self.preferred_units):
-            msg = "Preferred units must not be in the base dimensions."
-            raise ValueError(msg)
-
     @property  # TODO: classproperty
     def base_dimensions(self) -> tuple[Dimension, ...]:
         """Dimensions required for the unit system."""
@@ -178,9 +160,6 @@ class AbstractUnitSystem:
         key = u.get_physical_type(key)
         if key in self.base_dimensions:
             return getattr(self, get_dimension_name(key))
-
-        if key in self.preferred_units:
-            return self.preferred_units[key]
 
         unit = None
         for k, v in _physical_unit_mapping.items():

--- a/src/unxt/_unxt/unitsystems/realizations.py
+++ b/src/unxt/_unxt/unitsystems/realizations.py
@@ -14,7 +14,6 @@ import astropy.units as u
 
 from .base import AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem, LTMAUnitSystem
-from .builtin_dimensions import speed
 
 # Dimensionless. This is a singleton.
 dimensionless = DimensionlessUnitSystem()
@@ -25,7 +24,7 @@ galactic = LTMAUnitSystem(
     time=u.Myr,
     mass=u.Msun,
     angle=u.radian,
-    preferred_units={speed: u.km / u.s},
+    # preferred_units={speed: u.km / u.s},
 )
 
 # Solar system units

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -9,12 +9,10 @@ import astropy.units as u
 import numpy as np
 import pytest
 
-import unxt._unxt.unitsystems.builtin_dimensions as ud
 from unxt import unitsystems
 from unxt.unitsystems import (
     AbstractUnitSystem,
     DimensionlessUnitSystem,
-    LTMAUnitSystem,
     dimensionless,
     equivalent,
     unitsystem,
@@ -177,28 +175,3 @@ def test_equivalent():
 
     usys3 = unitsystem(u.kpc, u.Myr, u.radian)
     assert not equivalent(usys1, usys3)
-
-
-def test_preferred_units_in_base_units():
-    """Test error when preferred units are in base units."""
-    match = "Preferred units must not be in the base dimensions."
-    with pytest.raises(ValueError, match=match):
-        _ = LTMAUnitSystem(
-            length=u.kpc,
-            time=u.Myr,
-            mass=u.Msun,
-            angle=u.radian,
-            preferred_units={ud.length: u.kpc},
-        )
-
-
-def test_get_preferred_dimension():
-    """Test getting the preferred dimension."""
-    usys = LTMAUnitSystem(
-        length=u.kpc,
-        time=u.Myr,
-        mass=u.Msun,
-        angle=u.radian,
-        preferred_units={ud.speed: u.km / u.s},
-    )
-    assert usys["speed"] == u.km / u.s


### PR DESCRIPTION
This deserves more thought.
I think perhaps a `.preferred()` method would be better.