### PR TITLE
Potential fix for code scanning alert no. 19: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -39,12 +39,10 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
-          # For manual runs, honor the selected ref. For push events, use the
-          # immutable triggering commit to keep builds and emitted metadata reproducible.
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.sha }}
+          ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -39,6 +39,9 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
+          # This workflow only runs on trusted `push` and `workflow_dispatch` events.
+          # `github.ref` is therefore constrained to repository refs (main/tag or a
+          # manually selected ref) and does not accept untrusted PR fork heads.
           ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -39,7 +39,9 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.ref }}
+          # For manual runs, honor the selected ref. For push events, use the
+          # immutable triggering commit to keep builds and emitted metadata reproducible.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.sha }}
 
       - name: Validate git tag (for tagged releases)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -12,11 +12,6 @@ on:
       - "pyproject.toml"
       - "README.md"
       - ".github/workflows/cd-unxt.yml"
-  workflow_run:
-    workflows:
-      - "Create Package Tags"
-    types:
-      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,11 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Build runs for direct tag pushes or via workflow_run from Create Package Tags
-    # (which handles coordinator tag releases)
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
 
@@ -46,32 +39,14 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
-          # For workflow_run events, checkout the exact commit from upstream workflow
-          ref: |
-            ${{ github.event_name == 'workflow_run' &&
-            github.event.workflow_run.head_sha || github.ref }}
-
-      # For workflow_run events, find and export the package-specific tag
-      - name: Find package tag (workflow_run)
-        if: github.event_name == 'workflow_run'
-        uses: ./.github/actions/find-package-tag
-        with:
-          tag_glob: unxt-v*
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: |
-          startsWith(github.ref, 'refs/tags/') || github.event_name ==
-          'workflow_run'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
-          EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="$PACKAGE_TAG"
-          else
-            TAG="${GITHUB_REF_VAR#refs/tags/}"
-          fi
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
           python scripts/validate_tag.py "$TAG" "unxt"
         shell: bash
 
@@ -81,16 +56,12 @@ jobs:
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
 
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="${PACKAGE_TAG:-}"
-            TRIGGER_EVENT="push"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
-            TRIGGER_EVENT="push"
           else
             TAG=""
-            TRIGGER_EVENT="${EVENT_NAME}"
           fi
+          TRIGGER_EVENT="${EVENT_NAME}"
 
           jq -n \
             --arg package "unxt" \

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -121,9 +121,7 @@ jobs:
           if [ ${#TAGS_TO_PUSH[@]} -eq 0 ]; then
             echo "✅ All package tags already exist for version ${VERSION}"
             echo "   This is expected for workflow re-runs"
-            echo "   Re-dispatching CD for existing tag unxt-v${VERSION}"
-            echo "trigger_unxt_cd=true" >> "$GITHUB_OUTPUT"
-            echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "trigger_unxt_cd=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -136,10 +136,7 @@ jobs:
           echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
-        if:
-          steps.create_tags.outputs.trigger_unxt_cd == 'true' ||
-          (steps.create_tags.outputs.unxt_tag != '' &&
-          steps.create_tags.outputs.trigger_unxt_cd == 'false')
+        if: steps.create_tags.outputs.trigger_unxt_cd == 'true' || (steps.create_tags.outputs.unxt_tag != '' && steps.create_tags.outputs.trigger_unxt_cd == 'false')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -160,10 +160,15 @@ jobs:
               );
 
               const hasMatchingRun = existingRuns.some(
-                (run) =>
-                  run.head_branch === tagRef &&
-                  run.head_sha === tagSha &&
-                  (run.status !== "completed" || run.conclusion === "success"),
+                (run) => {
+                  const isMatchingTagSha =
+                    run.head_branch === tagRef && run.head_sha === tagSha;
+                  const isBlockingRun =
+                    run.status !== "completed" ||
+                    (run.status === "completed" && run.conclusion === "success");
+
+                  return isMatchingTagSha && isBlockingRun;
+                },
               );
 
               if (hasMatchingRun) {

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -136,7 +136,7 @@ jobs:
           echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
-        if: steps.create_tags.outputs.unxt_tag != ''
+        if: steps.create_tags.outputs.trigger_unxt_cd == 'true' || (steps.create_tags.outputs.unxt_tag != '' && steps.create_tags.outputs.trigger_unxt_cd == 'false')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -151,6 +151,8 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   workflow_id: "cd-unxt.yml",
+                  branch: tagRef,
+                  status: "completed",
                   per_page: 100,
                 },
               );

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -122,6 +122,8 @@ jobs:
             echo "✅ All package tags already exist for version ${VERSION}"
             echo "   This is expected for workflow re-runs"
             echo "trigger_unxt_cd=false" >> "$GITHUB_OUTPUT"
+            echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -131,13 +133,47 @@ jobs:
           echo "✅ Successfully created and pushed package-specific tags for version ${VERSION}"
           echo "trigger_unxt_cd=${UNXT_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
-        if: steps.create_tags.outputs.trigger_unxt_cd == 'true'
+        if: steps.create_tags.outputs.unxt_tag != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const tagRef = "${{ steps.create_tags.outputs.unxt_tag }}";
+            const tagSha = "${{ steps.create_tags.outputs.unxt_tag_sha }}";
+            const shouldDispatch = "${{ steps.create_tags.outputs.trigger_unxt_cd }}" === "true";
+
+            if (!shouldDispatch) {
+              const existingRuns = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "cd-unxt.yml",
+                  per_page: 100,
+                },
+              );
+
+              const alreadySucceeded = existingRuns.some(
+                (run) =>
+                  run.conclusion === "success" &&
+                  run.head_branch === tagRef &&
+                  run.head_sha === tagSha,
+              );
+
+              if (alreadySucceeded) {
+                core.info(
+                  `Skipping CD dispatch for ${tagRef}: a successful CD - unxt run already exists for ${tagSha}.`,
+                );
+                return;
+              }
+
+              core.info(
+                `No successful CD - unxt run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
+              );
+            }
+
             try {
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -136,7 +136,10 @@ jobs:
           echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
-        if: steps.create_tags.outputs.trigger_unxt_cd == 'true' || (steps.create_tags.outputs.unxt_tag != '' && steps.create_tags.outputs.trigger_unxt_cd == 'false')
+        if: |
+          steps.create_tags.outputs.trigger_unxt_cd == 'true' ||
+          (steps.create_tags.outputs.unxt_tag != '' &&
+          steps.create_tags.outputs.trigger_unxt_cd == 'false')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -137,9 +137,17 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "cd-unxt.yml",
-              ref: "${{ steps.create_tags.outputs.unxt_tag }}",
-            });
+            const tagRef = "${{ steps.create_tags.outputs.unxt_tag }}";
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "cd-unxt.yml",
+                ref: tagRef,
+              });
+              core.info(`Triggered CD - unxt for tag ${tagRef}`);
+            } catch (error) {
+              core.setFailed(
+                `Failed to trigger CD - unxt for tag ${tagRef}: ${error.message}`
+              );
+            }

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -121,7 +121,9 @@ jobs:
           if [ ${#TAGS_TO_PUSH[@]} -eq 0 ]; then
             echo "✅ All package tags already exist for version ${VERSION}"
             echo "   This is expected for workflow re-runs"
-            echo "trigger_unxt_cd=false" >> "$GITHUB_OUTPUT"
+            echo "   Re-dispatching CD for existing tag unxt-v${VERSION}"
+            echo "trigger_unxt_cd=true" >> "$GITHUB_OUTPUT"
+            echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -136,7 +136,10 @@ jobs:
           echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
-        if: steps.create_tags.outputs.trigger_unxt_cd == 'true' || (steps.create_tags.outputs.unxt_tag != '' && steps.create_tags.outputs.trigger_unxt_cd == 'false')
+        if:
+          steps.create_tags.outputs.trigger_unxt_cd == 'true' ||
+          (steps.create_tags.outputs.unxt_tag != '' &&
+          steps.create_tags.outputs.trigger_unxt_cd == 'false')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -155,27 +155,26 @@ jobs:
                   repo: context.repo.repo,
                   workflow_id: "cd-unxt.yml",
                   branch: tagRef,
-                  status: "completed",
                   per_page: 100,
                 },
               );
 
-              const alreadySucceeded = existingRuns.some(
+              const hasMatchingRun = existingRuns.some(
                 (run) =>
-                  run.conclusion === "success" &&
                   run.head_branch === tagRef &&
-                  run.head_sha === tagSha,
+                  run.head_sha === tagSha &&
+                  (run.status !== "completed" || run.conclusion === "success"),
               );
 
-              if (alreadySucceeded) {
+              if (hasMatchingRun) {
                 core.info(
-                  `Skipping CD dispatch for ${tagRef}: a successful CD - unxt run already exists for ${tagSha}.`,
+                  `Skipping CD dispatch for ${tagRef}: a queued/in-progress/successful CD - unxt run already exists for ${tagSha}.`,
                 );
                 return;
               }
 
               core.info(
-                `No successful CD - unxt run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
+                `No queued/in-progress/successful CD - unxt run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
               );
             }
 

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -21,6 +21,7 @@ jobs:
     name: Create package-specific tags
     runs-on: ubuntu-latest
     permissions:
+      actions: write # Needed to dispatch package CD workflows for bot-created tags
       contents: write # Needed to create and push tags
 
     steps:
@@ -60,9 +61,11 @@ jobs:
           echo "✅ Valid coordinator tag: $TAG"
 
       - name: Create and push package-specific tags
+        id: create_tags
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.version.outputs.tag }}"
+          UNXT_TAG_CREATED="false"
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -108,6 +111,9 @@ jobs:
               echo "📝 Creating tag $PACKAGE_TAG"
               git tag "$PACKAGE_TAG" "$COORDINATOR_SHA" -m "Release $PACKAGE ${VERSION} (auto-created from ${TAG})"
               TAGS_TO_PUSH+=("$PACKAGE_TAG")
+              if [ "$PACKAGE" = "unxt" ]; then
+                UNXT_TAG_CREATED="true"
+              fi
             fi
           done
 
@@ -115,6 +121,7 @@ jobs:
           if [ ${#TAGS_TO_PUSH[@]} -eq 0 ]; then
             echo "✅ All package tags already exist for version ${VERSION}"
             echo "   This is expected for workflow re-runs"
+            echo "trigger_unxt_cd=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -122,3 +129,17 @@ jobs:
           git push origin "${TAGS_TO_PUSH[@]}"
 
           echo "✅ Successfully created and pushed package-specific tags for version ${VERSION}"
+          echo "trigger_unxt_cd=${UNXT_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger CD - unxt for auto-created unxt tag
+        if: steps.create_tags.outputs.trigger_unxt_cd == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "cd-unxt.yml",
+              ref: "${{ steps.create_tags.outputs.unxt_tag }}",
+            });


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/unxt/security/code-scanning/19](https://github.com/GalacticDynamics/unxt/security/code-scanning/19)

General fix: avoid running build/validation steps that execute repository code under `workflow_run` when they can reference code from another workflow’s SHA. Keep privileged/default-branch workflows isolated from untrusted execution paths.

Best fix here (minimal functional impact): remove `workflow_run` as a trigger and remove all `workflow_run`-specific logic in this workflow:
- In `.github/workflows/cd-unxt.yml`:
  - Delete the `on.workflow_run` block.
  - Simplify job `if:` to only allow `workflow_dispatch` and `push` (main or tags).
  - Make checkout `ref` unconditional to `${{ github.ref }}`.
  - Remove the `Find package tag (workflow_run)` step.
  - Simplify tag validation step condition to only tagged pushes.
  - Remove `workflow_run` branching in “Emit release metadata”; derive tag only from `GITHUB_REF` tags and set `TRIGGER_EVENT` from `EVENT_NAME`.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
