### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-24.04
     needs: [format]
+    permissions:
+      contents: read
+      packages: read
     if:
       github.event_name == 'workflow_dispatch' || (github.event_name ==
       'pull_request' && contains(github.event.pull_request.labels.*.name,


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/unxt/security/code-scanning/6](https://github.com/GalacticDynamics/unxt/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `Run Benchmarks` job. This block will specify the minimal permissions required for the job to function correctly. Based on the job's steps, the following permissions are needed:
- `contents: read`: To allow the job to read the repository's contents.
- `packages: read`: To allow the job to access any packages required during the installation process.

We will add this `permissions` block under the `Run Benchmarks` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
