### PR TITLE
Add concept of unitsystem flags and enable overriding / extending unit systems

### DIFF
--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -13,6 +13,7 @@ from plum import dispatch
 
 from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
+from .flags import StandardUnitSystemFlag
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
 from .utils import get_dimension_name
 from unxt._src.dimensions.core import dimensions_of
@@ -158,6 +159,11 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
     """
     return NAMED_UNIT_SYSTEMS[name]
+
+
+@dispatch  # type: ignore[no-redef]
+def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
+    return unitsystem(*units_)
 
 
 # ----

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -162,6 +162,36 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
 
 @dispatch  # type: ignore[no-redef]
+def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
+    """Create a unit system from an existing unit system and additional units.
+
+    Examples
+    --------
+    We can add a new unit definition to an existing unit system:
+
+    >>> import astropy.units as u
+    >>> from unxt.unitsystems import unitsystem
+    >>> usys = unitsystem("galactic")
+    unitsystem(kpc, Myr, solMass, rad)
+    >>> unitsystem(usys, u.km/u.s)
+    LengthTimeMassAngleSpeedUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), speed=Unit("km / s"))
+
+    We can also override the base unit of an existing unit system:
+
+    >>> new_usys = unitsystem(usys, u.pc)
+    TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
+
+    """
+    new_usys = unitsystem(*units_)
+    current_units = [
+        unit
+        for unit in usys.base_units
+        if unit.physical_type not in new_usys.base_dimensions
+    ]
+    return unitsystem(*current_units, *units_)
+
+
+@dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
     return unitsystem(*units_)
 

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,0 +1,6 @@
+class AbstractUnitSystemFlag:
+    pass
+
+
+class StandardUnitSystemFlag(AbstractUnitSystemFlag):
+    pass

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -175,3 +175,14 @@ def test_equivalent():
 
     usys3 = unitsystem(u.kpc, u.Myr, u.radian)
     assert not equivalent(usys1, usys3)
+
+
+def test_extend():
+    """Test adding additional units to a unit system."""
+    usys1 = unitsystem(u.kpc, u.Myr, u.radian, u.Msun, u.km / u.s)
+    usys2 = unitsystem(usys1, u.mas / u.yr)
+    assert usys2["angular speed"] == u.mas / u.yr
+
+    usys3 = unitsystem(usys1, u.mas / u.yr, u.pc)
+    assert usys3["angular speed"] == u.mas / u.yr
+    assert usys3["length"] == u.pc  # overridden


### PR DESCRIPTION
This adds a new (currently not used) set of `Flag` types so we can dispatch on the type of unit system (will be useful for the follow-up to add a new `SimulationUnitSystem`). This also adds the ability to extend or override units in an existing unit system via:
```python
>>> usys = unitsystem(...)
>>> new_usys = unitsystem(usys, u.pc, u.erg)
```