### PR TITLE
feat: use wadler_lindig

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,7 +28,7 @@ As an example, consider the following code snippets:
 
 >>> q = u.Quantity(1, 'm')
 >>> q
-Quantity['length'](Array(1, dtype=int32, weak_type=True), unit='m')
+Quantity(Array(1, dtype=int32, weak_type=True), unit='m')
 ```
 
 First we'll show the object-oriented API:
@@ -36,7 +36,7 @@ First we'll show the object-oriented API:
 ```{code-block} python
 
 >>> q.uconvert('cm')
-Quantity['length'](Array(100., dtype=float32, weak_type=True), unit='cm')
+Quantity(Array(100., dtype=float32, weak_type=True), unit='cm')
 ```
 
 And now the function-oriented API:
@@ -44,7 +44,7 @@ And now the function-oriented API:
 ```{code-block} python
 
 >>> u.uconvert("cm", q)
-Quantity['length'](Array(100., dtype=float32, weak_type=True), unit='cm')
+Quantity(Array(100., dtype=float32, weak_type=True), unit='cm')
 ```
 
 ## Argument Order of Functional APIs
@@ -59,7 +59,7 @@ function with the unit as the first argument and the quantity as the second:
 ```{code-block} python
 
 >>> u.uconvert("cm", q)  # convert[to_unit](quantity)
-Quantity['length'](Array(100., dtype=float32, weak_type=True), unit='cm')
+Quantity(Array(100., dtype=float32, weak_type=True), unit='cm')
 ```
 
 One of the reasons for this order is because it works very well with a
@@ -90,7 +90,7 @@ For example, `unxt` provides a `Quantity.from_` method that can convert an
 
 >>> xq = u.Quantity.from_(aq)  # unxt Quantity
 >>> xq
-Quantity['length'](Array(1., dtype=float32), unit='m')
+Quantity(Array(1., dtype=float32), unit='m')
 
 ```
 

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -8,7 +8,7 @@ constructor.
 ```{code-block} python
 >>> import unxt as u
 >>> u.Quantity(5, "m")
-Quantity['length'](Array(5, dtype=int32, weak_type=True), unit='m')
+Quantity(Array(5, dtype=int32, weak_type=True), unit='m')
 ```
 
 The constructor will automatically
@@ -35,16 +35,16 @@ appropriate constructor based on the input arguments.
 
 ```{code-block} python
 >>> u.Quantity.from_(5, "m")  # same as Quantity(5, "m")
-Quantity['length'](Array(5, dtype=int32, ...), unit='m')
+Quantity(Array(5, dtype=int32, ...), unit='m')
 
 >>> u.Quantity.from_({"value": [1, 2, 3], "unit": "m"})
-Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
 >>> u.Quantity.from_(q)  # from another Quantity object
-Quantity['length'](Array([1, 2, 3, 5], dtype=int32), unit='m')
+Quantity(Array([1, 2, 3, 5], dtype=int32), unit='m')
 
 >>> u.Quantity.from_(5, "m", dtype=float)  # specify the dtype
-Quantity['length'](Array(5., dtype=float32), unit='m')
+Quantity(Array(5., dtype=float32), unit='m')
 
 ```
 
@@ -73,7 +73,7 @@ units. If you prefer an object-oriented approach, use the `uconvert` method.
 ```{code-block} python
 >>> q = u.Quantity(5, "m")
 >>> q.uconvert("cm")
-Quantity['length'](Array(500., dtype=float32, ...), unit='cm')
+Quantity(Array(500., dtype=float32, ...), unit='cm')
 ```
 
 :::{note} :class: dropdown
@@ -82,7 +82,7 @@ The Astropy API `.to` is also available for `Quantity` objects.
 
 ```{code-block} python
 >>> q.to("cm")
-Quantity['length'](Array(500., dtype=float32, ...), unit='cm')
+Quantity(Array(500., dtype=float32, ...), unit='cm')
 ```
 
 :::
@@ -91,7 +91,7 @@ If you prefer a more functional approach, use the `uconvert` function.
 
 ```{code-block} python
 >>> u.uconvert("cm", q)
-Quantity['length'](Array(500., dtype=float32, ...), unit='cm')
+Quantity(Array(500., dtype=float32, ...), unit='cm')
 ```
 
 To convert to the value in the new units, use the `ustrip` function.
@@ -153,16 +153,16 @@ You can perform standard mathematical operations on `Quantity` objects:
 >>> q2 = u.Quantity(10, "m")
 
 >>> q1 + q2
-Quantity['length'](Array(15, dtype=int32, ...), unit='m')
+Quantity(Array(15, dtype=int32, ...), unit='m')
 
 >>> q1 * 1.5
-Quantity['length'](Array(7.5, dtype=float32, ...), unit='m')
+Quantity(Array(7.5, dtype=float32, ...), unit='m')
 
 >>> q1 / q2
-Quantity['dimensionless'](Array(0.5, dtype=float32, ...), unit='')
+Quantity(Array(0.5, dtype=float32, ...), unit='')
 
 >>> q1 ** 2
-Quantity['area'](Array(25, dtype=int32, ...), unit='m2')
+Quantity(Array(25, dtype=int32, ...), unit='m2')
 
 ```
 
@@ -186,10 +186,10 @@ Array([ True, False,  True], dtype=bool)
 >>> q = u.Quantity([1, 2, 3, 4], "m")
 
 >>> q[1]
-Quantity['length'](Array(2, dtype=int32), unit='m')
+Quantity(Array(2, dtype=int32), unit='m')
 
 >>> q[1:]
-Quantity['length'](Array([2, 3, 4], dtype=int32), unit='m')
+Quantity(Array([2, 3, 4], dtype=int32), unit='m')
 
 ```
 
@@ -203,7 +203,7 @@ for more details.
 >>> q = u.Quantity([1., 2, 3, 4], "m")
 
 >>> q.at[2].set(u.Quantity(30.1, "cm"))
-Quantity['length'](Array([1.   , 2.   , 0.301, 4.   ], dtype=float32), unit='m')
+Quantity(Array([1.   , 2.   , 0.301, 4.   ], dtype=float32), unit='m')
 
 ```
 
@@ -244,7 +244,7 @@ top function. With `unxt` you can use normal JAX!
 
 >>> y = u.Quantity([4, 5, 6], "m")
 >>> func(x, y)
-Quantity['area'](Array([ 5, 14, 27], dtype=int32), unit='m2')
+Quantity(Array([ 5, 14, 27], dtype=int32), unit='m2')
 
 ```
 
@@ -257,7 +257,7 @@ It's a drop-in replacement for much of JAX.
 >>> import quaxed.numpy as jnp  # pre-quaxified JAX
 
 >>> jnp.square(x) + jnp.multiply(x, y)
-Quantity['area'](Array([ 5, 14, 27], dtype=int32), unit='m2')
+Quantity(Array([ 5, 14, 27], dtype=int32), unit='m2')
 
 ```
 

--- a/docs/guides/type-checking.md
+++ b/docs/guides/type-checking.md
@@ -118,7 +118,7 @@ Here's an example:
 >>> t = u.Quantity([1.], "s")
 
 >>> velocity(x, t)
-Quantity['speed'](Array([2.], dtype=float32), unit='m / s')
+Quantity(Array([2.], dtype=float32), unit='m / s')
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ Create a `Quantity` by passing a JAX array-compatible object and a unit:
 
 >>> x = u.Quantity([1.0, 2.0, 3.0], apyu.m)
 >>> x
-Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='m')
+Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 ```
 
 As a shorthand, we also support specifying units as strings (parsed by
@@ -130,7 +130,7 @@ As a shorthand, we also support specifying units as strings (parsed by
 
 >>> y = u.Quantity([4.0, 5.0, 6.0], "m")
 >>> y
-Quantity['length'](Array([4., 5., 6.], dtype=float32), unit='m')
+Quantity(Array([4., 5., 6.], dtype=float32), unit='m')
 ```
 
 The constituent value and unit are accessible as attributes:
@@ -151,13 +151,13 @@ correct units:
 ```{code-block} python
 
 >>> x + y
-Quantity['length'](Array([5., 7., 9.], dtype=float32), unit='m')
+Quantity(Array([5., 7., 9.], dtype=float32), unit='m')
 
 >>> x * y
-Quantity['area'](Array([ 4., 10., 18.], dtype=float32), unit='m2')
+Quantity(Array([ 4., 10., 18.], dtype=float32), unit='m2')
 
 >>> x / y
-Quantity['dimensionless'](Array([0.25, 0.4 , 0.5 ], dtype=float32), unit='')
+Quantity(Array([0.25, 0.4 , 0.5 ], dtype=float32), unit='')
 
 ```
 
@@ -184,7 +184,7 @@ using the explicit syntax
 ```{code-block} python
 
 >>> x.uconvert("cm")
-Quantity['length'](Array([100., 200., 300.], dtype=float32), unit='cm')
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
 
 ```
 
@@ -193,7 +193,7 @@ or Astropy's API
 ```{code-block} python
 
 >>> x.to("cm")
-Quantity['length'](Array([100., 200., 300.], dtype=float32), unit='cm')
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
 
 ```
 
@@ -206,7 +206,7 @@ or a function-oriented approach
 ```{code-block} python
 
 >>> u.uconvert("cm", x)
-Quantity['length'](Array([100., 200., 300.], dtype=float32), unit='cm')
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
 
 ```
 
@@ -254,7 +254,7 @@ top function. With `unxt` you can use normal JAX!
 ...     return jnp.square(x) + jnp.multiply(x, y)  # normal JAX
 
 >>> func(x, y)
-Quantity['area'](Array([ 5., 14., 27.], dtype=float32), unit='m2')
+Quantity(Array([ 5., 14., 27.], dtype=float32), unit='m2')
 
 ```
 
@@ -270,7 +270,7 @@ It's a drop-in replacement for much of JAX.
 >>> import quaxed.numpy as jnp  # pre-quaxified JAX
 
 >>> jnp.square(x) + jnp.multiply(x, y)
-Quantity['area'](Array([ 5., 14., 27.], dtype=float32), unit='m2')
+Quantity(Array([ 5., 14., 27.], dtype=float32), unit='m2')
 
 ```
 
@@ -292,7 +292,7 @@ Quantity['area'](Array([ 5., 14., 27.], dtype=float32), unit='m2')
 
 >>> jitted_func = jit(func)
 >>> jitted_func(x, y)
-Quantity['area'](Array([ 5., 14., 27.], dtype=float32), unit='m2')
+Quantity(Array([ 5., 14., 27.], dtype=float32), unit='m2')
 
 ```
 
@@ -321,7 +321,7 @@ JAX Auto-Differentiation (AD) is supported:
 
 >>> grad_f = quaxify(jax.grad(f))
 >>> grad_f(x, y)
-Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 ```
 
@@ -333,7 +333,7 @@ or using the convenience library
 
 >>> grad_f = qjax.grad(f)
 >>> grad_f(x, y)
-Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 ```
 
@@ -345,7 +345,7 @@ Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 >>> jac_f = quaxify(jax.jacfwd(f))
 >>> jac_f(x, y)
-Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 ```
 
@@ -355,7 +355,7 @@ or using the convenience library
 
 >>> jac_f = qjax.jacfwd(f)
 >>> jac_f(x, y)
-Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 ```
 
@@ -367,7 +367,7 @@ Quantity['speed'](Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 >>> hess_f = quaxify(jax.hessian(f))
 >>> hess_f(x, y)
-Quantity['frequency'](Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
 
 ```
 
@@ -377,7 +377,7 @@ or using the convenience library
 
 >>> hess_f = qjax.hessian(f)
 >>> hess_f(x, y)
-Quantity['frequency'](Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
+Quantity(Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
 
 ```
 

--- a/docs/interop/astropy.md
+++ b/docs/interop/astropy.md
@@ -72,7 +72,7 @@ Quantity][unxt-Quantity] is straightforward -- use `unxt.Quantity.from_`:
 
 >>> xq = u.Quantity.from_(aq)  # unxt Quantity
 >>> xq
-Quantity['length'](Array(1., dtype=float32), unit='m')
+Quantity(Array(1., dtype=float32), unit='m')
 ```
 
 Alternatively, the multiple-dispatch library on which `unxt` is built enables
@@ -82,7 +82,7 @@ Alternatively, the multiple-dispatch library on which `unxt` is built enables
 >>> from plum import convert
 
 >>> convert(aq, u.Quantity)
-Quantity['length'](Array(1., dtype=float32), unit='m')
+Quantity(Array(1., dtype=float32), unit='m')
 
 >>> convert(xq, apyu.Quantity)
 <Quantity 1. m>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,10 @@
     "quax>=0.2.0",
     "quax-blocks>=0.3",
     "quaxed>=0.9.0",
+    "wadler-lindig>=0.1.5",
     "xmmutablemap>=0.1",
     "zeroth>=1.0.0",
-  ]
+]
 
   [project.optional-dependencies]
     # jax extras

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -64,7 +64,7 @@ def from_(
     >>> import astropy.units as apyu
 
     >>> u.Quantity.from_(apyu.Quantity(1, "m"))
-    Quantity['length'](Array(1., dtype=float32), unit='m')
+    Quantity(Array(1., dtype=float32), unit='m')
 
     """
     u = unit_of(value)
@@ -86,7 +86,7 @@ def from_(
     >>> import astropy.units as apyu
 
     >>> u.Quantity.from_(apyu.Quantity(1, "m"), "cm")
-    Quantity['length'](Array(100., dtype=float32), unit='cm')
+    Quantity(Array(100., dtype=float32), unit='cm')
 
     """
     u = unit(u)
@@ -171,7 +171,7 @@ def convert_astropy_quantity_to_unxt_quantity(q: AstropyQuantity, /) -> Quantity
     >>> from unxt import Quantity
 
     >>> convert(AstropyQuantity(1.0, "cm"), Quantity)
-    Quantity['length'](Array(1., dtype=float32), unit='cm')
+    Quantity(Array(1., dtype=float32), unit='cm')
 
     """
     u = unit_of(q)
@@ -216,21 +216,21 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
 
     >>> x = u.Quantity(1000, "m")
     >>> u.uconvert(u.unit("km"), x)
-    Quantity['length'](Array(1., dtype=float32, ...), unit='km')
+    Quantity(Array(1., dtype=float32, ...), unit='km')
 
     >>> x = u.Quantity([1, 2, 3], "Kelvin")
     >>> with apyu.add_enabled_equivalencies(apyu.temperature()):
     ...     y = x.uconvert("deg_C")
     >>> y
-    Quantity['temperature'](Array([-272.15, -271.15, -270.15], dtype=float32, ...), unit='deg_C')
+    Quantity(Array([-272.15, -271.15, -270.15], dtype=float32, ...), unit='deg_C')
 
     >>> x = Quantity([1, 2, 3], "radian")
     >>> with apyu.add_enabled_equivalencies(apyu.dimensionless_angles()):
     ...     y = x.uconvert("")
     >>> y
-    Quantity['dimensionless'](Array([1., 2., 3.], dtype=float32, ...), unit='')
+    Quantity(Array([1., 2., 3.], dtype=float32, ...), unit='')
 
-    """  # noqa: E501
+    """
     # Hot-path: if no unit conversion is necessary
     if x.unit == u:
         return x

--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -72,7 +72,7 @@ def grad(
 
     >>> grad_cube_volume = u.experimental.grad(cube_volume, units=("m",))
     >>> grad_cube_volume(u.Quantity(2.0, "m"))
-    Quantity['area'](Array(12., dtype=float32, weak_type=True), unit='m2')
+    Quantity(Array(12., dtype=float32, weak_type=True), unit='m2')
 
     """
     theunits: tuple[AstropyUnits | None, ...] = tuple(map(unit_or_none, units))

--- a/src/unxt/_src/quantity/api.py
+++ b/src/unxt/_src/quantity/api.py
@@ -17,10 +17,10 @@ def uconvert(u: Any, x: Any, /) -> Any:
 
     >>> q = u.Quantity(1, "km")
     >>> u.uconvert(u.unit("m"), q)
-    Quantity['length'](Array(1000., dtype=float32, ...), unit='m')
+    Quantity(Array(1000., dtype=float32, ...), unit='m')
 
     >>> u.uconvert("m", q)
-    Quantity['length'](Array(1000., dtype=float32, ...), unit='m')
+    Quantity(Array(1000., dtype=float32, ...), unit='m')
 
     For further examples, see the other method dispatches.
 

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -40,7 +40,7 @@ class AstropyQuantityCompatMixin:
 
         >>> q = Quantity(1, "m")
         >>> q.to("cm")
-        Quantity['length'](Array(100., dtype=float32, ...), unit='cm')
+        Quantity(Array(100., dtype=float32, ...), unit='cm')
 
         """
         return uconvert(u, self)  # redirect to the standard method
@@ -72,7 +72,7 @@ class AstropyQuantityCompatMixin:
 
         >>> q = Quantity(1, "m")
         >>> q.decompose(["cm", "s"])
-        Quantity['length'](Array(100., dtype=float32, ...), unit='cm')
+        Quantity(Array(100., dtype=float32, ...), unit='cm')
 
         """
         bases_ = [parse_unit(b) for b in bases]
@@ -117,17 +117,17 @@ class IPythonReprMixin:
 
         >>> q = Quantity([1.0, 2, 3, 4], "m")
         >>> q._repr_mimebundle_()
-        {'text/plain': "Quantity['length'](Array([1., 2., 3., 4.], dtype=float32), unit='m')",
+        {'text/plain': "Quantity(Array([1., 2., 3., 4.], dtype=float32), unit='m')",
          'text/html': '<span>[1., 2., 3., 4.]</span> * <span>Unit("m")</span>',
          'text/latex': '$[1.,~2.,~3.,~4.] \\; \\mathrm{m}$'}
 
         >>> q._repr_mimebundle_(include=["text/plain"])
-        {'text/plain': "Quantity['length'](Array([1., 2., 3., 4.], dtype=float32), unit='m')"}
+        {'text/plain': "Quantity(Array([1., 2., 3., 4.], dtype=float32), unit='m')"}
 
         >>> q._repr_mimebundle_(exclude=["text/html", "text/latex"])
-        {'text/plain': "Quantity['length'](Array([1., 2., 3., 4.], dtype=float32), unit='m')"}
+        {'text/plain': "Quantity(Array([1., 2., 3., 4.], dtype=float32), unit='m')"}
 
-        """  # noqa: E501
+        """
         # Determine the set of keys to include in the MIME bundle
         keys: Sequence[str]
         if include is None and exclude is None:
@@ -177,7 +177,6 @@ class IPythonReprMixin:
         """
         unit_repr = getattr(self.unit, "_repr_latex_", self.unit.__repr__)()
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
-
         return f"${value_repr} \\; {unit_repr[1:-1]}$"
 
     # TODO: implement:
@@ -227,10 +226,10 @@ class NumPyCompatMixin:
 
         >>> q = u.Quantity([1.0, 2, 3, 4], "m")
         >>> np.sum(q)
-        Quantity['length'](Array(10., dtype=float32), unit='m')
+        Quantity(Array(10., dtype=float32), unit='m')
 
         >>> np.stack([q, q])
-        Quantity['length'](Array([[1., 2., 3., 4.],
+        Quantity(Array([[1., 2., 3., 4.],
                                   [1., 2., 3., 4.]], dtype=float32), unit='m')
 
         """

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -31,45 +31,45 @@ class Quantity(AbstractParametricQuantity):
     From an integer:
 
     >>> u.Quantity(1, "m")
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     From a float:
 
     >>> u.Quantity(1.0, "m")
-    Quantity['length'](Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32, ...), unit='m')
 
     From a list:
 
     >>> u.Quantity([1, 2, 3], "m")
-    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a tuple:
 
     >>> u.Quantity((1, 2, 3), "m")
-    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `numpy.ndarray`:
 
     >>> import numpy as np
     >>> u.Quantity(np.array([1, 2, 3]), "m")
-    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `jax.Array`:
 
     >>> import jax.numpy as jnp
     >>> u.Quantity(jnp.array([1, 2, 3]), "m")
-    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     The unit can also be given as a units object:
 
     >>> u.Quantity(1, u.unit("m"))
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     In the previous examples, the dimension parameter was inferred from the
     values. It can also be given explicitly:
 
     >>> u.Quantity["length"](1, "m")
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     This can be used for runtime checking of the input dimension!
 
@@ -85,12 +85,12 @@ class Quantity(AbstractParametricQuantity):
     >>> dims
     PhysicalType('length')
     >>> u.Quantity[dims](1.0, "m")
-    Quantity['length'](Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32, ...), unit='m')
 
     Or as a unit:
 
     >>> u.Quantity[u.unit("m")](1.0, "m")
-    Quantity['length'](Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32, ...), unit='m')
 
     Some tricky cases are when the physical type is unknown:
 
@@ -101,8 +101,8 @@ class Quantity(AbstractParametricQuantity):
     The dimension can be given as a string in all cases, but is necessary when
     the physical type is unknown:
 
-    >>> u.Quantity["m2 kg-1 s-2"](1.0, unit)
-    Quantity['m2 kg-1 s-2'](Array(1., dtype=float32, ...), unit='m2 / (kg s2)')
+    >>> print(u.Quantity["m2 kg-1 s-2"](1.0, unit))  # to show the [dim]
+    Quantity[m2 kg-1 s-2](f32[](jax), unit='m2 / (kg s2)')
 
     """
 
@@ -123,7 +123,7 @@ def mod(self: Quantity["dimensionless"], other: ArrayLike) -> Quantity["dimensio
 
     >>> q = u.Quantity(480, "deg")
     >>> q % u.Quantity(360, "deg")
-    Quantity['angle'](Array(120, dtype=int32, ...), unit='deg')
+    Quantity(Array(120, dtype=int32, ...), unit='deg')
 
     """
     return replace(self, value=self.value % other)

--- a/src/unxt/_src/quantity/register_api.py
+++ b/src/unxt/_src/quantity/register_api.py
@@ -96,7 +96,7 @@ def uconvert(ustr: str, x: AbstractQuantity, /) -> AbstractQuantity:
 
     >>> x = Quantity(1000, "m")
     >>> uconvert("km", x)
-    Quantity['length'](Array(1., dtype=float32, ...), unit='km')
+    Quantity(Array(1., dtype=float32, ...), unit='km')
 
     """
     return uconvert(unit(ustr), x)
@@ -113,7 +113,7 @@ def uconvert(usys: AbstractUnitSystem, x: AbstractQuantity, /) -> AbstractQuanti
 
     >>> q = Quantity(1e17, "km")
     >>> uconvert(galactic, q)
-    Quantity['length'](Array(3.2407792, dtype=float32, ...), unit='kpc')
+    Quantity(Array(3.2407792, dtype=float32, ...), unit='kpc')
 
     """
     return uconvert(usys[dimension_of(x)], x)

--- a/src/unxt/_src/quantity/register_conversions.py
+++ b/src/unxt/_src/quantity/register_conversions.py
@@ -51,7 +51,7 @@ def quantity_to_checked(q: AbstractQuantity, /) -> Quantity:
     BareQuantity(Array(1, dtype=int32, ...), unit='m')
 
     >>> convert(q, Quantity)
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     The self-conversion doesn't copy the object:
 

--- a/src/unxt/_src/quantity/register_dispatches.py
+++ b/src/unxt/_src/quantity/register_dispatches.py
@@ -33,13 +33,13 @@ def arange(
     >>> from unxt import Quantity
 
     >>> jnp.arange(Quantity(5, "m"))
-    Quantity['length'](Array([0, 1, 2, 3, 4], dtype=int32), unit='m')
+    Quantity(Array([0, 1, 2, 3, 4], dtype=int32), unit='m')
 
     >>> jnp.arange(Quantity(5, "m"), Quantity(10, "m"))
-    Quantity['length'](Array([5, 6, 7, 8, 9], dtype=int32), unit='m')
+    Quantity(Array([5, 6, 7, 8, 9], dtype=int32), unit='m')
 
     >>> jnp.arange(Quantity(5, "m"), Quantity(10, "m"), Quantity(2, "m"))
-    Quantity['length'](Array([5, 7, 9], dtype=int32), unit='m')
+    Quantity(Array([5, 7, 9], dtype=int32), unit='m')
 
     """
     unit = start.unit
@@ -69,7 +69,7 @@ def empty_like(
     >>> from unxt import Quantity
 
     >>> jnp.empty_like(Quantity(5, "m"))
-    Quantity['length'](Array(0, dtype=int32, ...), unit='m')
+    Quantity(Array(0, dtype=int32, ...), unit='m')
 
     """
     out = type_np(x)(jax_xp.empty_like(x.value, **kwargs), unit=x.unit)
@@ -91,7 +91,7 @@ def full(
     >>> from unxt import Quantity
 
     >>> jnp.full((2, 2), Quantity(5, "m"))
-    Quantity['length'](Array([[5, 5], [5, 5]], dtype=int32, ...), unit='m')
+    Quantity(Array([[5, 5], [5, 5]], dtype=int32, ...), unit='m')
 
     """
     fill_val = ustrip(fill_value.unit, fill_value)
@@ -113,7 +113,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), fill_value=Quantity(10, "m"))
-    Quantity['length'](Array(10, dtype=int32, ...), unit='m')
+    Quantity(Array(10, dtype=int32, ...), unit='m')
 
     """
     # re-dispatch to the correct implementation
@@ -132,7 +132,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), 100.0)
-    Quantity['length'](Array(100, dtype=int32, ...), unit='m')
+    Quantity(Array(100, dtype=int32, ...), unit='m')
 
     """
     return type_np(x)(jax_xp.full_like(x.value, fill_value, **kwargs), unit=x.unit)
@@ -150,7 +150,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), Quantity(10, "m"))
-    Quantity['length'](Array(10, dtype=int32, ...), unit='m')
+    Quantity(Array(10, dtype=int32, ...), unit='m')
 
     """
     fill_val = ustrip(x.unit, fill_value)
@@ -172,7 +172,7 @@ def linspace(
     >>> from unxt import Quantity
 
     >>> jnp.linspace(Quantity(0, "m"), Quantity(10, "m"), 5)
-    Quantity['length'](Array([ 0. ,  2.5,  5. ,  7.5, 10. ], dtype=float32), unit='m')
+    Quantity(Array([ 0. ,  2.5,  5. ,  7.5, 10. ], dtype=float32), unit='m')
 
     """
     unit = start.unit
@@ -194,7 +194,7 @@ def linspace(
     >>> from unxt import Quantity
 
     >>> jnp.linspace(Quantity(0, "m"), Quantity(10, "m"), num=5)
-    Quantity['length'](Array([ 0. ,  2.5,  5. ,  7.5, 10. ], dtype=float32), unit='m')
+    Quantity(Array([ 0. ,  2.5,  5. ,  7.5, 10. ], dtype=float32), unit='m')
 
     """
     unit = start.unit
@@ -218,7 +218,7 @@ def ones_like(
     >>> from unxt import Quantity
 
     >>> jnp.ones_like(Quantity(5, "m"))
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     """
     out = type_np(x)(jax_xp.ones_like(x.value, **kwargs), unit=x.unit)
@@ -240,7 +240,7 @@ def zeros_like(
     >>> from unxt import Quantity
 
     >>> jnp.zeros_like(Quantity(5, "m"))
-    Quantity['length'](Array(0, dtype=int32, ...), unit='m')
+    Quantity(Array(0, dtype=int32, ...), unit='m')
 
     """
     out = type_np(x)(jax_xp.zeros_like(x.value, **kwargs), unit=x.unit)

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -57,9 +57,9 @@ def abs_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(-1, "m")
     >>> jnp.abs(q)
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
     >>> abs(q)
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     >>> from unxt.quantity import BareQuantity
     >>> q = BareQuantity(-1, "m")
@@ -90,7 +90,7 @@ def acos_p_aq(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(-1, "")
     >>> jnp.acos(q).round(4)
-    Quantity['angle'](Array(3.1416, dtype=float32, ...), unit='rad')
+    Quantity(Array(3.1416, dtype=float32, ...), unit='rad')
 
     """
     x_ = ustrip(one, x)
@@ -115,7 +115,7 @@ def acosh_p_aq(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(2.0, "")
     >>> jnp.acosh(q)
-    Quantity['angle'](Array(1.316958, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.316958, dtype=float32, ...), unit='rad')
 
     """
     x_ = ustrip(one, x)
@@ -146,16 +146,16 @@ def add_p_aqaq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1, "km")
     >>> q2 = Quantity(500.0, "m")
     >>> jnp.add(q1, q2)
-    Quantity['length'](Array(1.5, dtype=float32, ...), unit='km')
+    Quantity(Array(1.5, dtype=float32, ...), unit='km')
     >>> q1 + q2
-    Quantity['length'](Array(1.5, dtype=float32, ...), unit='km')
+    Quantity(Array(1.5, dtype=float32, ...), unit='km')
 
     >>> q1 = BareQuantity(1, "km")
     >>> q2 = Quantity(500.0, "m")
     >>> jnp.add(q1, q2)
-    Quantity['length'](Array(1.5, dtype=float32, weak_type=True), unit='km')
+    Quantity(Array(1.5, dtype=float32, weak_type=True), unit='km')
     >>> q1 + q2
-    Quantity['length'](Array(1.5, dtype=float32, weak_type=True), unit='km')
+    Quantity(Array(1.5, dtype=float32, weak_type=True), unit='km')
 
     """
     x, y = promote(x, y)
@@ -220,15 +220,15 @@ def add_p_vaq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
 
     >>> q2 = Quantity(100.0, "")
     >>> jnp.add(x, q2)
-    Quantity['dimensionless'](Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32, ...), unit='')
 
     >>> x + q2
-    Quantity['dimensionless'](Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32, ...), unit='')
 
     >>> q2 = Quantity(1.0, "km")
     >>> q3 = Quantity(1_000.0, "m")
     >>> jnp.add(x, q2 / q3)
-    Quantity['dimensionless'](Array(501., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(501., dtype=float32, weak_type=True), unit='')
 
     """
     y = uconvert(one, y)
@@ -293,15 +293,15 @@ def add_p_aqv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
 
     >>> q1 = Quantity(100.0, "")
     >>> jnp.add(q1, y)
-    Quantity[...](Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32, ...), unit='')
 
     >>> q1 + y
-    Quantity[...](Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32, ...), unit='')
 
     >>> q2 = Quantity(1.0, "km")
     >>> q3 = Quantity(1_000.0, "m")
     >>> jnp.add(q2 / q3, y)
-    Quantity['dimensionless'](Array(501., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(501., dtype=float32, weak_type=True), unit='')
 
     """
     x = uconvert(one, x)
@@ -331,7 +331,7 @@ def add_any_p(
     ...     return x + y
 
     >>> f(q1, q2)
-    Quantity['length'](Array(1.5, dtype=float32, ...), unit='km')
+    Quantity(Array(1.5, dtype=float32, ...), unit='km')
 
     """
     return replace(x, value=add_any_p.bind(ustrip(x), ustrip(y)))  # type: ignore[no-untyped-call]
@@ -468,7 +468,7 @@ def asin_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "")
     >>> jnp.asin(q)
-    Quantity['angle'](Array(1.5707964, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.5707964, dtype=float32, ...), unit='rad')
 
     """
     return type_np(x)(lax.asin(ustrip(one, x)), unit=radian)
@@ -505,7 +505,7 @@ def asinh_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(2, "")
     >>> jnp.asinh(q)
-    Quantity['angle'](Array(1.4436355, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.4436355, dtype=float32, ...), unit='rad')
 
     """
     return type_np(x)(lax.asinh(ustrip(one, x)), unit=radian)
@@ -546,7 +546,7 @@ def atan2_p_qq(
     >>> q1 = Quantity(1, "m")
     >>> q2 = Quantity(3.0, "m")
     >>> jnp.atan2(q1, q2)
-    Quantity['angle'](Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
 
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
@@ -588,7 +588,7 @@ def atan2_p_vq(
     >>> x1 = jnp.asarray(1.0)
     >>> q2 = Quantity(3, "")
     >>> jnp.atan2(x1, q2)
-    Quantity['angle'](Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
 
     """
     yv = ustrip(one, y)
@@ -629,7 +629,7 @@ def atan2_p_qv(
     >>> q1 = Quantity(1.0, "")
     >>> x2 = jnp.asarray(3)
     >>> jnp.atan2(q1, x2)
-    Quantity['angle'](Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
 
     """
     xv = ustrip(one, x)
@@ -667,7 +667,7 @@ def atan_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "")
     >>> jnp.atan(q)
-    Quantity['angle'](Array(0.7853982, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.7853982, dtype=float32, ...), unit='rad')
 
     """
     return Quantity(lax.atan(ustrip(one, x)), unit=radian)
@@ -704,7 +704,7 @@ def atanh_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(2, "")
     >>> jnp.atanh(q)
-    Quantity['angle'](Array(nan, dtype=float32, ...), unit='rad')
+    Quantity(Array(nan, dtype=float32, ...), unit='rad')
 
     """
     return type_np(x)(lax.atanh(ustrip(one, x)), unit=radian)
@@ -729,7 +729,7 @@ def bessel_i0e_p(x: AbstractQuantity, /, **kwargs: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> x = Quantity(1.0, "")
     >>> qlax.bessel_i0e(x)
-    Quantity['dimensionless'](Array(0.46575963, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.46575963, dtype=float32, weak_type=True), unit='')
 
     """
     return replace(x, value=lax.bessel_i0e_p.bind(ustrip(one, x), **kwargs))
@@ -751,7 +751,7 @@ def bessel_i1e_p(x: AbstractQuantity, /, **kwargs: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> x = Quantity(1.0, "")
     >>> qlax.bessel_i1e(x)
-    Quantity['dimensionless'](Array(0.20791042, dtype=float32, ...), unit='')
+    Quantity(Array(0.20791042, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=lax.bessel_i1e_p.bind(ustrip(one, x), **kwargs))
@@ -778,7 +778,7 @@ def bitcast_convert_type_p(
     >>> from unxt.quantity import Quantity
     >>> x = Quantity(1.0, "")
     >>> qlax.bitcast_convert_type(x, jnp.int16)
-    Quantity['dimensionless'](Array([    0, 16256], dtype=int16), unit='')
+    Quantity(Array([    0, 16256], dtype=int16), unit='')
 
     """
     return replace(
@@ -814,7 +814,7 @@ def cbrt_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(8, "m3")
     >>> jnp.cbrt(q)
-    Quantity['length'](Array(2., dtype=float32, ...), unit='m')
+    Quantity(Array(2., dtype=float32, ...), unit='m')
 
     """
     return type_np(x)(lax.cbrt_p.bind(ustrip(x), **kw), unit=x.unit ** (1 / 3))
@@ -838,7 +838,7 @@ def ceil_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1.5, "m")
     >>> jnp.ceil(q)
-    Quantity['length'](Array(2., dtype=float32, ...), unit='m')
+    Quantity(Array(2., dtype=float32, ...), unit='m')
 
     """
     return replace(x, value=qlax.ceil(ustrip(x)))
@@ -873,10 +873,10 @@ def clamp_p(
     >>> max = Quantity(2, "m")
     >>> q = Quantity([-1, 1, 3], "m")
     >>> lax.clamp(min, q, max)
-    Quantity['length'](Array([0, 1, 2], dtype=int32), unit='m')
+    Quantity(Array([0, 1, 2], dtype=int32), unit='m')
 
     >>> jnp.clip(q.astype(float), min, max)
-    Quantity['length'](Array([0., 1., 2.], dtype=float32), unit='m')
+    Quantity(Array([0., 1., 2.], dtype=float32), unit='m')
 
     """
     return replace(
@@ -910,7 +910,7 @@ def clamp_p_vaqaq(
     >>> max = Quantity(2, "")
     >>> q = Quantity([-1, 1, 3], "")
     >>> lax.clamp(min, q, max)
-    Quantity['dimensionless'](Array([0, 1, 2], dtype=int32), unit='')
+    Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
     """
     return replace(x, value=qlax.clamp(min, ustrip(one, x), ustrip(one, max)))
@@ -1008,7 +1008,7 @@ def clamp_p_qqv(
     >>> max = jnp.asarray(2)
     >>> q = Quantity([-1, 1, 3], "")
     >>> lax.clamp(min, q, max)
-    Quantity['dimensionless'](Array([0, 1, 2], dtype=int32), unit='')
+    Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
     """
     return replace(x, value=qlax.clamp(ustrip(one, min), ustrip(one, x), max))
@@ -1033,7 +1033,7 @@ def clz_p(x: AbstractQuantity, /) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "")
     >>> qlax.clz(q)
-    Quantity['dimensionless'](Array(31, dtype=int32, ...), unit='')
+    Quantity(Array(31, dtype=int32, ...), unit='')
 
     """
     return replace(x, value=lax.clz_p.bind(ustrip(x)))
@@ -1059,7 +1059,7 @@ def complex_p(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> x = Quantity(1.0, "m")
     >>> y = Quantity(2.0, "m")
     >>> lax.complex(x, y)
-    Quantity['length'](Array(1.+2.j, dtype=complex64, ...), unit='m')
+    Quantity(Array(1.+2.j, dtype=complex64, ...), unit='m')
 
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
@@ -1089,7 +1089,7 @@ def concatenate_p_aq(*operands: AbstractQuantity, dimension: Any) -> AbstractQua
     >>> q1 = Quantity([1.0], "km")
     >>> q2 = Quantity([2_000.0], "m")
     >>> jnp.concat([q1, q2])
-    Quantity['length'](Array([1., 2.], dtype=float32), unit='km')
+    Quantity(Array([1., 2.], dtype=float32), unit='km')
 
     """
     operand0 = operands[0]
@@ -1124,7 +1124,7 @@ def concatenate_p_qnd(
     ...     ]
     ... )
     >>> Rz
-    Quantity[...](Array([[ 0.70710677, -0.70710677,  0.        ],
+    Quantity(Array([[ 0.70710677, -0.70710677,  0.        ],
                          [ 0.70710677,  0.70710677,  0.        ],
                          [ 0.        ,  0.        ,  1.        ]], dtype=float32),
                   unit='')
@@ -1161,7 +1161,7 @@ def concatenate_p_vqnd(
     ...     ]
     ... )
     >>> Rx
-    Quantity[...](Array([[ 1.        ,  0.        ,  0.        ],
+    Quantity(Array([[ 1.        ,  0.        ,  0.        ],
                          [ 0.        ,  0.70710677, -0.70710677],
                          [ 0.        ,  0.70710677,  0.70710677]], dtype=float32),
                   unit='')
@@ -1213,7 +1213,7 @@ def conj_p(x: AbstractQuantity, *, input_dtype: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1 + 2j, "m")
     >>> jnp.conj(q)
-    Quantity['length'](Array(1.-2.j, dtype=complex64, ...), unit='m')
+    Quantity(Array(1.-2.j, dtype=complex64, ...), unit='m')
 
     """
     del input_dtype  # TODO: use this?
@@ -1253,7 +1253,7 @@ def copy_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "m")
     >>> jnp.copy(q)
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     """
     return replace(x, value=lax.copy_p.bind(ustrip(x)))  # type: ignore[no-untyped-call]
@@ -1294,11 +1294,11 @@ def cos_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "rad")
     >>> jnp.cos(q)
-    Quantity['dimensionless'](Array(0.5403023, dtype=float32, ...), unit='')
+    Quantity(Array(0.5403023, dtype=float32, ...), unit='')
 
     >>> q = Quantity(1, "")
     >>> jnp.cos(q)
-    Quantity['dimensionless'](Array(0.5403023, dtype=float32, ...), unit='')
+    Quantity(Array(0.5403023, dtype=float32, ...), unit='')
 
     """
     return Quantity(lax.cos_p.bind(_to_value_rad_or_one(x), **kw), unit=one)
@@ -1339,11 +1339,11 @@ def cosh_p_q(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "rad")
     >>> jnp.cosh(q)
-    Quantity['dimensionless'](Array(1.5430806, dtype=float32, ...), unit='')
+    Quantity(Array(1.5430806, dtype=float32, ...), unit='')
 
     >>> q = Quantity(1, "")
     >>> jnp.cosh(q)
-    Quantity['dimensionless'](Array(1.5430806, dtype=float32, ...), unit='')
+    Quantity(Array(1.5430806, dtype=float32, ...), unit='')
 
     """
     return type_np(x)(lax.cosh(_to_value_rad_or_one(x)), unit=one)
@@ -1370,7 +1370,7 @@ def cumlogsumexp_p(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([-1.0, -2, -3], "")
     >>> lax.cumlogsumexp(q)
-    Quantity['dimensionless'](Array([-1. , -0.6867383 , -0.59239405], dtype=float32),
+    Quantity(Array([-1. , -0.6867383 , -0.59239405], dtype=float32),
                               unit='')
 
     """
@@ -1399,7 +1399,7 @@ def cummax_p(operand: AbstractQuantity, *, axis: Any, reverse: Any) -> AbstractQ
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([1, 2, 1], "m")
     >>> lax.cummax(q)
-    Quantity['length'](Array([1, 2, 2], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 2], dtype=int32), unit='m')
 
     """
     return replace(
@@ -1426,7 +1426,7 @@ def cummin_p(operand: AbstractQuantity, *, axis: Any, reverse: Any) -> AbstractQ
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([2, 1, 3], "m")
     >>> lax.cummin(q)
-    Quantity['length'](Array([2, 1, 1], dtype=int32), unit='m')
+    Quantity(Array([2, 1, 1], dtype=int32), unit='m')
 
     """
     return replace(
@@ -1455,7 +1455,7 @@ def cumprod_p(
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([1, 2, 3], "")
     >>> lax.cumprod(q)
-    Quantity['dimensionless'](Array([1, 2, 6], dtype=int32), unit='')
+    Quantity(Array([1, 2, 6], dtype=int32), unit='')
 
     """
     return replace(
@@ -1482,7 +1482,7 @@ def cumsum_p(operand: AbstractQuantity, *, axis: Any, reverse: Any) -> AbstractQ
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([1, 2, 3], "m")
     >>> lax.cumsum(q)
-    Quantity['length'](Array([1, 3, 6], dtype=int32), unit='m')
+    Quantity(Array([1, 3, 6], dtype=int32), unit='m')
 
     """
     return replace(
@@ -1509,7 +1509,7 @@ def device_put_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "m")
     >>> device_put(q)
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     """
     return jt.map(lambda y: lax.device_put_p.bind(y, **kw), x)  # type: ignore[no-untyped-call]
@@ -1534,7 +1534,7 @@ def digamma_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1.0, "")
     >>> lax.digamma(q)
-    Quantity['dimensionless'](Array(-0.5772154, dtype=float32, ...), unit='')
+    Quantity(Array(-0.5772154, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=qlax.digamma(ustrip(one, x)))
@@ -1564,9 +1564,9 @@ def div_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1, "m")
     >>> q2 = Quantity(2, "s")
     >>> jnp.divide(q1, q2)
-    Quantity['speed'](Array(0.5, dtype=float32, ...), unit='m / s')
+    Quantity(Array(0.5, dtype=float32, ...), unit='m / s')
     >>> q1 / q2
-    Quantity['speed'](Array(0.5, dtype=float32, ...), unit='m / s')
+    Quantity(Array(0.5, dtype=float32, ...), unit='m / s')
 
     """
     x, y = promote(x, y)
@@ -1593,9 +1593,9 @@ def div_p_vq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(2.0, "m")
     >>> jnp.divide(x, q)
-    Quantity['wavenumber'](Array([0.5, 1. , 1.5], dtype=float32), unit='1 / m')
+    Quantity(Array([0.5, 1. , 1.5], dtype=float32), unit='1 / m')
     >>> x / q
-    Quantity['wavenumber'](Array([0.5, 1. , 1.5], dtype=float32), unit='1 / m')
+    Quantity(Array([0.5, 1. , 1.5], dtype=float32), unit='1 / m')
 
     """
     u = (1 / y.unit).unit  # TODO: better construction of the unit
@@ -1621,9 +1621,9 @@ def div_p_qv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(6.0, "m")
     >>> jnp.divide(q, y)
-    Quantity['length'](Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    Quantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
     >>> q / y
-    Quantity['length'](Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    Quantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
 
     """
     return replace(x, value=qlax.div(ustrip(x), y))
@@ -1658,9 +1658,9 @@ def dot_general_jq(
 
     >>> q = Quantity([1, 0, 0], "m")
     >>> jnp.linalg.matmul(Rz, q)
-    Quantity['length'](Array([0.70710677, 0.70710677, 0. ], dtype=float32), unit='m')
+    Quantity(Array([0.70710677, 0.70710677, 0. ], dtype=float32), unit='m')
     >>> Rz @ q
-    Quantity['length'](Array([0.70710677, 0.70710677, 0. ], dtype=float32), unit='m')
+    Quantity(Array([0.70710677, 0.70710677, 0. ], dtype=float32), unit='m')
 
     """
     return type_np(rhs)(lax.dot_general_p.bind(lhs, ustrip(rhs), **kw), unit=rhs.unit)
@@ -1691,21 +1691,21 @@ def dot_general_qq(
     >>> q1 = Quantity([1, 2, 3], "m")
     >>> q2 = Quantity([4, 5, 6], "m")
     >>> jnp.vecdot(q1, q2)
-    Quantity['area'](Array(32, dtype=int32), unit='m2')
+    Quantity(Array(32, dtype=int32), unit='m2')
     >>> q1 @ q2
-    Quantity['area'](Array(32, dtype=int32), unit='m2')
+    Quantity(Array(32, dtype=int32), unit='m2')
 
     This rule is also used by `jnp.matmul` for quantities.
 
     >>> Rz = jnp.asarray([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
     >>> q = Quantity([1, 0, 0], "m")
     >>> Rz @ q
-    Quantity['length'](Array([0, 1, 0], dtype=int32), unit='m')
+    Quantity(Array([0, 1, 0], dtype=int32), unit='m')
 
     This uses `matmul` for quantities.
 
     >>> jnp.linalg.matmul(Rz, q)
-    Quantity['length'](Array([0, 1, 0], dtype=int32), unit='m')
+    Quantity(Array([0, 1, 0], dtype=int32), unit='m')
 
     """
     lhs, rhs = promote(lhs, rhs)
@@ -1728,7 +1728,7 @@ def dynamic_slice_q(
 
     >>> q = Quantity([1, 2, 3, 4, 5], "m")
     >>> lax.dynamic_slice(q, (1,), (3,))
-    Quantity['length'](Array([2, 3, 4], dtype=int32), unit='m')
+    Quantity(Array([2, 3, 4], dtype=int32), unit='m')
 
     """
     return replace(
@@ -1757,7 +1757,7 @@ def dynamic_update_slice_p(
     >>> q = Quantity([1, 2, 3, 4, 5], "m")
     >>> update = Quantity([6, 7], "m")
     >>> lax.dynamic_update_slice(q, update, (1,))
-    Quantity['length'](Array([1, 6, 7, 4, 5], dtype=int32), unit='m')
+    Quantity(Array([1, 6, 7, 4, 5], dtype=int32), unit='m')
 
     """
     return replace(
@@ -1917,7 +1917,7 @@ def erf_inv_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(0.5, "")
     >>> lax.erf_inv(q)
-    Quantity['dimensionless'](Array(0.47693628, dtype=float32, ...), unit='')
+    Quantity(Array(0.47693628, dtype=float32, ...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -1944,7 +1944,7 @@ def erf_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(0.5, "")
     >>> lax.erf(q)
-    Quantity['dimensionless'](Array(0.5204999, dtype=float32, ...), unit='')
+    Quantity(Array(0.5204999, dtype=float32, ...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -1970,7 +1970,7 @@ def erfc_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(0.5, "")
     >>> lax.erfc(q)
-    Quantity['dimensionless'](Array(0.47950017, dtype=float32, ...), unit='')
+    Quantity(Array(0.47950017, dtype=float32, ...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -1996,7 +1996,7 @@ def exp2_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(3, "")
     >>> jnp.exp2(q)
-    Quantity['dimensionless'](Array(8., dtype=float32, ...), unit='')
+    Quantity(Array(8., dtype=float32, ...), unit='')
 
     """
     return replace(x, value=lax.exp2_p.bind(ustrip(one, x), **kw))
@@ -2021,12 +2021,12 @@ def exp_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "")
     >>> jnp.exp(q)
-    Quantity['dimensionless'](Array(2.7182817, dtype=float32, ...), unit='')
+    Quantity(Array(2.7182817, dtype=float32, ...), unit='')
 
     Euler's crown jewel:
 
     >>> jnp.exp(Quantity(jnp.pi * 1j, "")) + 1
-    Quantity['dimensionless'](Array(0.-8.742278e-08j, dtype=complex64, ...), unit='')
+    Quantity(Array(0.-8.742278e-08j, dtype=complex64, ...), unit='')
 
     Pretty close to zero!
 
@@ -2054,7 +2054,7 @@ def expm1_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(0, "")
     >>> jnp.expm1(q)
-    Quantity['dimensionless'](Array(0., dtype=float32, ...), unit='')
+    Quantity(Array(0., dtype=float32, ...), unit='')
 
     """
     return replace(x, value=lax.expm1_p.bind(ustrip(one, x), **kw))
@@ -2080,7 +2080,7 @@ def fft_p(x: AbstractQuantity, *, fft_type: Any, fft_lengths: Any) -> AbstractQu
     >>> from unxt.quantity import Quantity
     >>> q = Quantity([1, 2, 3], "")
     >>> jnp.fft.fft(q)
-    Quantity['dimensionless'](Array([ 6. +0.j       , -1.5+0.8660254j, -1.5-0.8660254j],
+    Quantity(Array([ 6. +0.j       , -1.5+0.8660254j, -1.5-0.8660254j],
                                     dtype=complex64), unit='')
 
     """
@@ -2106,7 +2106,7 @@ def floor_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1.5, "")
     >>> jnp.floor(q)
-    Quantity['dimensionless'](Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32, ...), unit='')
 
     """
     return replace(x, value=qlax.floor(ustrip(x)))
@@ -2368,7 +2368,7 @@ def igamma_p(
     >>> a = Quantity(1.0, "")
     >>> x = Quantity(1.0, "")
     >>> lax.igamma(a, x)
-    Quantity['dimensionless'](Array(0.6321202, dtype=float32, ...), unit='')
+    Quantity(Array(0.6321202, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=qlax.igamma(ustrip(AllowValue, one, a), ustrip(one, x)))
@@ -2401,7 +2401,7 @@ def igammac_p(
     >>> a = Quantity(1.0, "")
     >>> x = Quantity(1.0, "")
     >>> qlax.igammac(a, x)
-    Quantity['dimensionless'](Array(0.36787927, dtype=float32, ...), unit='')
+    Quantity(Array(0.36787927, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=qlax.igammac(ustrip(AllowValue, one, a), ustrip(one, x)))
@@ -2432,7 +2432,7 @@ def integer_pow_p(x: AbstractQuantity, *, y: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(2, "m")
     >>> q**3
-    Quantity['volume'](Array(8, dtype=int32, ...), unit='m3')
+    Quantity(Array(8, dtype=int32, ...), unit='m3')
 
     """
     return type_np(x)(value=qlax.integer_pow(ustrip(x), y), unit=x.unit**y)
@@ -2592,7 +2592,7 @@ def lgamma_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(3, "")
     >>> jsp.special.gammaln(q)
-    Quantity['dimensionless'](Array(0.6931474, dtype=float32, ...), unit='')
+    Quantity(Array(0.6931474, dtype=float32, ...), unit='')
 
     """
     # TODO: are there any units that this can support?
@@ -2617,7 +2617,7 @@ def log1p_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(-1, "")
     >>> jnp.log1p(q)
-    Quantity['dimensionless'](Array(-inf, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(-inf, dtype=float32, weak_type=True), unit='')
 
     """
     return replace(x, value=lax.log1p_p.bind(ustrip(one, x), **kw))
@@ -2641,7 +2641,7 @@ def log_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(1, "")
     >>> jnp.log(q)
-    Quantity['dimensionless'](Array(0., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0., dtype=float32, weak_type=True), unit='')
 
     """
     return replace(x, value=lax.log_p.bind(ustrip(one, x), **kw))
@@ -2665,7 +2665,7 @@ def logistic_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(1.0, "")
     >>> qlax.logistic(q)
-    Quantity['dimensionless'](Array(0.7310586, dtype=float32, ...), unit='')
+    Quantity(Array(0.7310586, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=lax.logistic_p.bind(ustrip(one, x), **kw))
@@ -2876,7 +2876,7 @@ def max_p_qq(x: AbstractQuantity, y: AbstractQuantity, /) -> AbstractQuantity:
     >>> q1 = Quantity(1, "m")
     >>> q2 = Quantity(2, "m")
     >>> jnp.maximum(q1, q2)
-    Quantity['length'](Array(2, dtype=int32, ...), unit='m')
+    Quantity(Array(2, dtype=int32, ...), unit='m')
 
     """
     yv = ustrip(x.unit, y)
@@ -2900,7 +2900,7 @@ def max_p_vq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q2 = Quantity(2, "")
     >>> jnp.maximum(x, q2)
-    Quantity['dimensionless'](Array([2.], dtype=float32), unit='')
+    Quantity(Array([2.], dtype=float32), unit='')
 
     """
     yv = ustrip(one, y)
@@ -2924,7 +2924,7 @@ def max_p_qv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q1 = Quantity(2, "")
     >>> jnp.maximum(q1, y)
-    Quantity['dimensionless'](Array([2.], dtype=float32), unit='')
+    Quantity(Array([2.], dtype=float32), unit='')
 
     """
     xv = ustrip(one, x)
@@ -2951,13 +2951,13 @@ def min_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q3 = Quantity([1, 2, 3], "m")
     >>> q4 = Quantity([2, 1, 3], "m")
     >>> jnp.minimum(q3, q4)
-    Quantity['length'](Array([1, 1, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 1, 3], dtype=int32), unit='m')
 
     >>> jnp.minimum(q1, q4)
     BareQuantity(Array([1, 1, 3], dtype=int32), unit='m')
 
     >>> jnp.minimum(q3, q2)
-    Quantity['length'](Array([1, 1, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 1, 3], dtype=int32), unit='m')
 
     """
     return replace(x, value=qlax.min(ustrip(x), ustrip(x.unit, y)))
@@ -2979,7 +2979,7 @@ def min_p_vq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
 
     >>> q = Quantity(2, "")
     >>> jnp.minimum(x, q)
-    Quantity['dimensionless'](Array([1, 2, 2], dtype=int32), unit='')
+    Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
     """
     return replace(y, value=qlax.min(x, ustrip(one, y)))
@@ -3001,7 +3001,7 @@ def min_p_qv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
 
     >>> q = Quantity(2, "")
     >>> jnp.minimum(q, x)
-    Quantity['dimensionless'](Array([1, 2, 2], dtype=int32), unit='')
+    Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
     """
     return replace(x, value=qlax.min(ustrip(one, x), y))
@@ -3029,12 +3029,12 @@ def mul_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(2, "m")
     >>> q2 = Quantity(3, "m")
     >>> jnp.multiply(q1, q2)
-    Quantity['area'](Array(6, dtype=int32, ...), unit='m2')
+    Quantity(Array(6, dtype=int32, ...), unit='m2')
 
     >>> q1 = BareQuantity(2, "m")
     >>> q2 = Quantity(3, "m")
     >>> jnp.multiply(q1, q2)
-    Quantity['area'](Array(6, dtype=int32, weak_type=True), unit='m2')
+    Quantity(Array(6, dtype=int32, weak_type=True), unit='m2')
 
     """
     # Promote to a common type
@@ -3069,13 +3069,13 @@ def mul_p_vq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
     >>> q = Quantity(2, "m")
 
     >>> 2.0 * q
-    Quantity['length'](Array(4., dtype=float32, ...), unit='m')
+    Quantity(Array(4., dtype=float32, ...), unit='m')
 
     >>> jnp.asarray(2) * q
-    Quantity['length'](Array(4, dtype=int32, ...), unit='m')
+    Quantity(Array(4, dtype=int32, ...), unit='m')
 
     >>> jnp.asarray([2, 3]) * q
-    Quantity['length'](Array([4, 6], dtype=int32), unit='m')
+    Quantity(Array([4, 6], dtype=int32), unit='m')
 
     """
     return replace(y, value=qlax.mul(x, ustrip(y)))
@@ -3105,13 +3105,13 @@ def mul_p_qv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
     >>> q = Quantity(2, "m")
 
     >>> q * 2.0
-    Quantity['length'](Array(4., dtype=float32, ...), unit='m')
+    Quantity(Array(4., dtype=float32, ...), unit='m')
 
     >>> q * jnp.asarray(2)
-    Quantity['length'](Array(4, dtype=int32, weak_type=True), unit='m')
+    Quantity(Array(4, dtype=int32, weak_type=True), unit='m')
 
     >>> q * jnp.asarray([2, 3])
-    Quantity['length'](Array([4, 6], dtype=int32), unit='m')
+    Quantity(Array([4, 6], dtype=int32), unit='m')
 
     """
     return replace(x, value=qlax.mul(ustrip(x), y))
@@ -3276,7 +3276,7 @@ def neg_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "m")
     >>> -q
-    Quantity['length'](Array(-1, dtype=int32, weak_type=True), unit='m')
+    Quantity(Array(-1, dtype=int32, weak_type=True), unit='m')
 
     """
     return replace(x, value=qlax.neg(ustrip(x)))
@@ -3303,7 +3303,7 @@ def nextafter_p(x1: AbstractQuantity, x2: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1, "")
     >>> q2 = Quantity(2, "")
     >>> jnp.nextafter(q1, q2)
-    Quantity['dimensionless'](Array(1.0000001, dtype=float32, ...), unit='')
+    Quantity(Array(1.0000001, dtype=float32, ...), unit='')
 
     """
     u = unit_of(x1)
@@ -3328,7 +3328,7 @@ def not_p(x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(1, "")
     >>> ~q
-    Quantity['dimensionless'](Array(-2, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(-2, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(x, value=qlax.bitwise_not(ustrip(one, x)))
@@ -3355,7 +3355,7 @@ def or_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1, "")
     >>> q2 = Quantity(2, "")
     >>> jnp.bitwise_or(q1, q2)
-    Quantity['dimensionless'](Array(3, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(3, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(x, value=qlax.bitwise_or(ustrip(one, x), ustrip(one, y)))
@@ -3380,7 +3380,7 @@ def polygamma_p(m: ArrayLike, x: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(3.0, "")
     >>> qlax.polygamma(1.0, q)
-    Quantity['dimensionless'](Array(0.39493403, dtype=float32, ...), unit='')
+    Quantity(Array(0.39493403, dtype=float32, ...), unit='')
 
     """
     return replace(x, value=qlax.polygamma(m, ustrip(one, x)))
@@ -3405,7 +3405,7 @@ def population_count_p(x: AbstractQuantity, /) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(3, "")
     >>> qlax.population_count(q)
-    Quantity['dimensionless'](Array(2, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(2, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(x, value=lax.population_count(ustrip(one, x)))
@@ -3434,9 +3434,9 @@ def pow_p_qq(
 
     >>> q1 = Quantity(2.0, "m")
     >>> jnp.power(q1, p)
-    Quantity['volume'](Array(8., dtype=float32, ...), unit='m3')
+    Quantity(Array(8., dtype=float32, ...), unit='m3')
     >>> q1**p
-    Quantity['volume'](Array(8., dtype=float32, ...), unit='m3')
+    Quantity(Array(8., dtype=float32, ...), unit='m3')
 
     """
     yv = ustrip(one, y)
@@ -3463,9 +3463,9 @@ def pow_p_qf(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
 
     >>> q1 = Quantity(2.0, "m")
     >>> jnp.power(q1, y)
-    Quantity['volume'](Array(8., dtype=float32, weak_type=True), unit='m3')
+    Quantity(Array(8., dtype=float32, weak_type=True), unit='m3')
     >>> q1**y
-    Quantity['volume'](Array(8., dtype=float32, weak_type=True), unit='m3')
+    Quantity(Array(8., dtype=float32, weak_type=True), unit='m3')
 
     """
     return type_np(x)(value=qlax.pow(ustrip(x), y), unit=x.unit**y)
@@ -3485,7 +3485,7 @@ def pow_p_vq(
     >>> x = jnp.array([2.0])
     >>> p = Quantity(3, "")
     >>> jnp.power(x, p)
-    Quantity['dimensionless'](Array([8.], dtype=float32), unit='')
+    Quantity(Array([8.], dtype=float32), unit='')
 
     """
     return replace(y, value=qlax.pow(x, ustrip(y)))
@@ -3510,10 +3510,10 @@ def real_p(x: AbstractQuantity) -> AbstractQuantity:
     BareQuantity(Array(1., dtype=float32, ...), unit='m')
 
     >>> jnp.real(Quantity(1.0, "m"))
-    Quantity['length'](Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32, ...), unit='m')
 
     >>> jnp.real(Quantity(1 + 2j, "m"))
-    Quantity['length'](Array(1., dtype=float32, weak_type=True), unit='m')
+    Quantity(Array(1., dtype=float32, weak_type=True), unit='m')
 
     """
     return replace(x, value=qlax.real(ustrip(x)))
@@ -3623,7 +3623,7 @@ def regularized_incomplete_beta_q(
 
     >>> x = Quantity(0.5, "")
     >>> jsp.betainc(a, b, x)
-    Quantity['dimensionless'](Array(0.6874998, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.6874998, dtype=float32, weak_type=True), unit='')
 
     >>> x = Quantity(0.5, "m")
     >>> try:
@@ -3659,7 +3659,7 @@ def rem_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(10, "m")
     >>> q2 = Quantity(3, "m")
     >>> q1 % q2
-    Quantity['length'](Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32, ...), unit='m')
 
     """
     return replace(x, value=qlax.rem(ustrip(x), ustrip(x.unit, y)))
@@ -3677,7 +3677,7 @@ def rem_p_uqv(x: Quantity["dimensionless"], y: ArrayLike) -> Quantity["dimension
     >>> q1 = Quantity(10, "")
     >>> q2 = jnp.array(3)
     >>> q1 % q2
-    Quantity['dimensionless'](Array(1, dtype=int32, ...), unit='')
+    Quantity(Array(1, dtype=int32, ...), unit='')
 
     """
     return replace(x, value=qlax.rem(ustrip(x), y))
@@ -3703,7 +3703,7 @@ def reshape_p(operand: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(jnp.arange(6), "m")
     >>> jnp.reshape(q, (3, 2))
-    Quantity['length'](Array([[0, 1],
+    Quantity(Array([[0, 1],
                               [2, 3],
                               [4, 5]], dtype=int32), unit='m')
 
@@ -3729,7 +3729,7 @@ def rev_p(operand: AbstractQuantity, *, dimensions: Any) -> AbstractQuantity:
 
     >>> q = Quantity([0, 1, 2, 3], "m")
     >>> qlax.rev(q, dimensions=(0,))
-    Quantity['length'](Array([3, 2, 1, 0], dtype=int32), unit='m')
+    Quantity(Array([3, 2, 1, 0], dtype=int32), unit='m')
 
     """
     return replace(operand, value=qlax.rev(ustrip(operand), dimensions))
@@ -3753,7 +3753,7 @@ def round_p(x: AbstractQuantity, *, rounding_method: Any) -> AbstractQuantity:
 
     >>> q = Quantity(1.234, "m")
     >>> jnp.round(q, 2)
-    Quantity['length'](Array(1.23, dtype=float32, ...), unit='m')
+    Quantity(Array(1.23, dtype=float32, ...), unit='m')
 
     """
     return replace(x, value=qlax.round(ustrip(x), rounding_method))
@@ -3777,7 +3777,7 @@ def rsqrt_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(1 / 4, "m")
     >>> qlax.rsqrt(q)
-    Quantity['m-0.5'](Array(2., dtype=float32, ...), unit='1 / m(1/2)')
+    Quantity(Array(2., dtype=float32, ...), unit='1 / m(1/2)')
 
     """
     return type_np(x)(lax.rsqrt_p.bind(ustrip(x), **kw), unit=x.unit ** (-1 / 2))
@@ -3883,7 +3883,7 @@ def select_n_p(which: AbstractQuantity, *cases: AbstractQuantity) -> AbstractQua
     >>> b = u.Quantity([2.0, 4.0, 10.0], "km")
     >>> which = u.Quantity(a > b, "")
     >>> jnp.where(which, a, b)
-    Quantity['length'](Array([ 2.,  5., 10.], dtype=float32), unit='km')
+    Quantity(Array([ 2.,  5., 10.], dtype=float32), unit='km')
 
     """
     u = cases[0].unit
@@ -3927,10 +3927,10 @@ def select_n_p_jqj(
     >>> y = u.Quantity([2.0, 4.0, 10.0], "km")
 
     >>> jnp.hypot(x, y)
-    Quantity[...](Array([ 2.236068 ,  6.4031243, 13.453625 ], dtype=float32), unit='km')
+    Quantity(Array([ 2.236068 ,  6.4031243, 13.453625 ], dtype=float32), unit='km')
 
     >>> jnp.triu(u.Quantity([[1, 2], [3, 4]], "km"))
-    Quantity['length'](Array([[1, 2],
+    Quantity(Array([[1, 2],
                               [0, 4]], dtype=int32), unit='km')
 
     """
@@ -3951,14 +3951,14 @@ def select_n_p_jqq(which: ArrayLike, *cases: AbstractQuantity) -> AbstractQuanti
     >>> a = Q([1.0, 5.0, 9.0], "kpc")
     >>> b = Q([2.0, 6.0, 10.0], "kpc")
     >>> jnp.select(([a > Q(4, "kpc"), b < Q(8, "kpc")]), [a, b], default=Q(0, "kpc"))
-    Quantity[...](Array([2., 5., 9.], dtype=float32), unit='kpc')
+    Quantity(Array([2., 5., 9.], dtype=float32), unit='kpc')
 
     This selection dispatch also happens when using ``jnp.hypot``.
 
     >>> a = Q([3], "kpc")
     >>> b = Q([4], "kpc")
     >>> jnp.hypot(a, b)
-    Quantity[...](Array([5.], dtype=float32), unit='kpc')
+    Quantity(Array([5.], dtype=float32), unit='kpc')
 
     """
     u = unit_of(cases[0])
@@ -3988,7 +3988,7 @@ def shift_right_arithmetic_p(
 
     >>> q = Quantity(1, "")
     >>> qlax.shift_right_arithmetic(q, 2)
-    Quantity['dimensionless'](Array(0, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(0, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(
@@ -4043,11 +4043,11 @@ def sin_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(90, "deg")
     >>> jnp.sin(q)
-    Quantity['dimensionless'](Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32, ...), unit='')
 
     >>> q = Quantity(jnp.pi / 2, "")
     >>> jnp.sin(q)
-    Quantity['dimensionless'](Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32, ...), unit='')
 
     """
     return type_np(x)(lax.sin_p.bind(_to_value_rad_or_one(x), **kw), unit=one)
@@ -4075,11 +4075,11 @@ def sinh_p(x: AbstractQuantity) -> AbstractQuantity:
 
     >>> q = Quantity(90, "deg")
     >>> jnp.sinh(q)
-    Quantity['dimensionless'](Array(2.301299, dtype=float32, ...), unit='')
+    Quantity(Array(2.301299, dtype=float32, ...), unit='')
 
     >>> q = Quantity(jnp.pi / 2, "")
     >>> jnp.sinh(q)
-    Quantity['dimensionless'](Array(2.301299, dtype=float32, ...), unit='')
+    Quantity(Array(2.301299, dtype=float32, ...), unit='')
 
     """
     return type_np(x)(lax.sinh(_to_value_rad_or_one(x)), unit=one)
@@ -4105,7 +4105,7 @@ def shift_left_p(
 
     >>> q = Quantity(1, "")
     >>> qlax.shift_left(q, 2)
-    Quantity['dimensionless'](Array(4, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(4, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(x, value=qlax.shift_left(ustrip(x), ustrip(AllowValue, one, y)))
@@ -4190,7 +4190,7 @@ def square_p(x: AbstractQuantity) -> AbstractQuantity:
 
     >>> q = Quantity(3, "m")
     >>> jnp.square(q)
-    Quantity['area'](Array(9, dtype=int32, ...), unit='m2')
+    Quantity(Array(9, dtype=int32, ...), unit='m2')
 
     """
     return type_np(x)(lax.square(ustrip(x)), unit=x.unit**2)
@@ -4215,7 +4215,7 @@ def sqrt_p_q(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(9, "m")
     >>> jnp.sqrt(q)
-    Quantity['m0.5'](Array(3., dtype=float32, ...), unit='m(1/2)')
+    Quantity(Array(3., dtype=float32, ...), unit='m(1/2)')
 
     """
     # Apply sqrt to the value and adjust the unit
@@ -4240,7 +4240,7 @@ def squeeze_p(x: AbstractQuantity, *, dimensions: Any) -> AbstractQuantity:
 
     >>> q = Quantity(jnp.array([[[1], [2], [3]]]), "m")
     >>> jnp.squeeze(q)
-    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+    Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     """
     return type_np(x)(lax.squeeze(ustrip(x), dimensions), unit=x.unit)
@@ -4290,9 +4290,9 @@ def sub_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1.0, "km")
     >>> q2 = Quantity(500.0, "m")
     >>> jnp.subtract(q1, q2)
-    Quantity['length'](Array(0.5, dtype=float32, ...), unit='km')
+    Quantity(Array(0.5, dtype=float32, ...), unit='km')
     >>> q1 - q2
-    Quantity['length'](Array(0.5, dtype=float32, ...), unit='km')
+    Quantity(Array(0.5, dtype=float32, ...), unit='km')
 
     """
     # Get the values, promoting if needed
@@ -4323,10 +4323,10 @@ def sub_p_vq(x: ArrayLike, y: AbstractQuantity) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(500.0, "")
     >>> jnp.subtract(x, q)
-    Quantity['dimensionless'](Array(500., dtype=float32, ...), unit='')
+    Quantity(Array(500., dtype=float32, ...), unit='')
 
     >>> x - q
-    Quantity['dimensionless'](Array(500., dtype=float32, ...), unit='')
+    Quantity(Array(500., dtype=float32, ...), unit='')
 
     """
     y = uconvert(one, y)
@@ -4353,10 +4353,10 @@ def sub_p_qv(x: AbstractQuantity, y: ArrayLike) -> AbstractQuantity:
     >>> from unxt.quantity import Quantity
     >>> q = Quantity(500.0, "")
     >>> jnp.subtract(q, y)
-    Quantity['dimensionless'](Array(-500., dtype=float32, ...), unit='')
+    Quantity(Array(-500., dtype=float32, ...), unit='')
 
     >>> q - y
-    Quantity['dimensionless'](Array(-500., dtype=float32, ...), unit='')
+    Quantity(Array(-500., dtype=float32, ...), unit='')
 
     """
     x = uconvert(one, x)
@@ -4385,11 +4385,11 @@ def tan_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(45, "deg")
     >>> jnp.tan(q)
-    Quantity['dimensionless'](Array(1., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(1., dtype=float32, weak_type=True), unit='')
 
     >>> q = Quantity(jnp.pi / 4, "")
     >>> jnp.tan(q)
-    Quantity['dimensionless'](Array(1., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(1., dtype=float32, weak_type=True), unit='')
 
     """
     return type_np(x)(lax.tan_p.bind(_to_value_rad_or_one(x), **kw), unit=one)
@@ -4417,11 +4417,11 @@ def tanh_p(x: AbstractQuantity, /, **kw: Any) -> AbstractQuantity:
 
     >>> q = Quantity(45, "deg")
     >>> jnp.tanh(q)
-    Quantity['dimensionless'](Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
 
     >>> q = Quantity(jnp.pi / 4, "")
     >>> jnp.tanh(q)
-    Quantity['dimensionless'](Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
 
     """
     return type_np(x)(lax.tanh_p.bind(_to_value_rad_or_one(x), **kw), unit=one)
@@ -4446,8 +4446,8 @@ def top_k_p(operand: AbstractQuantity, /, **kwargs: Any) -> AbstractQuantity:
 
     >>> q = Quantity([1, 2, 3], "m")
     >>> qlax.top_k(q, k=2)
-    [Quantity['length'](Array([3, 2], dtype=int32), unit='m'),
-     Quantity['length'](Array([2, 1], dtype=int32), unit='m')]
+    [Quantity(Array([3, 2], dtype=int32), unit='m'),
+     Quantity(Array([2, 1], dtype=int32), unit='m')]
 
     """
     return replace(operand, value=lax.top_k_p.bind(ustrip(operand), **kwargs))  # type: ignore[no-untyped-call]
@@ -4475,7 +4475,7 @@ def transpose_p(operand: AbstractQuantity, *, permutation: Any) -> AbstractQuant
 
     >>> q = Quantity(x, "m")
     >>> jnp.transpose(q)
-    Quantity['length'](Array([[0, 3],
+    Quantity(Array([[0, 3],
                               [1, 4],
                               [2, 5]], dtype=int32), unit='m')
 
@@ -4506,7 +4506,7 @@ def xor_p_qq(x: AbstractQuantity, y: AbstractQuantity) -> AbstractQuantity:
     >>> q1 = Quantity(1, "")
     >>> q2 = Quantity(2, "")
     >>> jnp.bitwise_xor(q1, q2)
-    Quantity['dimensionless'](Array(3, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(3, dtype=int32, weak_type=True), unit='')
 
     """
     return replace(x, value=qlax.bitwise_xor(ustrip(one, x), ustrip(one, y)))

--- a/uv.lock
+++ b/uv.lock
@@ -2692,6 +2692,7 @@ dependencies = [
     { name = "quax" },
     { name = "quax-blocks" },
     { name = "quaxed" },
+    { name = "wadler-lindig" },
     { name = "xmmutablemap" },
     { name = "zeroth" },
 ]
@@ -2830,6 +2831,7 @@ requires-dist = [
     { name = "quax", specifier = ">=0.2.0" },
     { name = "quax-blocks", specifier = ">=0.3" },
     { name = "quaxed", specifier = ">=0.9.0" },
+    { name = "wadler-lindig", specifier = ">=0.1.5" },
     { name = "xmmutablemap", specifier = ">=0.1" },
     { name = "zeroth", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
This changes the string representation machinery to use the Wadler-Lindig library. 
See https://docs.kidger.site/wadler_lindig/.
There's now a lot more flexibility to format the strings.
I also make the nice change that `repr` doesn't show the [dimension] since this is currently uniquely determined by the unit.
The `str` does show it, and instead abbreviates the array.

This will help a lot with nicer formatting in `coordinax` and `galax`.

Note that Equinox already has W-L as a dependency, so this isn't really adding any new dependencies.