### PR TITLE
Backport PR #321 on branch versions/v1.0.x (🔧 config(uv): add temporary jax constraint)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,3 +247,9 @@ name = "cz_gitmoji"
 
   [tool.pylint."FORMAT"]
   max-module-lines = 2000
+
+
+[tool.uv]
+constraint-dependencies = [
+  "jax<0.4.36", # TODO: remove when https://github.com/patrick-kidger/quax/pull/37 is merged
+]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 
+[manifest]
+constraints = [{ name = "jax", specifier = "<0.4.36" }]
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -2252,7 +2255,7 @@ wheels = [
 
 [[package]]
 name = "unxt"
-version = "1.0.1.dev1+g3beebb6.d20241203"
+version = "1.0.1.dev2+g801f623.d20241211"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
Signed-off-by: nstarman <nstarman@users.noreply.github.com>
(cherry picked from commit 9fb427b40d93915f208219846d35c5db0f9db8a3)