### PR TITLE
Fix for Non-standard exception raised in special method

### DIFF
--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -153,7 +153,7 @@ class AbstractUnitSystem:
         # IDK if it's possible to get here
         else:
             msg = f"Physical type {key!r} doesn't exist in unit registry."  # pragma: no cover  # noqa: E501
-            raise ValueError(msg)  # pragma: no cover
+            raise KeyError(msg)  # pragma: no cover
 
         out = out.decompose(self.base_units)
         out._scale = 1.0  # noqa: SLF001


### PR DESCRIPTION
The fix is to raise `KeyError` (or another `LookupError` subtype) instead of `ValueError` in `__getitem__` when the key cannot be resolved.  
Best minimal fix: change only the exception type at the error site in `src/unxt/_src/unitsystems/base.py` (around lines 154–156), preserving message and behavior otherwise. No functionality changes besides using the correct protocol exception for failed key lookup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._