### PR TITLE
💄 ui(quantity): make AbstractQuantity available from the unxt namespace

### DIFF
--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     # quantities
     "quantity",  # module
     "Quantity",  # main class
+    "AbstractQuantity",  # base class
     "uconvert",  # convert units
     "ustrip",  # strip units
     "is_unit_convertible",  # check if units can be converted
@@ -51,7 +52,13 @@ with install_import_hook("unxt", RUNTIME_TYPECHECKER):
     from . import dims, quantity, units, unitsystems
     from ._version import version as __version__
     from .dims import dimension, dimension_of
-    from .quantity import Quantity, is_unit_convertible, uconvert, ustrip
+    from .quantity import (
+        AbstractQuantity,
+        Quantity,
+        is_unit_convertible,
+        uconvert,
+        ustrip,
+    )
     from .units import unit, unit_of
     from .unitsystems import AbstractUnitSystem, unitsystem, unitsystem_of
 

--- a/uv.lock
+++ b/uv.lock
@@ -2627,7 +2627,7 @@ wheels = [
 
 [[package]]
 name = "unxt"
-version = "1.0.1.dev29+g49de864.d20250122"
+version = "1.0.1.dev30+gc7ae4f5.d20250122"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
This is good for users in 2 primary use cases.
1. Makes isinstance checks for ANY quantity type easier (`isinstance(x, u.AbstractQuantity)` vs `isinstance(x, u.quantity.AbstractQuantity)`
2. Makes type annotations shorter / fewer imports.