### PR TITLE
👽️ external(quaxed): use new quaxed.experimental.arrayish module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Install the project
         run: uv sync --group nox
 
-      #     - uses: pre-commit/action@v3.0.1
-      #       with:
-      #         extra_args: --hook-stage manual --all-files
+      - uses: pre-commit/action@v3.0.1
+
       - name: Run PyLint
         run: uv run nox -s pylint -- --output-format=github
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,7 @@ repos:
         files: src
         additional_dependencies:
           - plum-dispatch>=2.5.6
+          - quaxed>=0.8.1
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.3.0"
@@ -91,11 +92,3 @@ repos:
   #   hooks:
   #     - id: validate-pyproject
   #       additional_dependencies: ["validate-pyproject-schema-store[all]"]
-
-  - repo: local
-    hooks:
-      - id: disallow-caps
-        name: Disallow improper capitalization
-        language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
-        exclude: .pre-commit-config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
     "optional-dependencies>=0.3.2",
     "plum-dispatch>=2.5.6",
     "quax>=0.0.5",
-    "quaxed>=0.7.1",
+    "quaxed>=0.8.1",
     "xmmutablemap>=0.1",
     "zeroth>=1.0.0",
 ]

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -157,7 +157,7 @@ class IPythonReprMixin:
 
         """
         unit_repr = getattr(self.unit, "_repr_html_", self.unit.__repr__)()
-        value_repr = np.array2string(self.value, separator=", ")
+        value_repr = np.array2string(self.value, separator=", ")  # type: ignore[arg-type]
 
         return f"<span>{value_repr}</span> * <span>{unit_repr}</span>"
 
@@ -174,7 +174,7 @@ class IPythonReprMixin:
 
         """
         unit_repr = getattr(self.unit, "_repr_latex_", self.unit.__repr__)()
-        value_repr = np.array2string(self.value, separator=",~")
+        value_repr = np.array2string(self.value, separator=",~")  # type: ignore[arg-type]
 
         return f"${value_repr} \\; {unit_repr[1:-1]}$"
 

--- a/src/unxt/_src/utils.py
+++ b/src/unxt/_src/utils.py
@@ -50,7 +50,9 @@ class SingletonMixin:
 class HasDType(Protocol):
     """Protocol for objects that have a dtype attribute."""
 
-    dtype: DType
+    @property
+    def dtype(self) -> DType:
+        """The dtype of the object."""
 
 
 def promote_dtypes(*arrays: HasDType) -> tuple[HasDType, ...]:
@@ -77,7 +79,7 @@ def promote_dtypes(*arrays: HasDType) -> tuple[HasDType, ...]:
     """
     common_dtype = dtypes.result_type(*arrays)
     # TODO: check if this copies.
-    return tuple(qlax.convert_element_type(arr, common_dtype) for arr in arrays)
+    return tuple(qlax.convert_element_type(arr, common_dtype) for arr in arrays)  # type: ignore[arg-type]
 
 
 def promote_dtypes_if_needed(

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -521,7 +521,6 @@ def test_bitwise_left_shift():
     assert jnp.array_equal(got.value, expected.value)
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_bitwise_invert():
     """Test `bitwise_invert`."""
     x = u.Quantity(jnp.asarray([1, 2, 3], dtype=int), "")
@@ -836,7 +835,6 @@ def test_logical_and():
     assert jnp.array_equal(got, expected)
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_logical_not():
     """Test `logical_not`."""
     x = u.Quantity([True, False, True], "")

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -138,8 +138,13 @@ def test_getitem():
 
 def test_len():
     """Test the ``len(Quantity)`` method."""
+    # Length 3
     q = u.Quantity([1, 2, 3], "m")
     assert len(q) == 3
+
+    # Scalar
+    q = u.Quantity(1, "m")
+    assert len(q) == 0
 
 
 @pytest.mark.skip("TODO")

--- a/uv.lock
+++ b/uv.lock
@@ -1542,6 +1542,18 @@ wheels = [
 ]
 
 [[package]]
+name = "optype"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/99/3f70b7983a7cfbbd0f9c296dd7f8c6269c57e216f21cd3fde578a0d611ae/optype-0.9.0.tar.gz", hash = "sha256:1c2f99b0708ab6e2625f52093a6e000f805a4346191f09bcce0459da84a265a9", size = 93076 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/c2/0d5694ea30f6b852955a86e13e6a28387f60079b0b10e2ca9658fbf5cca5/optype-0.9.0-py3-none-any.whl", hash = "sha256:19dbbb71622961e903e60c12f370d910498e81bc4ae8b40d18c94dd106f4ce6b", size = 81554 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2051,18 +2063,19 @@ wheels = [
 
 [[package]]
 name = "quaxed"
-version = "0.7.1"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
+    { name = "optype" },
     { name = "plum-dispatch" },
     { name = "quax" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/01e425d053ee37ae2fd2cc736aaf418088c0b71c402719d06bda768bdf83/quaxed-0.7.1.tar.gz", hash = "sha256:bbc3596be9211324c2e5045e7fd919281f1a76eab63ad0dd1c8027378b1760f9", size = 123702 }
+sdist = { url = "https://files.pythonhosted.org/packages/75/17/80c24f8f21e764f2819182eaf032d620fbdd72df56388929ac4781347d02/quaxed-0.8.1.tar.gz", hash = "sha256:3856a778360cf74f01860f6774bb699a1a49b2b73c4ec7df13dd518f144084fc", size = 131590 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/63/a28e96b31fc27edac3c62d4359b82bdcb61da978b6a891061309a5bfb422/quaxed-0.7.1-py3-none-any.whl", hash = "sha256:1e1f66f3a523ff87f0a70b69c7079d5809f23091636747d8af4a6a99fa9925ba", size = 36547 },
+    { url = "https://files.pythonhosted.org/packages/cd/54/3694e96202a6fea6b197071e4d874ebda49dca5c9eb53434f7c3310b3f06/quaxed-0.8.1-py3-none-any.whl", hash = "sha256:0ce637a7154ccaf7d045caeebb0b7d1433c1f75b6d20a233a29ea99810dbd0ba", size = 48267 },
 ]
 
 [[package]]
@@ -2614,7 +2627,7 @@ wheels = [
 
 [[package]]
 name = "unxt"
-version = "1.0.1.dev28+g37602ac"
+version = "1.0.1.dev29+g49de864.d20250122"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
@@ -2767,7 +2780,7 @@ requires-dist = [
     { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "plum-dispatch", specifier = ">=2.5.6" },
     { name = "quax", specifier = ">=0.0.5" },
-    { name = "quaxed", specifier = ">=0.7.1" },
+    { name = "quaxed", specifier = ">=0.8.1" },
     { name = "xmmutablemap", specifier = ">=0.1" },
     { name = "zeroth", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
The `quaxed.experimental.arrayish` provides building blocks for constructing array-ish objects. After that the primitives need to be registered.
This PR refactors Quantity to use these blocks.
Since we vendor `quaxed`, using the experimental module is alright. The problems in that module — typing and lax —  aren't impactful here.