### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         runs-on: [ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@
     "jaxlib>0.4.32",
     "jaxtyping>=0.2.34",
     "optional-dependencies>=0.3.2",
-    "plum-dispatch>=2.5.3",
+    "plum-dispatch>=2.5.4",
     "quax>=0.0.5",
     "quaxed>=0.6.7",
     "xmmutablemap>=0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
   dynamic = ["version"]
   description = "Quantities in JAX"
   readme = "README.md"
-  requires-python = ">=3.10,<3.13"
+  requires-python = ">=3.10,<3.14"
   authors = [
     { name = "GalacticDynamics", email = "nstarman@users.noreply.github.com" },
     { name = "Nathaniel Starkman", email = "nstarman@users.noreply.github.com" },
@@ -20,6 +20,7 @@
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
     "Typing :: Typed",

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -25,7 +25,7 @@ from unxt.quantity import AbstractQuantity, Quantity, UncheckedQuantity
 # Constructor
 
 
-@AbstractQuantity.from_._f.register  # noqa: SLF001
+@AbstractQuantity.from_.dispatch
 def from_(
     cls: type[AbstractQuantity], value: AstropyQuantity, /, **kwargs: Any
 ) -> AbstractQuantity:
@@ -45,7 +45,7 @@ def from_(
     return cls(jnp.asarray(value.value, **kwargs), value.unit)
 
 
-@AbstractQuantity.from_._f.register  # type: ignore[no-redef] # noqa: SLF001
+@AbstractQuantity.from_.dispatch  # type: ignore[no-redef]
 def from_(
     cls: type[AbstractQuantity], value: AstropyQuantity, unit: Any, /, **kwargs: Any
 ) -> AbstractQuantity:

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -873,7 +873,7 @@ class AbstractQuantity(
 # Register additional constructors
 
 
-@AbstractQuantity.from_._f.register  # noqa: SLF001
+@AbstractQuantity.from_.dispatch
 def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,
@@ -899,7 +899,7 @@ def from_(
     return cls(value.value, unit)
 
 
-@AbstractQuantity.from_._f.register  # type: ignore[no-redef]  # noqa: SLF001
+@AbstractQuantity.from_.dispatch  # type: ignore[no-redef]
 def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,
@@ -925,7 +925,7 @@ def from_(
     return cls(value.value, value.unit)
 
 
-@AbstractQuantity.from_._f.register  # type: ignore[no-redef] # noqa: SLF001
+@AbstractQuantity.from_.dispatch  # type: ignore[no-redef]
 def from_(
     cls: type[AbstractQuantity],
     value: AbstractQuantity,


### PR DESCRIPTION
A draft for Python 3.13 compatibility. Currently solving none of the bugs, but simply updating the CI matrix to test all versions of supported Python and updating the pyproject.toml to have the 3.13 tag while disallowing 3.14. 