### PR TITLE
✨ feat(quantity): AllowValue flag to let ustrip work on non-quantities

### DIFF
--- a/src/unxt/_src/quantity/flag.py
+++ b/src/unxt/_src/quantity/flag.py
@@ -1,0 +1,76 @@
+__all__ = ["AllowValue"]
+
+from typing import Any, NoReturn
+
+from jaxtyping import Array
+from plum import dispatch
+
+from . import api
+from .base import AbstractQuantity
+
+
+class AllowValue:
+    """A flag to allow a value to be passed through `unxt.ustrip`.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+
+    >>> x = jnp.array(1)
+    >>> y = u.ustrip(AllowValue, "km", x)
+    >>> y is x
+    True
+
+    >>> u.ustrip(AllowValue, "km", u.Quantity(1000, "m"))
+    Array(1., dtype=float32, ...)
+
+    This is a flag, so it cannot be instantiated.
+
+    >>> try:
+    ...     AllowValue()
+    ... except TypeError as e:
+    ...     print(e)
+    Cannot instantiate AllowValue
+
+    """
+
+    def __new__(cls) -> NoReturn:
+        msg = "Cannot instantiate AllowValue"
+        raise TypeError(msg)
+
+
+@dispatch
+def ustrip(flag: type[AllowValue], unit: Any, x: Array, /) -> Array:
+    """Strip the units from a value. This is a no-op.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+
+    >>> x = jnp.array(1)
+    >>> y = u.ustrip(AllowValue, "km", x)
+    >>> y is x
+    True
+
+    """
+    return x
+
+
+@dispatch  # TODO: type annotate by value
+def ustrip(flag: type[AllowValue], unit: Any, x: AbstractQuantity, /) -> Any:
+    """Strip the units from a quantity.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+    >>> q = u.Quantity(1000, "m")
+    >>> u.ustrip(AllowValue, "km", q)
+    Array(1., dtype=float32, ...)
+
+    """
+    return api.ustrip(unit, x)

--- a/src/unxt/_src/quantity/register_conversions.py
+++ b/src/unxt/_src/quantity/register_conversions.py
@@ -12,7 +12,7 @@ from unxt.units import unit_of
 
 
 @conversion_method(type_from=AbstractQuantity, type_to=BareQuantity)  # type: ignore[arg-type]
-def _quantity_to_unchecked(q: AbstractQuantity, /) -> BareQuantity:
+def quantity_to_unchecked(q: AbstractQuantity, /) -> BareQuantity:
     """Convert any quantity to an unchecked quantity.
 
     Examples
@@ -38,7 +38,7 @@ def _quantity_to_unchecked(q: AbstractQuantity, /) -> BareQuantity:
 
 
 @conversion_method(type_from=AbstractQuantity, type_to=Quantity)  # type: ignore[arg-type]
-def _quantity_to_checked(q: AbstractQuantity, /) -> Quantity:
+def quantity_to_checked(q: AbstractQuantity, /) -> Quantity:
     """Convert any quantity to a checked quantity.
 
     Examples

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -27,6 +27,7 @@ __all__ = [
     "is_unit_convertible",
     "is_any_quantity",
     "convert_to_quantity_value",
+    "AllowValue",
 ]
 
 
@@ -38,18 +39,19 @@ with install_import_hook("unxt.quantity", RUNTIME_TYPECHECKER):
     from ._src.quantity.api import is_unit_convertible, uconvert, ustrip
     from ._src.quantity.base import AbstractQuantity, is_any_quantity
     from ._src.quantity.base_parametric import AbstractParametricQuantity
+    from ._src.quantity.flag import AllowValue
     from ._src.quantity.quantity import Quantity
     from ._src.quantity.unchecked import BareQuantity, UncheckedQuantity
     from ._src.quantity.value import convert_to_quantity_value
 
-# isort: split
-# Register dispatches and conversions
-from ._src.quantity import (
-    register_api,
-    register_conversions,
-    register_dispatches,
-    register_primitives,
-)
+    # isort: split
+    # Register dispatches and conversions
+    from ._src.quantity import (
+        register_api,
+        register_conversions,
+        register_dispatches,
+        register_primitives,
+    )
 
 # Clean up namespace
 del register_conversions, register_api, register_dispatches, register_primitives


### PR DESCRIPTION
This assumes the value to be in the right unit.
This will simplify code in `galax`, where the assumption about values having the right units is common.