### PR TITLE
Add support for dynamical simulation unit systems (G=1 or other value)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ build-backend = "hatchling.build"
       "F821",    # undefined name '...'  <- jaxtyping
       "FIX002",  # Line contains TODO
       "ISC001",  # Conflicts with formatter
+      "N806",    # Variable in function should be lowercase
       "PD",      # Pandas
       "PLR09",   # Too many <...>
       "PLR2004", # Magic value used in comparison

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -18,7 +18,7 @@ from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
 from .flags import (
     AbstractUnitSystemFlag,
-    SimulationUnitSystemFlag,
+    DynamicalSimulationUnitSystemFlag,
     StandardUnitSystemFlag,
 )
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
@@ -222,7 +222,7 @@ def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnit
 
 @dispatch  # type: ignore[no-redef]
 def unitsystem(
-    flag: type[SimulationUnitSystemFlag],
+    flag: type[DynamicalSimulationUnitSystemFlag],
     *units_: Any,
     G: u.Quantity | float | int = 1.0,  # noqa: N803
 ) -> AbstractUnitSystem:

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 
 import astropy.units as u
 import equinox as eqx
-from astropy.constants import G as const_G
+from astropy.constants import G as const_G  # noqa: N811
 from plum import dispatch
 
 import quaxed.numpy as jnp
@@ -231,10 +231,10 @@ def unitsystem(
     tmp = unitsystem(*units_)
 
     if not isinstance(G, Quantity):
-        G = Quantity.constructor(G, "")
+        G = Quantity.from_(G, "")
 
     if G.unit.physical_type == ud.dimensionless:
-        G = G * const_G
+        G = G * Quantity.from_(const_G)
     elif not G.unit.is_equivalent(const_G):
         msg = (
             "Invalid value for G: must be dimensionless or have the correct dimensions "

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -247,11 +247,11 @@ def unitsystem(
         added = (length,)
     elif ud.mass in tmp.base_dimensions and ud.speed in tmp.base_dimensions:
         length = G * tmp["mass"] / tmp["velocity"] ** 2
-        time = tmp["length"] / tmp["velocity"]
+        time = length / tmp["velocity"]
         added = (length, time)
     elif ud.time in tmp.base_dimensions and ud.speed in tmp.base_dimensions:
         mass = 1 / G * tmp["velocity"] ** 3 * tmp["time"]
-        length = G * tmp["mass"] / tmp["velocity"] ** 2
+        length = G * mass / tmp["velocity"] ** 2
         added = (mass, length)
 
     return unitsystem(*tmp, *added)

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -224,20 +224,12 @@ def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnit
 def unitsystem(
     flag: type[DynamicalSimulationUnitSystemFlag],
     *units_: Any,
-    G: u.Quantity | float | int = 1.0,  # noqa: N803
+    G: float | int = 1.0,  # noqa: N803
 ) -> AbstractUnitSystem:
     tmp = unitsystem(*units_)
 
-    G = u.Quantity(G)
-
-    if G.unit.physical_type == u.get_physical_type("dimensionless"):
-        G = G * const_G
-    elif not G.unit.is_equivalent(const_G.unit):
-        msg = (
-            "Invalid value for G: must be dimensionless or have the correct dimensions "
-            "(equivalent to length per mass times velocity^2)"
-        )
-        raise ValueError(msg)
+    # Use G for computing the missing units below:
+    G = G * const_G
 
     added = ()
     if ud.length in tmp.base_dimensions and ud.mass in tmp.base_dimensions:

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 import astropy.units as u
 import equinox as eqx
 import numpy as np
-from astropy.constants import G as const_G  # noqa: N811
+from astropy.constants import G as const_G  # noqa: N811, pylint: disable=E0611
 from plum import dispatch
 
 from . import builtin_dimensions as ud

--- a/src/unxt/_src/units/system/core.py
+++ b/src/unxt/_src/units/system/core.py
@@ -17,9 +17,9 @@ from . import builtin_dimensions as ud
 from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem
 from .flags import (
-    AbstractUnitSystemFlag,
-    DynamicalSimulationUnitSystemFlag,
-    StandardUnitSystemFlag,
+    AbstractUSysFlag,
+    DynamicalSimUSysFlag,
+    StandardUSysFlag,
 )
 from .realizations import NAMED_UNIT_SYSTEMS, dimensionless
 from .utils import get_dimension_name
@@ -199,21 +199,21 @@ def unitsystem(usys: AbstractUnitSystem, *units_: Any) -> AbstractUnitSystem:
 
 
 @dispatch  # type: ignore[no-redef]
-def unitsystem(flag: type[AbstractUnitSystemFlag], *_: Any) -> AbstractUnitSystem:
+def unitsystem(flag: type[AbstractUSysFlag], *_: Any) -> AbstractUnitSystem:
     """Raise an exception since the flag is abstract."""
-    msg = "Do not use the AbstractUnitSystemFlag directly, only use subclasses."
+    msg = "Do not use the AbstractUSysFlag directly, only use subclasses."
     raise TypeError(msg)
 
 
 @dispatch  # type: ignore[no-redef]
-def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnitSystem:
+def unitsystem(flag: type[StandardUSysFlag], *units_: Any) -> AbstractUnitSystem:
     """Create a standard unit system using the inputted units.
 
     Examples
     --------
     >>> import astropy.units as u
     >>> from unxt import unitsystem, unitsystems
-    >>> unitsystem(unitsystems.StandardUnitSystemFlag, u.kpc, u.Myr, u.Msun)
+    >>> unitsystem(unitsystems.StandardUSysFlag, u.kpc, u.Myr, u.Msun)
     LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"))
 
     """
@@ -222,7 +222,7 @@ def unitsystem(flag: type[StandardUnitSystemFlag], *units_: Any) -> AbstractUnit
 
 @dispatch  # type: ignore[no-redef]
 def unitsystem(
-    flag: type[DynamicalSimulationUnitSystemFlag],
+    flag: type[DynamicalSimUSysFlag],
     *units_: Any,
     G: float | int = 1.0,  # noqa: N803
 ) -> AbstractUnitSystem:

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,13 +1,13 @@
 __all__ = [
-    "AbstractUnitSystemFlag",
-    "StandardUnitSystemFlag",
-    "DynamicalSimulationUnitSystemFlag",
+    "AbstractUSysFlag",
+    "StandardUSysFlag",
+    "DynamicalSimUSysFlag",
 ]
 
 from typing import Any
 
 
-class AbstractUnitSystemFlag:
+class AbstractUSysFlag:
     """Abstract class for unit system flags to provide dispatch control."""
 
     def __new__(cls, *_: Any, **__: Any) -> None:  # type: ignore[misc]
@@ -15,9 +15,9 @@ class AbstractUnitSystemFlag:
         raise ValueError(msg)
 
 
-class StandardUnitSystemFlag(AbstractUnitSystemFlag):
+class StandardUSysFlag(AbstractUSysFlag):
     """Flag to indicate a standard unit system with no additional arguments."""
 
 
-class DynamicalSimulationUnitSystemFlag(AbstractUnitSystemFlag):
+class DynamicalSimUSysFlag(AbstractUSysFlag):
     """Flag to indicate a unit system with optional definition of G."""

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,6 +1,8 @@
-__all__ = ["AbstractUnitSystemFlag", "StandardUnitSystemFlag"]
-
-from typing import Any
+__all__ = [
+    "AbstractUnitSystemFlag",
+    "StandardUnitSystemFlag",
+    "SimulationUnitSystemFlag",
+]
 
 
 class AbstractUnitSystemFlag:

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -1,7 +1,7 @@
 __all__ = [
     "AbstractUnitSystemFlag",
     "StandardUnitSystemFlag",
-    "SimulationUnitSystemFlag",
+    "DynamicalSimulationUnitSystemFlag",
 ]
 
 from typing import Any
@@ -19,5 +19,5 @@ class StandardUnitSystemFlag(AbstractUnitSystemFlag):
     """Flag to indicate a standard unit system with no additional arguments."""
 
 
-class SimulationUnitSystemFlag(AbstractUnitSystemFlag):
+class DynamicalSimulationUnitSystemFlag(AbstractUnitSystemFlag):
     """Flag to indicate a unit system with optional definition of G."""

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -4,6 +4,8 @@ __all__ = [
     "SimulationUnitSystemFlag",
 ]
 
+from typing import Any
+
 
 class AbstractUnitSystemFlag:
     """Abstract class for unit system flags to provide dispatch control."""

--- a/src/unxt/_src/units/system/flags.py
+++ b/src/unxt/_src/units/system/flags.py
@@ -12,4 +12,8 @@ class AbstractUnitSystemFlag:
 
 
 class StandardUnitSystemFlag(AbstractUnitSystemFlag):
-    """Unit system flag to indicate a standard unit system with no additional args."""
+    """Flag to indicate a standard unit system with no additional arguments."""
+
+
+class SimulationUnitSystemFlag(AbstractUnitSystemFlag):
+    """Flag to indicate a unit system with optional definition of G."""

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -225,4 +225,7 @@ def test_simulation_usys():
 
     tmp_G = const_G.decompose([u.kpc, u.Myr, u.Msun])
     usys1 = unitsystem(SimulationUnitSystemFlag, u.kpc, u.Myr, u.rad)
-    assert np.isclose(usys1["mass"].to_value(u.Msun), 1 / tmp_G.value)
+    assert np.isclose((1 * usys1["mass"]).to_value(u.Msun), 1 / tmp_G.value)
+
+    usys2 = unitsystem(SimulationUnitSystemFlag, u.kpc, u.Msun, u.rad)
+    assert np.isclose((1 * usys2["time"]).to_value(u.Myr), 1 / np.sqrt(tmp_G.value))

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -14,10 +14,10 @@ from unxt import unitsystems
 from unxt._src.units.system.base import _UNITSYSTEMS_REGISTRY
 from unxt.unitsystems import (
     AbstractUnitSystem,
-    AbstractUnitSystemFlag,
+    AbstractUSysFlag,
     DimensionlessUnitSystem,
-    DynamicalSimulationUnitSystemFlag,
-    StandardUnitSystemFlag,
+    DynamicalSimUSysFlag,
+    StandardUSysFlag,
     dimensionless,
     equivalent,
     unitsystem,
@@ -204,20 +204,20 @@ def test_extend():
 def test_abstract_usys_flag():
     """Test that the abstract unit system flag fails."""
     with pytest.raises(TypeError, match="Do not use"):
-        unitsystem(AbstractUnitSystemFlag, u.kpc)
+        unitsystem(AbstractUSysFlag, u.kpc)
 
     with pytest.raises(ValueError, match="unit system flag classes"):
-        AbstractUnitSystemFlag()
+        AbstractUSysFlag()
 
 
 def test_standard_flag():
     """Test defining unit system with the standard flag."""
-    usys1 = unitsystem(StandardUnitSystemFlag, u.kpc, u.Myr)
+    usys1 = unitsystem(StandardUSysFlag, u.kpc, u.Myr)
     usys2 = unitsystem(u.kpc, u.Myr)
     assert usys1 == usys2
 
     with pytest.raises(ValueError, match="unit system flag classes"):
-        StandardUnitSystemFlag()
+        StandardUSysFlag()
 
 
 def test_simulation_usys():
@@ -225,10 +225,10 @@ def test_simulation_usys():
     from astropy.constants import G as const_G  # noqa: N811
 
     tmp_G = const_G.decompose([u.kpc, u.Myr, u.Msun])
-    usys1 = unitsystem(DynamicalSimulationUnitSystemFlag, u.kpc, u.Myr, u.rad)
+    usys1 = unitsystem(DynamicalSimUSysFlag, u.kpc, u.Myr, u.rad)
     assert np.isclose((1 * usys1["mass"]).to_value(u.Msun), 1 / tmp_G.value)
 
-    usys2 = unitsystem(DynamicalSimulationUnitSystemFlag, u.kpc, u.Msun, u.rad)
+    usys2 = unitsystem(DynamicalSimUSysFlag, u.kpc, u.Msun, u.rad)
     assert np.isclose((1 * usys2["time"]).to_value(u.Myr), 1 / np.sqrt(tmp_G.value))
 
     base_units = (u.kpc, u.Myr, u.Msun, u.km / u.s)
@@ -236,7 +236,7 @@ def test_simulation_usys():
         if u1 == u2:
             continue
 
-        usys = unitsystem(DynamicalSimulationUnitSystemFlag, u1, u2)
+        usys = unitsystem(DynamicalSimUSysFlag, u1, u2)
 
         # For now, just test retrieving all three base unit types:
         usys["length"]

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -15,6 +15,7 @@ from unxt.unitsystems import (
     AbstractUnitSystem,
     AbstractUnitSystemFlag,
     DimensionlessUnitSystem,
+    SimulationUnitSystemFlag,
     StandardUnitSystemFlag,
     dimensionless,
     equivalent,
@@ -216,3 +217,12 @@ def test_standard_flag():
 
     with pytest.raises(ValueError, match="unit system flag classes"):
         StandardUnitSystemFlag()
+
+
+def test_simulation_usys():
+    """Test defining the simulation unit system with expected inputs."""
+    from astropy.constants import G as const_G  # noqa: N811
+
+    tmp_G = const_G.decompose([u.kpc, u.Myr, u.Msun])
+    usys1 = unitsystem(SimulationUnitSystemFlag, u.kpc, u.Myr, u.rad)
+    assert np.isclose(usys1["mass"].to_value(u.Msun), 1 / tmp_G.value)

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -1,5 +1,6 @@
 """Test the `unxt.unitsystems` module."""
 
+import itertools
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
@@ -229,3 +230,15 @@ def test_simulation_usys():
 
     usys2 = unitsystem(DynamicalSimulationUnitSystemFlag, u.kpc, u.Msun, u.rad)
     assert np.isclose((1 * usys2["time"]).to_value(u.Myr), 1 / np.sqrt(tmp_G.value))
+
+    base_units = (u.kpc, u.Myr, u.Msun, u.km / u.s)
+    for u1, u2 in itertools.product(base_units, base_units):
+        if u1 == u2:
+            continue
+
+        usys = unitsystem(DynamicalSimulationUnitSystemFlag, u1, u2)
+
+        # For now, just test retrieving all three base unit types:
+        usys["length"]
+        usys["mass"]
+        usys["time"]

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -15,7 +15,7 @@ from unxt.unitsystems import (
     AbstractUnitSystem,
     AbstractUnitSystemFlag,
     DimensionlessUnitSystem,
-    SimulationUnitSystemFlag,
+    DynamicalSimulationUnitSystemFlag,
     StandardUnitSystemFlag,
     dimensionless,
     equivalent,
@@ -224,8 +224,8 @@ def test_simulation_usys():
     from astropy.constants import G as const_G  # noqa: N811
 
     tmp_G = const_G.decompose([u.kpc, u.Myr, u.Msun])
-    usys1 = unitsystem(SimulationUnitSystemFlag, u.kpc, u.Myr, u.rad)
+    usys1 = unitsystem(DynamicalSimulationUnitSystemFlag, u.kpc, u.Myr, u.rad)
     assert np.isclose((1 * usys1["mass"]).to_value(u.Msun), 1 / tmp_G.value)
 
-    usys2 = unitsystem(SimulationUnitSystemFlag, u.kpc, u.Msun, u.rad)
+    usys2 = unitsystem(DynamicalSimulationUnitSystemFlag, u.kpc, u.Msun, u.rad)
     assert np.isclose((1 * usys2["time"]).to_value(u.Myr), 1 / np.sqrt(tmp_G.value))

--- a/uv.lock
+++ b/uv.lock
@@ -1621,8 +1621,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -2340,7 +2338,7 @@ wheels = [
 
 [[package]]
 name = "unxt"
-version = "0.17.1.dev3+gfbae9bd.d20241004"
+version = "0.17.2.dev17+ga80ece9"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
@@ -2453,7 +2451,7 @@ requires-dist = [
     { name = "astropy", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "astropy", marker = "extra == 'test-all'", specifier = ">=6.0" },
     { name = "dataclassish", specifier = ">=0.3" },
-    { name = "equinox", specifier = ">0.11" },
+    { name = "equinox", specifier = ">=0.11.5" },
     { name = "gala", marker = "extra == 'all'" },
     { name = "gala", marker = "extra == 'dev'" },
     { name = "gala", marker = "extra == 'interop-gala'" },


### PR DESCRIPTION
This is to add support for unit systems where only two of three of `{length, mass, time}` units need to be specified because the value of G is set to 1 (or some other value). This is analogous to Gala's [`SimulationUnitSystem`](http://gala.adrian.pw/en/latest/api/gala.units.SimulationUnitSystem.html#gala.units.SimulationUnitSystem).

For the value of G, I was originally planning to accept `unxt.Quantity | float | int`. But I think this needs to be a concrete value as the computed units need to be passed to `unxt.units()`, which under the hood calls `astropy.units.Unit`. So the current approach accepts `astropy.units.Quantity | float | int`, but now I'm thinking that this should instead require only `float | int` because it doesn't really make sense to allow someone to pass in a unit-ful G. That would also simplify some logic here. Thoughts?