### PR TITLE
🥅 catch: trim whitespace from dimension names in regex match

### DIFF
--- a/src/unxt/_src/dimensions.py
+++ b/src/unxt/_src/dimensions.py
@@ -54,7 +54,9 @@ def _preprocess_dimension_string(expr: str, /) -> tuple[str, dict[str, str]]:
 
     def replace_paren_dim(match: re.Match[str], /) -> str:
         nonlocal counter
-        dim_name = match.group(1)
+        # Strip whitespace from the captured dimension name to handle cases like
+        # "( amount of substance )" where users might include extra spaces
+        dim_name = match.group(1).strip()
         temp_id = f"_dim{counter}"
         dim_mapping[temp_id] = dim_name
         counter += 1

--- a/tests/unit/test_dims.py
+++ b/tests/unit/test_dims.py
@@ -156,3 +156,35 @@ class TestDimensionOperatorDetection:
         dim = u.dimension("length**2")
         expected = u.dimension("length") ** 2
         assert dim == expected
+
+    @given(dim_name=st.sampled_from(ust.DIMENSION_NAMES))
+    def test_parenthesized_with_whitespace(self, dim_name):
+        """Test that whitespace in parentheses is stripped correctly.
+
+        Hypothesis generates dimension names and tests that wrapping them in
+        parentheses with varying whitespace doesn't change the result.
+        """
+        # Without spaces
+        dim_no_space = u.dimension(f"({dim_name})")
+        # With spaces
+        dim_with_space = u.dimension(f"( {dim_name} )")
+        # With multiple spaces
+        dim_multi_space = u.dimension(f"(  {dim_name}  )")
+
+        expected = u.dimension(dim_name)
+        assert dim_no_space == expected
+        assert dim_with_space == expected
+        assert dim_multi_space == expected
+
+    @given(
+        dim_name1=st.sampled_from(ust.DIMENSION_NAMES),
+        dim_name2=st.sampled_from(ust.DIMENSION_NAMES),
+    )
+    def test_division_expression_with_whitespace(self, dim_name1, dim_name2):
+        """Test division expressions with whitespace in parentheses."""
+        dim_no_space = u.dimension(f"({dim_name1}) / ({dim_name2})")
+        dim_with_space = u.dimension(f"( {dim_name1} ) / ( {dim_name2} )")
+
+        expected = u.dimension(dim_name1) / u.dimension(dim_name2)
+        assert dim_no_space == expected
+        assert dim_with_space == expected


### PR DESCRIPTION
Strip whitespace from captured dimension names to handle extra spaces.