### PR TITLE
Add concept of unitsystem flags and enable overriding / extending unit systems

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,9 @@
 """Doctest configuration."""
 
+import os
 import platform
 from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
+from typing import Any
 
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser, SkipParser
@@ -42,3 +44,7 @@ if not OptDeps.GALA.installed:
     collect_ignore_glob.append("src/unxt/_interop/unxt_interop_gala/*")
 if not OptDeps.MATPLOTLIB.installed or not OptDeps.ZEROTH.installed:
     collect_ignore_glob.append("src/unxt/_interop/unxt_interop_mpl/*")
+
+
+def pytest_generate_tests(metafunc: Any) -> None:
+    os.environ["UNXT_ENABLE_RUNTIME_TYPECHECKING"] = "beartype.beartype"

--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -3,13 +3,21 @@
 Copyright (c) 2023 Galactic Dynamics. All rights reserved.
 """
 
-from . import quantity, unitsystems
-from ._src import experimental  # noqa: F401
-from ._src.dimensions.core import dimensions, dimensions_of
-from ._src.units.core import units, units_of
-from ._version import version as __version__
-from .quantity import *
-from .unitsystems import AbstractUnitSystem, unitsystem, unitsystem_of
+from jaxtyping import install_import_hook
+
+from .setup_package import RUNTIME_TYPECHECKER
+
+with install_import_hook("unxt", RUNTIME_TYPECHECKER):
+    from . import quantity, unitsystems
+    from ._src.dimensions.core import dimensions, dimensions_of
+    from ._src.units.core import units, units_of
+    from ._version import version as __version__
+    from .quantity import *
+    from .unitsystems import AbstractUnitSystem, unitsystem, unitsystem_of
+
+from ._src import (
+    experimental,  # noqa: F401
+)
 
 # isort: split
 from . import _interop  # noqa: F401  # register interop
@@ -29,3 +37,6 @@ __all__ = [
     "unitsystem_of",  # get the unit system
 ]
 __all__ += quantity.__all__
+
+# Clean up the namespace
+del install_import_hook

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -31,8 +31,8 @@ from unxt._interop.optional_deps import OptDeps
 # Constructor
 
 
-@AbstractQuantity.constructor._f.register  # noqa: SLF001
-def constructor(
+@AbstractQuantity.from_._f.register  # noqa: SLF001
+def from_(
     cls: type[AbstractQuantity], value: AstropyQuantity, /, **kwargs: Any
 ) -> AbstractQuantity:
     """Construct a `Quantity` from another `Quantity`.
@@ -44,15 +44,15 @@ def constructor(
     >>> import astropy.units as u
     >>> from unxt import Quantity
 
-    >>> Quantity.constructor(u.Quantity(1, "m"))
+    >>> Quantity.from_(u.Quantity(1, "m"))
     Quantity['length'](Array(1., dtype=float32), unit='m')
 
     """
     return cls(jnp.asarray(value.value, **kwargs), value.unit)
 
 
-@AbstractQuantity.constructor._f.register  # type: ignore[no-redef] # noqa: SLF001
-def constructor(
+@AbstractQuantity.from_._f.register  # type: ignore[no-redef] # noqa: SLF001
+def from_(
     cls: type[AbstractQuantity], value: AstropyQuantity, unit: Any, /, **kwargs: Any
 ) -> AbstractQuantity:
     """Construct a `Quantity` from another `Quantity`.
@@ -64,7 +64,7 @@ def constructor(
     >>> import astropy.units as u
     >>> from unxt import Quantity
 
-    >>> Quantity.constructor(u.Quantity(1, "m"), "cm")
+    >>> Quantity.from_(u.Quantity(1, "m"), "cm")
     Quantity['length'](Array(100., dtype=float32), unit='cm')
 
     """

--- a/src/unxt/_interop/unxt_interop_mpl/__init__.py
+++ b/src/unxt/_interop/unxt_interop_mpl/__init__.py
@@ -55,7 +55,7 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
         if isinstance(obj, AbstractQuantity):
             return ustrip(unit, obj)
 
-        return ustrip(unit, UncheckedQuantity.constructor(obj, axis.get_units()))
+        return ustrip(unit, UncheckedQuantity.from_(obj, axis.get_units()))
 
     def axisinfo(self, unit: Any, _: Axes) -> matplotlib.units.AxisInfo:
         """Return axis information for this particular unit."""

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -169,7 +169,7 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
 
     @classmethod
     @dispatch
-    def constructor(
+    def from_(
         cls: "type[AbstractQuantity]",
         value: ArrayLike | ArrayLikeSequence,
         unit: Any,
@@ -202,13 +202,13 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
         >>> from unxt import Quantity
 
         >>> x = jnp.array([1.0, 2, 3])
-        >>> Quantity.constructor(x, "m")
+        >>> Quantity.from_(x, "m")
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
-        >>> Quantity.constructor([1.0, 2, 3], "m")
+        >>> Quantity.from_([1.0, 2, 3], "m")
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
-        >>> Quantity.constructor((1.0, 2, 3), "m")
+        >>> Quantity.from_((1.0, 2, 3), "m")
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
         """
@@ -218,7 +218,7 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
 
     @classmethod  # type: ignore[no-redef]
     @dispatch
-    def constructor(
+    def from_(
         cls: "type[AbstractQuantity]",
         value: ArrayLike | ArrayLikeSequence,
         /,
@@ -234,16 +234,16 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
         any subclass of [`AbstractQuantity`][].
 
         >>> from unxt import Quantity
-        >>> Quantity.constructor([1.0, 2, 3], unit="m")
+        >>> Quantity.from_([1.0, 2, 3], unit="m")
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
         """
         # Dispatch on the `value` only. Dispatch to the full constructor.
-        return cls.constructor(value, unit, dtype=dtype)
+        return cls.from_(value, unit, dtype=dtype)
 
     @classmethod  # type: ignore[no-redef]
     @dispatch
-    def constructor(
+    def from_(
         cls: "type[AbstractQuantity]", *, value: Any, unit: Any, dtype: Any = None
     ) -> "AbstractQuantity":
         """Construct a `AbstractQuantity` from value and unit kwargs.
@@ -254,16 +254,16 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
         any subclass of `AbstractQuantity`.
 
         >>> from unxt import Quantity
-        >>> Quantity.constructor(value=[1.0, 2, 3], unit="m")
+        >>> Quantity.from_(value=[1.0, 2, 3], unit="m")
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
         """
         # Dispatched on no argument. Dispatch to the full constructor.
-        return cls.constructor(value, unit, dtype=dtype)
+        return cls.from_(value, unit, dtype=dtype)
 
     @classmethod  # type: ignore[no-redef]
     @dispatch
-    def constructor(
+    def from_(
         cls: "type[AbstractQuantity]", mapping: Mapping[str, Any]
     ) -> "AbstractQuantity":
         """Construct a `Quantity` from a Mapping.
@@ -286,17 +286,17 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
         >>> from unxt import Quantity
 
         >>> x = jnp.array([1.0, 2, 3])
-        >>> q = Quantity.constructor({"value": x, "unit": "m"})
+        >>> q = Quantity.from_({"value": x, "unit": "m"})
         >>> q
         Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
 
-        >>> Quantity.constructor({"value": q, "unit": "km"})
+        >>> Quantity.from_({"value": q, "unit": "km"})
         Quantity['length'](Array([0.001, 0.002, 0.003], dtype=float32), unit='km')
 
         """
         # Dispatch on both arguments.
         # Construct using the standard `__init__` method.
-        return cls.constructor(**mapping)
+        return cls.from_(**mapping)
 
     # See below for additional constructors.
 
@@ -550,8 +550,8 @@ class AbstractQuantity(AstropyQuantityCompatMixin, ArrayValue):  # type: ignore[
 # Register additional constructors
 
 
-@AbstractQuantity.constructor._f.register  # noqa: SLF001
-def constructor(
+@AbstractQuantity.from_._f.register  # noqa: SLF001
+def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,
     unit: Any,
@@ -568,7 +568,7 @@ def constructor(
     >>> from unxt import Quantity
 
     >>> q = Quantity(1, "m")
-    >>> Quantity.constructor(q, "cm")
+    >>> Quantity.from_(q, "cm")
     Quantity['length'](Array(100., dtype=float32, ...), unit='cm')
 
     """
@@ -576,8 +576,8 @@ def constructor(
     return cls(value.value, unit)
 
 
-@AbstractQuantity.constructor._f.register  # type: ignore[no-redef]  # noqa: SLF001
-def constructor(
+@AbstractQuantity.from_._f.register  # type: ignore[no-redef]  # noqa: SLF001
+def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,
     unit: None,
@@ -594,7 +594,7 @@ def constructor(
     >>> from unxt import Quantity
 
     >>> q = Quantity(1, "m")
-    >>> Quantity.constructor(q, None)
+    >>> Quantity.from_(q, None)
     Quantity['length'](Array(1, dtype=int32, ...), unit='m')
 
     """
@@ -602,8 +602,8 @@ def constructor(
     return cls(value.value, value.unit)
 
 
-@AbstractQuantity.constructor._f.register  # type: ignore[no-redef] # noqa: SLF001
-def constructor(
+@AbstractQuantity.from_._f.register  # type: ignore[no-redef] # noqa: SLF001
+def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,
     /,

--- a/src/unxt/_src/quantity/base_parametric.py
+++ b/src/unxt/_src/quantity/base_parametric.py
@@ -3,6 +3,7 @@
 
 __all__ = ["AbstractParametricQuantity"]
 
+from collections.abc import Sequence
 from functools import partial
 from typing import Any
 
@@ -78,7 +79,7 @@ class AbstractParametricQuantity(AbstractQuantity):
 
     @classmethod
     def __infer_type_parameter__(
-        cls, value: ArrayLike, unit: Any, **kwargs: Any
+        cls, value: ArrayLike | Sequence[Any], unit: Any, **kwargs: Any
     ) -> tuple[Dimensions]:
         """Infer the type parameter from the arguments."""
         return (dimensions_of(units(unit)),)
@@ -122,7 +123,7 @@ class AbstractParametricQuantity(AbstractQuantity):
     # https://docs.python.org/3.12/library/pickle.html
     def __reduce__(
         self,
-    ) -> tuple["partial[type[AbstractParametricQuantity]]", tuple[Any, ...]]:
+    ) -> tuple[partial["type[AbstractParametricQuantity]"], tuple[Any, ...]]:
         r"""Return the reduced value: a constructor and arguments.
 
         The ``__reduce__`` protocol has limited support for keyword-only

--- a/src/unxt/_src/quantity/distance.py
+++ b/src/unxt/_src/quantity/distance.py
@@ -316,8 +316,8 @@ class DistanceModulus(AbstractDistance):
 # Additional constructors
 
 
-@Distance.constructor._f.register  # noqa: SLF001
-def constructor(
+@Distance.from_._f.register  # noqa: SLF001
+def from_(
     cls: type[Distance], value: Parallax | Quantity["angle"], /, *, dtype: Any = None
 ) -> Distance:
     """Construct a `Distance` from an angle through the parallax.
@@ -326,10 +326,10 @@ def constructor(
     --------
     >>> from unxt import Distance, Parallax, Quantity
 
-    >>> Distance.constructor(Parallax(1, "mas")).to("kpc")
+    >>> Distance.from_(Parallax(1, "mas")).to("kpc")
     Distance(Array(1., dtype=float32, ...), unit='kpc')
 
-    >>> Distance.constructor(Quantity(1, "mas")).to("kpc")
+    >>> Distance.from_(Quantity(1, "mas")).to("kpc")
     Distance(Array(1., dtype=float32, ...), unit='kpc')
 
     """
@@ -337,8 +337,8 @@ def constructor(
     return cls(jnp.asarray(d.value, dtype=dtype), d.unit)
 
 
-@Distance.constructor._f.register  # type: ignore[no-redef]  # noqa: SLF001
-def constructor(
+@Distance.from_._f.register  # type: ignore[no-redef]  # noqa: SLF001
+def from_(
     cls: type[Distance],
     value: DistanceModulus | Quantity["mag"],
     /,
@@ -351,10 +351,10 @@ def constructor(
     --------
     >>> from unxt import Distance, DistanceModulus, Quantity
 
-    >>> Distance.constructor(DistanceModulus(10, "mag")).to("pc")
+    >>> Distance.from_(DistanceModulus(10, "mag")).to("pc")
     Distance(Array(1000., dtype=float32, ...), unit='pc')
 
-    >>> Distance.constructor(Quantity(10, "mag")).to("pc")
+    >>> Distance.from_(Quantity(10, "mag")).to("pc")
     Distance(Array(1000., dtype=float32, ...), unit='pc')
 
     """
@@ -362,8 +362,8 @@ def constructor(
     return cls(jnp.asarray(d, dtype=dtype), "pc")
 
 
-@Parallax.constructor._f.register  # type: ignore[no-redef]  # noqa: SLF001
-def constructor(
+@Parallax.from_._f.register  # type: ignore[no-redef]  # noqa: SLF001
+def from_(
     cls: type[Parallax], value: Distance | Quantity["length"], /, *, dtype: Any = None
 ) -> Parallax:
     """Construct a `Parallax` from a distance.
@@ -373,10 +373,10 @@ def constructor(
     >>> import quaxed.numpy as jnp
     >>> from unxt import Parallax, Distance, Quantity
 
-    >>> jnp.round(Parallax.constructor(Distance(1, "pc")).to("mas"))
+    >>> jnp.round(Parallax.from_(Distance(1, "pc")).to("mas"))
     Parallax(Array(1000., dtype=float32, ...), unit='mas')
 
-    >>> jnp.round(Parallax.constructor(Quantity(1, "pc")).to("mas"), 2)
+    >>> jnp.round(Parallax.from_(Quantity(1, "pc")).to("mas"), 2)
     Parallax(Array(1000., dtype=float32, ...), unit='mas')
 
     """

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -13,6 +13,7 @@ from plum import dispatch
 
 from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
+from .flags import StandardUnitSystemFlag
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
 from .utils import get_dimension_name
 from unxt._src.dimensions.core import dimensions_of
@@ -158,6 +159,11 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
     """
     return NAMED_UNIT_SYSTEMS[name]
+
+
+@dispatch  # type: ignore[no-redef]
+def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
+    return unitsystem(*units_)
 
 
 # ----

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -162,6 +162,36 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
 
 @dispatch  # type: ignore[no-redef]
+def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
+    """Create a unit system from an existing unit system and additional units.
+
+    Examples
+    --------
+    We can add a new unit definition to an existing unit system:
+
+    >>> import astropy.units as u
+    >>> from unxt.unitsystems import unitsystem
+    >>> usys = unitsystem("galactic")
+    unitsystem(kpc, Myr, solMass, rad)
+    >>> unitsystem(usys, u.km/u.s)
+    LengthTimeMassAngleSpeedUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), speed=Unit("km / s"))
+
+    We can also override the base unit of an existing unit system:
+
+    >>> new_usys = unitsystem(usys, u.pc)
+    TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
+
+    """
+    new_usys = unitsystem(*units_)
+    current_units = [
+        unit
+        for unit in usys.base_units
+        if unit.physical_type not in new_usys.base_dimensions
+    ]
+    return unitsystem(*current_units, *units_)
+
+
+@dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
     return unitsystem(*units_)
 

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,0 +1,6 @@
+class AbstractUnitSystemFlag:
+    pass
+
+
+class StandardUnitSystemFlag(AbstractUnitSystemFlag):
+    pass

--- a/src/unxt/_src/utils.py
+++ b/src/unxt/_src/utils.py
@@ -5,8 +5,11 @@ Copyright (c) 2023 Galactic Dynamics. All rights reserved.
 
 __all__: list[str] = []
 
-from typing import cast
-from typing_extensions import Self
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 
 _singleton_insts: dict[type, object] = {}
 
@@ -28,10 +31,10 @@ class SingletonMixin:
 
     """
 
-    def __new__(cls, /) -> Self:
+    def __new__(cls, /) -> "Self":
         # Check if instance already exists
         if cls in _singleton_insts:
-            return cast(Self, _singleton_insts[cls])
+            return cast("Self", _singleton_insts[cls])
         # Create new instance and cache it
         self = object.__new__(cls)
         _singleton_insts[cls] = self

--- a/src/unxt/setup_package.py
+++ b/src/unxt/setup_package.py
@@ -1,0 +1,17 @@
+"""Copyright (c) 2023 unxt maintainers. All rights reserved."""
+
+import os
+from typing import Final
+
+RUNTIME_TYPECHECKER: Final[str | None] = os.environ.get(
+    "UNXT_ENABLE_RUNTIME_TYPECHECKING", None
+)
+"""Runtime type checking variable "UNXT_ENABLE_RUNTIME_TYPECHECKING".
+
+Set to "None" to disable runtime typechecking (default). Set to
+"beartype.beartype" to enable runtime typechecking.
+
+See https://docs.kidger.site/jaxtyping/api/runtime-type-checking for more
+information on options.
+
+"""

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -14,6 +14,7 @@ from hypothesis import example, given, strategies as st
 from hypothesis.extra.array_api import make_strategies_namespace
 from hypothesis.extra.numpy import array_shapes as np_array_shapes, arrays as np_arrays
 from jax.dtypes import canonicalize_dtype
+from jaxtyping import TypeCheckError
 from plum import convert, parametric
 
 import quaxed.numpy as jnp
@@ -424,7 +425,7 @@ def test_at():
     assert q2[1] == Quantity(2.0, "km")
     assert q[1] == Quantity(1.0, "km")  # original is unchanged
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, TypeCheckError)):
         q.at[1].mul(Quantity(2, "m"))
 
     # Divide
@@ -432,7 +433,7 @@ def test_at():
     assert q2[1] == Quantity(0.5, "km")
     assert q[1] == Quantity(1.0, "km")  # original is unchanged
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, TypeCheckError)):
         q.at[1].divide(Quantity(2, "m"))
 
     # Power

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -478,9 +478,9 @@ def test_parametric_pickle_dumps_with_kw_fields():
 
 
 def test_from_astropy():
-    """Test the ``Quantity.constructor(AstropyQuantity)`` method."""
+    """Test the ``Quantity.from_(AstropyQuantity)`` method."""
     apyq = u.Quantity(1, u.m)
-    q = Quantity.constructor(apyq)
+    q = Quantity.from_(apyq)
     assert isinstance(q, Quantity)
     assert np.equal(q.value, apyq.value)
     assert q.unit == apyq.unit

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -175,3 +175,14 @@ def test_equivalent():
 
     usys3 = unitsystem(u.kpc, u.Myr, u.radian)
     assert not equivalent(usys1, usys3)
+
+
+def test_extend():
+    """Test adding additional units to a unit system."""
+    usys1 = unitsystem(u.kpc, u.Myr, u.radian, u.Msun, u.km / u.s)
+    usys2 = unitsystem(usys1, u.mas / u.yr)
+    assert usys2["angular speed"] == u.mas / u.yr
+
+    usys3 = unitsystem(usys1, u.mas / u.yr, u.pc)
+    assert usys3["angular speed"] == u.mas / u.yr
+    assert usys3["length"] == u.pc  # overridden

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -31,8 +31,8 @@ def clean_unitsystems_registry(monkeypatch):
 # ===================================================================
 
 
-def test_unitsystem_constructor() -> None:
-    """Test the :class:`~unxt.UnitSystem` constructor."""
+def test_unitsystem_from_() -> None:
+    """Test the :class:`~unxt.UnitSystem` from_."""
     usys = unitsystem(5 * u.kpc, 50 * u.Myr, 1e5 * u.Msun, u.rad)
     assert np.isclose((8 * u.Myr).decompose(usys).value, 8 / 50)
 


### PR DESCRIPTION
This adds a new (currently not used) set of `Flag` types so we can dispatch on the type of unit system (will be useful for the follow-up to add a new `SimulationUnitSystem`). This also adds the ability to extend or override units in an existing unit system via:
```python
>>> usys = unitsystem(...)
>>> new_usys = unitsystem(usys, u.pc, u.erg)
```