### PR TITLE
🐛 fix(quantity): printing with short_array no longer appends the kind

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,7 @@ repos:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
+        exclude: "^docs/.*\\.md$"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -265,6 +265,14 @@ Quantity(Array([ 5, 14, 27], dtype=int32), unit='m2')
 [`quax.quaxify`](https://docs.kidger.site/quax/api/quax/#quax.quaxify) manually,
 to only decorate your top-level functions or to call 3rd party functions.
 
+:::{attention}
+
+`Quantity` should support **all** JAX functions. If you find a function that
+doesn't work, please open an issue on the
+[GitHub repository](https:://github.com/GalacticDynamics/unxt).
+
+:::
+
 ## Pretty Printing
 
 `Quantity` objects support the
@@ -306,13 +314,7 @@ Quantity(i32[3], 'm')
 See the [wadler_lindig documentation](https://docs.kidger.site/wadler_lindig)
 for more details on the pretty printing options.
 
-:::{attention}
-
-`Quantity` should support **all** JAX functions. If you find a function that
-doesn't work, please open an issue on the
-[GitHub repository](https:://github.com/GalacticDynamics/unxt).
-
-:::
+---
 
 :::{seealso}
 

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -265,6 +265,47 @@ Quantity(Array([ 5, 14, 27], dtype=int32), unit='m2')
 [`quax.quaxify`](https://docs.kidger.site/quax/api/quax/#quax.quaxify) manually,
 to only decorate your top-level functions or to call 3rd party functions.
 
+## Pretty Printing
+
+`Quantity` objects support the
+[`wadler_lindig`](https://docs.kidger.site/wadler_lindig) library for pretty
+printing.
+
+```{code-block} python
+
+>>> import wadler_lindig as wl
+
+>>> q = u.Quantity([1, 2, 3], "m")
+
+>>> wl.pprint(q)  # The default pretty printing
+Quantity(i32[3], unit='m')
+
+# The type parameter can be included in the representation:
+>>> wl.pprint(q, include_params=True)
+Quantity[length](i32[3], unit='m')
+
+# The `str` method uses this as well:
+>>> print(q)
+Quantity[length](i32[3], unit='m')
+
+# Arrays can be printed in full:
+>>> wl.pprint(q, short_arrays=False)
+Quantity(Array([1, 2, 3], dtype=int32), unit='m')
+
+# The `repr` method uses this setting:
+>>> print(repr(q))
+Quantity(Array([1, 2, 3], dtype=int32), unit='m')
+
+# The units can be turned from a named argument to
+# a positional argument by setting `named_unit=False`:
+>>> wl.pprint(q, named_unit=False)
+Quantity(i32[3], 'm')
+
+```
+
+See the [wadler_lindig documentation](https://docs.kidger.site/wadler_lindig)
+for more details on the pretty printing options.
+
 :::{attention}
 
 `Quantity` should support **all** JAX functions. If you find a function that

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -288,24 +288,49 @@ printing.
 >>> wl.pprint(q)  # The default pretty printing
 Quantity(i32[3], unit='m')
 
-# The type parameter can be included in the representation:
+```
+
+The type parameter can be included in the representation:
+
+```{code-block} python
+
 >>> wl.pprint(q, include_params=True)
 Quantity[length](i32[3], unit='m')
 
-# The `str` method uses this as well:
+```
+
+The `str` method uses this as well:
+
+```{code-block} python
+
 >>> print(q)
 Quantity[length](i32[3], unit='m')
 
-# Arrays can be printed in full:
+```
+
+Arrays can be printed in full:
+
+```{code-block} python
+
 >>> wl.pprint(q, short_arrays=False)
 Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
-# The `repr` method uses this setting:
+```
+
+The `repr` method uses this setting:
+
+```{code-block} python
+
 >>> print(repr(q))
 Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
-# The units can be turned from a named argument to
-# a positional argument by setting `named_unit=False`:
+```
+
+The units can be turned from a named argument to a positional argument by
+setting `named_unit=False`:
+
+```{code-block} python
+
 >>> wl.pprint(q, named_unit=False)
 Quantity(i32[3], 'm')
 

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -311,7 +311,7 @@ Quantity(i32[3], 'm')
 
 ```
 
-See the [wadler_lindig documentation](https://docs.kidger.site/wadler_lindig)
+See the [`wadler_lindig` documentation](https://docs.kidger.site/wadler_lindig)
 for more details on the pretty printing options.
 
 ---

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -76,7 +76,8 @@ units. If you prefer an object-oriented approach, use the `uconvert` method.
 Quantity(Array(500., dtype=float32, ...), unit='cm')
 ```
 
-:::{note} :class: dropdown
+:::{note}
+:class: dropdown
 
 The Astropy API `.to` is also available for `Quantity` objects.
 
@@ -118,7 +119,8 @@ without units to be passed in, assuming them to be in the correct output units.
 500
 ```
 
-:::{note} :class: dropdown
+:::{note}
+:class: dropdown
 
 The Astropy API `.to_value` is also available for `Quantity` objects.
 

--- a/src/unxt/_src/quantity/base_parametric.py
+++ b/src/unxt/_src/quantity/base_parametric.py
@@ -178,7 +178,65 @@ class AbstractParametricQuantity(AbstractQuantity):
     def __pdoc__(
         self, *, include_params: bool = False, named_unit: bool = True, **kwargs: Any
     ) -> wl.AbstractDoc:
-        """Return the Wadler-Lindig representation of this class."""
+        """Return the Wadler-Lindig representation of this class.
+
+        This is used for the `__repr__` and `__str__` methods or when using the
+        `wadler_lindig` library.
+
+        Parameters
+        ----------
+        include_params
+            If `True`, the type parameter is included in the representation. If
+            `False`, the type parameter is not included in the representation.
+            For example, ``Quantity['length'][i32]`` versus ``Quantity[i32]``.
+        named_unit
+            If `True`, the unit is included in the representation as a named
+            argument. If `False`, the unit is included as a positional argument.
+            For example, ``Quantity(<array>, unit='m')`` versus
+            ``Quantity(<array>, 'm')``.
+        kwargs
+            Additional keyword arguments ``wadler_lindig.pdoc`` method for
+            formatting the value, stringified unit, and other fields.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> import wadler_lindig as wl
+
+        >>> q = u.Quantity([1, 2, 3], "m")
+
+        The default pretty printing:
+
+        >>> wl.pprint(q)
+        Quantity(i32[3], unit='m')
+
+        The type parameter can be included in the representation:
+
+        >>> wl.pprint(q, include_params=True)
+        Quantity[length](i32[3], unit='m')
+
+        The `str` method uses this as well:
+
+        >>> print(q)
+        Quantity[length](i32[3], unit='m')
+
+        Arrays can be printed in full:
+
+        >>> wl.pprint(q, short_arrays=False)
+        Quantity(Array([1, 2, 3], dtype=int32), unit='m')
+
+        The `repr` method uses this setting:
+
+        >>> print(repr(q))
+        Quantity(Array([1, 2, 3], dtype=int32), unit='m')
+
+        The units can be turned from a named argument to a positional argument
+        by setting `named_unit=False`:
+
+        >>> wl.pprint(q, named_unit=False)
+        Quantity(i32[3], 'm')
+
+        """
         pdoc = super().__pdoc__(
             include_params=include_params, named_unit=named_unit, **kwargs
         )

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -102,7 +102,7 @@ class Quantity(AbstractParametricQuantity):
     the physical type is unknown:
 
     >>> print(u.Quantity["m2 kg-1 s-2"](1.0, unit))  # to show the [dim]
-    Quantity[m2 kg-1 s-2](f32[](jax), unit='m2 / (kg s2)')
+    Quantity[m2 kg-1 s-2](weak_f32[], unit='m2 / (kg s2)')
 
     """
 


### PR DESCRIPTION
All arrays are jax arrays, so the kind is not necessary.
Resolved using answer in https://github.com/patrick-kidger/wadler_lindig/issues/7