### PR TITLE
Disallow version 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
   dynamic = ["version"]
   description = "Quantities in JAX"
   readme = "README.md"
-  requires-python = ">=3.10"
+  requires-python = ">=3.10,<3.13"
   authors = [
     { name = "GalacticDynamics", email = "nstarman@users.noreply.github.com" },
     { name = "Nathaniel Starkman", email = "nstarman@users.noreply.github.com" },


### PR DESCRIPTION
Small edit to pyproject.toml so that it no longer installs with pip on unsupported Python versions. 