### PR TITLE
Add concept of unitsystem flags and enable overriding / extending unit systems

### DIFF
--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -13,6 +13,7 @@ from plum import dispatch
 
 from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
+from .flags import StandardUnitSystemFlag
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
 from .utils import get_dimension_name
 from unxt._src.dimensions.core import dimensions_of
@@ -158,6 +159,11 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
     """
     return NAMED_UNIT_SYSTEMS[name]
+
+
+@dispatch  # type: ignore[no-redef]
+def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
+    return unitsystem(*units_)
 
 
 # ----

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -13,7 +13,7 @@ from plum import dispatch
 
 from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
-from .flags import StandardUnitSystemFlag
+from .flags import AbstractUnitSystemFlag, StandardUnitSystemFlag
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
 from .utils import get_dimension_name
 from unxt._src.dimensions.core import dimensions_of
@@ -189,6 +189,12 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
         if unit.physical_type not in new_usys.base_dimensions
     ]
     return unitsystem(*current_units, *units_)
+
+
+@dispatch  # type: ignore[no-redef]
+def unitsystem(flag: type[AbstractUnitSystemFlag], *_: Any) -> AbstractUnitSystem:
+    msg = "Do not use the AbstractUnitSystemFlag directly, only use subclasses."
+    raise ValueError(msg)
 
 
 @dispatch  # type: ignore[no-redef]

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -193,12 +193,22 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
 
 @dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[AbstractUnitSystemFlag], *_: Any) -> AbstractUnitSystem:
+    """Raise an exception since the flag is abstract."""
     msg = "Do not use the AbstractUnitSystemFlag directly, only use subclasses."
     raise TypeError(msg)
 
 
 @dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
+    """Create a standard unit system using the inputted units.
+
+    Examples
+    --------
+    >>> from unxt import unitsystem
+    >>> unitsystem(unitsystems.StandardUnitSystemFlag, u.kpc, u.Myr, u.Msun)
+    LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"))
+
+    """
     return unitsystem(*units_)
 
 

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -205,7 +205,7 @@ def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnit
     Examples
     --------
     >>> import astropy.units as u
-    >>> from unxt import unitsystem
+    >>> from unxt import unitsystem, unitsystems
     >>> unitsystem(unitsystems.StandardUnitSystemFlag, u.kpc, u.Myr, u.Msun)
     LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"))
 

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -162,6 +162,36 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
 
 
 @dispatch  # type: ignore[no-redef]
+def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
+    """Create a unit system from an existing unit system and additional units.
+
+    Examples
+    --------
+    We can add a new unit definition to an existing unit system:
+
+    >>> import astropy.units as u
+    >>> from unxt.unitsystems import unitsystem
+    >>> usys = unitsystem("galactic")
+    unitsystem(kpc, Myr, solMass, rad)
+    >>> unitsystem(usys, u.km/u.s)
+    LengthTimeMassAngleSpeedUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), speed=Unit("km / s"))
+
+    We can also override the base unit of an existing unit system:
+
+    >>> new_usys = unitsystem(usys, u.pc)
+    TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
+
+    """
+    new_usys = unitsystem(*units_)
+    current_units = [
+        unit
+        for unit in usys.base_units
+        if unit.physical_type not in new_usys.base_dimensions
+    ]
+    return unitsystem(*current_units, *units_)
+
+
+@dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
     return unitsystem(*units_)
 

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -172,13 +172,13 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
     >>> import astropy.units as u
     >>> from unxt.unitsystems import unitsystem
     >>> usys = unitsystem("galactic")
-    unitsystem(kpc, Myr, solMass, rad)
     >>> unitsystem(usys, u.km/u.s)
     LengthTimeMassAngleSpeedUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), speed=Unit("km / s"))
 
     We can also override the base unit of an existing unit system:
 
     >>> new_usys = unitsystem(usys, u.pc)
+    >>> new_usys
     TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
 
     """  # noqa: E501

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -181,7 +181,7 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
     >>> new_usys = unitsystem(usys, u.pc)
     TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
 
-    """
+    """  # noqa: E501
     new_usys = unitsystem(*units_)
     current_units = [
         unit

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -204,6 +204,7 @@ def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnit
 
     Examples
     --------
+    >>> import astropy.units as u
     >>> from unxt import unitsystem
     >>> unitsystem(unitsystems.StandardUnitSystemFlag, u.kpc, u.Myr, u.Msun)
     LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"))

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -194,7 +194,7 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
 @dispatch  # type: ignore[no-redef]
 def unitsystem(flag: type[AbstractUnitSystemFlag], *_: Any) -> AbstractUnitSystem:
     msg = "Do not use the AbstractUnitSystemFlag directly, only use subclasses."
-    raise ValueError(msg)
+    raise TypeError(msg)
 
 
 @dispatch  # type: ignore[no-redef]

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,6 +1,10 @@
 class AbstractUnitSystemFlag:
     """Abstract class for unit system flags to provide dispatch control."""
 
+    def __new__(cls, *args: Any, **kwargs: Any) -> Never:
+        msg = "unit system flag classes cannot be instantiated."
+        raise ValueError(msg)
+
 
 class StandardUnitSystemFlag(AbstractUnitSystemFlag):
     """Unit system flag to indicate a standard unit system with no additional args."""

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,7 +1,12 @@
+__all__ = ["AbstractUnitSystemFlag", "StandardUnitSystemFlag"]
+
+from typing import Any
+
+
 class AbstractUnitSystemFlag:
     """Abstract class for unit system flags to provide dispatch control."""
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Never:
+    def __new__(cls, *_: Any, **__: Any) -> None:  # type: ignore[misc]
         msg = "unit system flag classes cannot be instantiated."
         raise ValueError(msg)
 

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,0 +1,6 @@
+class AbstractUnitSystemFlag:
+    pass
+
+
+class StandardUnitSystemFlag(AbstractUnitSystemFlag):
+    pass

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,6 +1,6 @@
 class AbstractUnitSystemFlag:
-    pass
+    """Abstract class for unit system flags to provide dispatch control."""
 
 
 class StandardUnitSystemFlag(AbstractUnitSystemFlag):
-    pass
+    """Unit system flag to indicate a standard unit system with no additional args."""

--- a/src/unxt/unitsystems.py
+++ b/src/unxt/unitsystems.py
@@ -1,10 +1,11 @@
 """Tools for representing systems of units."""
 
-from ._src.units.system import base, builtin, compare, core, realizations, utils
+from ._src.units.system import base, builtin, compare, core, flags, realizations, utils
 from ._src.units.system.base import *  # noqa: F403
 from ._src.units.system.builtin import *  # noqa: F403
 from ._src.units.system.compare import *  # noqa: F403
 from ._src.units.system.core import *  # noqa: F403
+from ._src.units.system.flags import *  # noqa: F403
 from ._src.units.system.realizations import *  # noqa: F403
 from ._src.units.system.utils import *  # noqa: F403
 
@@ -15,6 +16,7 @@ __all__ += builtin.__all__
 __all__ += realizations.__all__
 __all__ += compare.__all__
 __all__ += utils.__all__
+__all__ += flags.__all__
 
 # Clean up namespace
-del base, builtin, compare, core, utils, realizations
+del base, builtin, compare, core, utils, realizations, flags

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from unxt import unitsystems
-from unxt._src.units.system.flags import AbstractUnitSystemFlag
+from unxt._src.units.system.flags import AbstractUnitSystemFlag, StandardUnitSystemFlag
 from unxt.unitsystems import (
     AbstractUnitSystem,
     DimensionlessUnitSystem,
@@ -198,3 +198,10 @@ def test_abstract_usys_flag():
     """Test that the abstract unit system flag fails."""
     with pytest.raises(ValueError, match="Do not use"):
         unitsystem(AbstractUnitSystemFlag, u.kpc)
+
+
+def test_standard_flag():
+    """Test defining unit system with the standard flag."""
+    usys1 = unitsystem(StandardUnitSystemFlag, u.kpc, u.Myr)
+    usys2 = unitsystem(u.kpc, u.Myr)
+    assert usys1 == usys2

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -10,10 +10,12 @@ import numpy as np
 import pytest
 
 from unxt import unitsystems
-from unxt._src.units.system.flags import AbstractUnitSystemFlag, StandardUnitSystemFlag
+from unxt._src.units.system.base import _UNITSYSTEMS_REGISTRY
 from unxt.unitsystems import (
     AbstractUnitSystem,
+    AbstractUnitSystemFlag,
     DimensionlessUnitSystem,
+    StandardUnitSystemFlag,
     dimensionless,
     equivalent,
     unitsystem,
@@ -199,7 +201,7 @@ def test_extend():
 
 def test_abstract_usys_flag():
     """Test that the abstract unit system flag fails."""
-    with pytest.raises(ValueError, match="Do not use"):
+    with pytest.raises(TypeError, match="Do not use"):
         unitsystem(AbstractUnitSystemFlag, u.kpc)
 
 

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -204,9 +204,15 @@ def test_abstract_usys_flag():
     with pytest.raises(TypeError, match="Do not use"):
         unitsystem(AbstractUnitSystemFlag, u.kpc)
 
+    with pytest.raises(ValueError, match="unit system flag classes"):
+        AbstractUnitSystemFlag()
+
 
 def test_standard_flag():
     """Test defining unit system with the standard flag."""
     usys1 = unitsystem(StandardUnitSystemFlag, u.kpc, u.Myr)
     usys2 = unitsystem(u.kpc, u.Myr)
     assert usys1 == usys2
+
+    with pytest.raises(ValueError, match="unit system flag classes"):
+        StandardUnitSystemFlag()

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from unxt import unitsystems
+from unxt._src.units.system.flags import AbstractUnitSystemFlag
 from unxt.unitsystems import (
     AbstractUnitSystem,
     DimensionlessUnitSystem,
@@ -191,3 +192,9 @@ def test_extend():
     usys3 = unitsystem(usys1, u.mas / u.yr, u.pc)
     assert usys3["angular speed"] == u.mas / u.yr
     assert usys3["length"] == u.pc  # overridden
+
+
+def test_abstract_usys_flag():
+    """Test that the abstract unit system flag fails."""
+    with pytest.raises(ValueError, match="Do not use"):
+        unitsystem(AbstractUnitSystemFlag, u.kpc)

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -180,3 +180,14 @@ def test_equivalent():
 
     usys3 = unitsystem(u.kpc, u.Myr, u.radian)
     assert not equivalent(usys1, usys3)
+
+
+def test_extend():
+    """Test adding additional units to a unit system."""
+    usys1 = unitsystem(u.kpc, u.Myr, u.radian, u.Msun, u.km / u.s)
+    usys2 = unitsystem(usys1, u.mas / u.yr)
+    assert usys2["angular speed"] == u.mas / u.yr
+
+    usys3 = unitsystem(usys1, u.mas / u.yr, u.pc)
+    assert usys3["angular speed"] == u.mas / u.yr
+    assert usys3["length"] == u.pc  # overridden

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -147,6 +147,9 @@ def test_unitsystem_already_registered():
             length: Annotated[u.Unit, u.get_physical_type("length")]
             time: Annotated[u.Unit, u.get_physical_type("time")]
 
+    # Clean up custom unit system from registry:
+    del _UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
+
 
 class TestDimensionlessUnitSystem:
     """Test `unxt.unitsystems.DimensionlessUnitSystem`."""


### PR DESCRIPTION
This adds a new (currently not used) set of `Flag` types so we can dispatch on the type of unit system (will be useful for the follow-up to add a new `SimulationUnitSystem`). This also adds the ability to extend or override units in an existing unit system via:
```python
>>> usys = unitsystem(...)
>>> new_usys = unitsystem(usys, u.pc, u.erg)
```