### PR TITLE
Potential fix for code scanning alert no. 15: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/actions/dispatch-package-cd/action.yml
+++ b/.github/actions/dispatch-package-cd/action.yml
@@ -8,7 +8,8 @@ inputs:
     description: The workflow file name to dispatch (e.g., cd-unxt.yml).
     required: true
   workflow_name:
-    description: Human-readable workflow name for log messages (e.g., CD - unxt).
+    description:
+      Human-readable workflow name for log messages (e.g., CD - unxt).
     required: true
   tag_ref:
     description: The tag ref to dispatch the workflow on (e.g., unxt-v1.2.0).
@@ -19,8 +20,8 @@ inputs:
   trigger_cd:
     description: >
       Whether a new tag was just created ('true') or all tags pre-existed
-      ('false', i.e. a re-run). When 'false', an idempotency check is
-      performed before dispatching.
+      ('false', i.e. a re-run). When 'false', an idempotency check is performed
+      before dispatching.
     required: true
 
 runs:

--- a/.github/actions/dispatch-package-cd/action.yml
+++ b/.github/actions/dispatch-package-cd/action.yml
@@ -1,0 +1,86 @@
+name: Dispatch package CD workflow
+description: >
+  Dispatch a package CD workflow for a tag, with an idempotency check so that
+  re-running the coordinator workflow does not trigger duplicate CD runs.
+
+inputs:
+  workflow_id:
+    description: The workflow file name to dispatch (e.g., cd-unxt.yml).
+    required: true
+  workflow_name:
+    description: Human-readable workflow name for log messages (e.g., CD - unxt).
+    required: true
+  tag_ref:
+    description: The tag ref to dispatch the workflow on (e.g., unxt-v1.2.0).
+    required: true
+  tag_sha:
+    description: The commit SHA the tag points to.
+    required: true
+  trigger_cd:
+    description: >
+      Whether a new tag was just created ('true') or all tags pre-existed
+      ('false', i.e. a re-run). When 'false', an idempotency check is
+      performed before dispatching.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          const workflowId = "${{ inputs.workflow_id }}";
+          const workflowName = "${{ inputs.workflow_name }}";
+          const tagRef = "${{ inputs.tag_ref }}";
+          const tagSha = "${{ inputs.tag_sha }}";
+          const shouldDispatch = "${{ inputs.trigger_cd }}" === "true";
+
+          if (!shouldDispatch) {
+            const existingRuns = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflowId,
+                branch: tagRef,
+                per_page: 100,
+              },
+            );
+
+            const hasMatchingRun = existingRuns.some(
+              (run) => {
+                const isMatchingTagSha =
+                  run.head_branch === tagRef && run.head_sha === tagSha;
+                const isBlockingRun =
+                  run.status !== "completed" ||
+                  (run.status === "completed" && run.conclusion === "success");
+
+                return isMatchingTagSha && isBlockingRun;
+              },
+            );
+
+            if (hasMatchingRun) {
+              core.info(
+                `Skipping CD dispatch for ${tagRef}: a queued/in-progress/successful ${workflowName} run already exists for ${tagSha}.`,
+              );
+              return;
+            }
+
+            core.info(
+              `No queued/in-progress/successful ${workflowName} run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
+            );
+          }
+
+          try {
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              ref: tagRef,
+            });
+            core.info(`Triggered ${workflowName} for tag ${tagRef}`);
+          } catch (error) {
+            core.setFailed(
+              `Failed to trigger ${workflowName} for tag ${tagRef}: ${error.message}`
+            );
+          }

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -43,7 +43,9 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
         env:
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |
@@ -52,6 +54,8 @@ jobs:
         shell: bash
 
       - name: Emit release metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
 
@@ -60,12 +64,13 @@ jobs:
           else
             TAG=""
           fi
+          TRIGGER_EVENT="${EVENT_NAME}"
 
           jq -n \
             --arg package "unxt-api" \
             --arg package_tag "${TAG}" \
             --arg head_sha "${HEAD_SHA}" \
-            --arg trigger_event "${GITHUB_EVENT_NAME}" \
+            --arg trigger_event "${TRIGGER_EVENT}" \
             '{"package": $package, "package_tag": $package_tag, "head_sha": $head_sha, "trigger_event": $trigger_event}' \
             > release-metadata.json
 

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -10,11 +10,6 @@ on:
     paths:
       - "packages/unxt-api/**"
       - ".github/workflows/cd-unxt-api.yml"
-  workflow_run:
-    workflows:
-      - "Create Package Tags"
-    types:
-      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +28,6 @@ jobs:
     # (which handles coordinator tag releases)
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
 
@@ -44,32 +38,16 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
-          # For workflow_run events, checkout the exact commit from upstream workflow
-          ref: |
-            ${{ github.event_name == 'workflow_run' &&
-            github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.ref }}
 
-      # For workflow_run events, find and export the package-specific tag
-      - name: Find package tag (workflow_run)
-        if: github.event_name == 'workflow_run'
-        uses: ./.github/actions/find-package-tag
-        with:
-          tag_glob: unxt-api-v*
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+
 
       - name: Validate git tag (for tagged releases)
-        if: |
-          startsWith(github.ref, 'refs/tags/') || github.event_name ==
-          'workflow_run'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
-          EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="$PACKAGE_TAG"
-          else
-            TAG="${GITHUB_REF_VAR#refs/tags/}"
-          fi
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
           python scripts/validate_tag.py "$TAG" "unxt-api"
         shell: bash
 
@@ -79,10 +57,7 @@ jobs:
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
 
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="${PACKAGE_TAG:-}"
-            TRIGGER_EVENT="push"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             TRIGGER_EVENT="push"
           else

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -2,6 +2,11 @@ name: CD - unxt-api
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Create Package Tags"
+    types:
+      - completed
   push:
     branches:
       - main
@@ -24,9 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Build runs for manual dispatch, main pushes, and direct package tag pushes
+    # Build runs for manual dispatch, successful package-tag workflow completions,
+    # main pushes, and direct package tag pushes.
     if: |
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
 

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -24,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Build runs for direct tag pushes or via workflow_run from Create Package Tags
-    # (which handles coordinator tag releases)
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -38,12 +37,13 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
+          # This workflow only runs on trusted `push` and `workflow_dispatch` events.
+          # `github.ref` is therefore constrained to repository refs (main/tag or a
+          # manually selected ref) and does not accept untrusted PR fork heads.
           ref: ${{ github.ref }}
 
-
-
       - name: Validate git tag (for tagged releases)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |
@@ -59,11 +59,10 @@ jobs:
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
-            TRIGGER_EVENT="push"
           else
             TAG=""
-            TRIGGER_EVENT="${EVENT_NAME}"
           fi
+          TRIGGER_EVENT="${EVENT_NAME}"
 
           jq -n \
             --arg package "unxt-api" \

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -54,20 +54,18 @@ jobs:
       - name: Emit release metadata
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
-          EVENT_NAME="${GITHUB_EVENT_NAME}"
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           else
             TAG=""
           fi
-          TRIGGER_EVENT="${EVENT_NAME}"
 
           jq -n \
             --arg package "unxt-api" \
             --arg package_tag "${TAG}" \
             --arg head_sha "${HEAD_SHA}" \
-            --arg trigger_event "${TRIGGER_EVENT}" \
+            --arg trigger_event "${GITHUB_EVENT_NAME}" \
             '{"package": $package, "package_tag": $package_tag, "head_sha": $head_sha, "trigger_event": $trigger_event}' \
             > release-metadata.json
 

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -52,10 +52,9 @@ jobs:
         shell: bash
 
       - name: Emit release metadata
-        env:
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
+          EVENT_NAME="${GITHUB_EVENT_NAME}"
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -2,11 +2,6 @@ name: CD - unxt-api
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - "Create Package Tags"
-    types:
-      - completed
   push:
     branches:
       - main
@@ -29,11 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Build runs for manual dispatch, successful package-tag workflow completions,
-    # main pushes, and direct package tag pushes.
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
 

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -151,121 +151,23 @@ jobs:
           steps.create_tags.outputs.trigger_unxt_cd == 'true' ||
           (steps.create_tags.outputs.unxt_tag != '' &&
           steps.create_tags.outputs.trigger_unxt_cd == 'false')
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/dispatch-package-cd
         with:
-          script: |
-            const tagRef = "${{ steps.create_tags.outputs.unxt_tag }}";
-            const tagSha = "${{ steps.create_tags.outputs.unxt_tag_sha }}";
-            const shouldDispatch = "${{ steps.create_tags.outputs.trigger_unxt_cd }}" === "true";
-
-            if (!shouldDispatch) {
-              const existingRuns = await github.paginate(
-                github.rest.actions.listWorkflowRuns,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: "cd-unxt.yml",
-                  branch: tagRef,
-                  per_page: 100,
-                },
-              );
-
-              const hasMatchingRun = existingRuns.some(
-                (run) => {
-                  const isMatchingTagSha =
-                    run.head_branch === tagRef && run.head_sha === tagSha;
-                  const isBlockingRun =
-                    run.status !== "completed" ||
-                    (run.status === "completed" && run.conclusion === "success");
-
-                  return isMatchingTagSha && isBlockingRun;
-                },
-              );
-
-              if (hasMatchingRun) {
-                core.info(
-                  `Skipping CD dispatch for ${tagRef}: a queued/in-progress/successful CD - unxt run already exists for ${tagSha}.`,
-                );
-                return;
-              }
-
-              core.info(
-                `No queued/in-progress/successful CD - unxt run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
-              );
-            }
-
-            try {
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "cd-unxt.yml",
-                ref: tagRef,
-              });
-              core.info(`Triggered CD - unxt for tag ${tagRef}`);
-            } catch (error) {
-              core.setFailed(
-                `Failed to trigger CD - unxt for tag ${tagRef}: ${error.message}`
-              );
-            }
+          workflow_id: cd-unxt.yml
+          workflow_name: CD - unxt
+          tag_ref: ${{ steps.create_tags.outputs.unxt_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.unxt_tag_sha }}
+          trigger_cd: ${{ steps.create_tags.outputs.trigger_unxt_cd }}
 
       - name: Trigger CD - unxt-api for auto-created unxt-api tag
         if: |
           steps.create_tags.outputs.trigger_unxt_api_cd == 'true' ||
           (steps.create_tags.outputs.unxt_api_tag != '' &&
           steps.create_tags.outputs.trigger_unxt_api_cd == 'false')
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/dispatch-package-cd
         with:
-          script: |
-            const tagRef = "${{ steps.create_tags.outputs.unxt_api_tag }}";
-            const tagSha = "${{ steps.create_tags.outputs.unxt_api_tag_sha }}";
-            const shouldDispatch = "${{ steps.create_tags.outputs.trigger_unxt_api_cd }}" === "true";
-
-            if (!shouldDispatch) {
-              const existingRuns = await github.paginate(
-                github.rest.actions.listWorkflowRuns,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: "cd-unxt-api.yml",
-                  branch: tagRef,
-                  per_page: 100,
-                },
-              );
-
-              const hasMatchingRun = existingRuns.some(
-                (run) => {
-                  const isMatchingTagSha =
-                    run.head_branch === tagRef && run.head_sha === tagSha;
-                  const isBlockingRun =
-                    run.status !== "completed" ||
-                    (run.status === "completed" && run.conclusion === "success");
-
-                  return isMatchingTagSha && isBlockingRun;
-                },
-              );
-
-              if (hasMatchingRun) {
-                core.info(
-                  `Skipping CD dispatch for ${tagRef}: a queued/in-progress/successful CD - unxt-api run already exists for ${tagSha}.`,
-                );
-                return;
-              }
-
-              core.info(
-                `No queued/in-progress/successful CD - unxt-api run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
-              );
-            }
-
-            try {
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "cd-unxt-api.yml",
-                ref: tagRef,
-              });
-              core.info(`Triggered CD - unxt-api for tag ${tagRef}`);
-            } catch (error) {
-              core.setFailed(
-                `Failed to trigger CD - unxt-api for tag ${tagRef}: ${error.message}`
-              );
-            }
+          workflow_id: cd-unxt-api.yml
+          workflow_name: CD - unxt-api
+          tag_ref: ${{ steps.create_tags.outputs.unxt_api_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.unxt_api_tag_sha }}
+          trigger_cd: ${{ steps.create_tags.outputs.trigger_unxt_api_cd }}

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -82,6 +82,8 @@ jobs:
           PACKAGES=("unxt" "unxt-api" "unxt-hypothesis")
           TAGS_TO_PUSH=()
 
+          UNXT_API_TAG_CREATED="false"
+
           # Check and create each package tag
           for PACKAGE in "${PACKAGES[@]}"; do
             PACKAGE_TAG="${PACKAGE}-v${VERSION}"
@@ -114,6 +116,9 @@ jobs:
               if [ "$PACKAGE" = "unxt" ]; then
                 UNXT_TAG_CREATED="true"
               fi
+              if [ "$PACKAGE" = "unxt-api" ]; then
+                UNXT_API_TAG_CREATED="true"
+              fi
             fi
           done
 
@@ -124,6 +129,9 @@ jobs:
             echo "trigger_unxt_cd=false" >> "$GITHUB_OUTPUT"
             echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
             echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "trigger_unxt_api_cd=false" >> "$GITHUB_OUTPUT"
+            echo "unxt_api_tag=unxt-api-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "unxt_api_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -134,6 +142,9 @@ jobs:
           echo "trigger_unxt_cd=${UNXT_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "unxt_tag=unxt-v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "unxt_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "trigger_unxt_api_cd=${UNXT_API_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "unxt_api_tag=unxt-api-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "unxt_api_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
         if: |
@@ -194,5 +205,67 @@ jobs:
             } catch (error) {
               core.setFailed(
                 `Failed to trigger CD - unxt for tag ${tagRef}: ${error.message}`
+              );
+            }
+
+      - name: Trigger CD - unxt-api for auto-created unxt-api tag
+        if: |
+          steps.create_tags.outputs.trigger_unxt_api_cd == 'true' ||
+          (steps.create_tags.outputs.unxt_api_tag != '' &&
+          steps.create_tags.outputs.trigger_unxt_api_cd == 'false')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const tagRef = "${{ steps.create_tags.outputs.unxt_api_tag }}";
+            const tagSha = "${{ steps.create_tags.outputs.unxt_api_tag_sha }}";
+            const shouldDispatch = "${{ steps.create_tags.outputs.trigger_unxt_api_cd }}" === "true";
+
+            if (!shouldDispatch) {
+              const existingRuns = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "cd-unxt-api.yml",
+                  branch: tagRef,
+                  per_page: 100,
+                },
+              );
+
+              const hasMatchingRun = existingRuns.some(
+                (run) => {
+                  const isMatchingTagSha =
+                    run.head_branch === tagRef && run.head_sha === tagSha;
+                  const isBlockingRun =
+                    run.status !== "completed" ||
+                    (run.status === "completed" && run.conclusion === "success");
+
+                  return isMatchingTagSha && isBlockingRun;
+                },
+              );
+
+              if (hasMatchingRun) {
+                core.info(
+                  `Skipping CD dispatch for ${tagRef}: a queued/in-progress/successful CD - unxt-api run already exists for ${tagSha}.`,
+                );
+                return;
+              }
+
+              core.info(
+                `No queued/in-progress/successful CD - unxt-api run found for ${tagRef} at ${tagSha}; dispatching recovery run.`,
+              );
+            }
+
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "cd-unxt-api.yml",
+                ref: tagRef,
+              });
+              core.info(`Triggered CD - unxt-api for tag ${tagRef}`);
+            } catch (error) {
+              core.setFailed(
+                `Failed to trigger CD - unxt-api for tag ${tagRef}: ${error.message}`
               );
             }


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/unxt/security/code-scanning/15](https://github.com/GalacticDynamics/unxt/security/code-scanning/15)

General fix: remove untrusted/indirect triggers (`workflow_run`) from privileged workflows, and remove branches of logic that consume `github.event.workflow_run.*` data. Keep execution only on trusted events (`push` to `main` / tags, and optionally `workflow_dispatch`).

Best fix in this file without changing intended release behavior:  
- In `.github/workflows/cd-unxt-api.yml`, remove the `on.workflow_run` trigger block.  
- Simplify the job-level `if:` to exclude the `workflow_run` condition.  
- Remove checkout ref fallback to `workflow_run.head_sha`; checkout should use `github.ref`.  
- Remove the `Find package tag (workflow_run)` step entirely.  
- Simplify tag-validation condition and script to only handle `push` tag refs.  
- Simplify release metadata emission to drop the `workflow_run` branch and rely on tag/non-tag logic from `GITHUB_REF`.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
