### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/unxt/security/code-scanning/2](https://github.com/GalacticDynamics/unxt/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `dist` job in the workflow file `.github/workflows/cd.yml`. The permissions should be set to `contents: read`, as this is the minimal privilege required for the job to perform its tasks. This change ensures that the job does not have unnecessary write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
