### PR TITLE
Potential fix for code scanning alert no. 18: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/cd-unxt-hypothesis.yml
+++ b/.github/workflows/cd-unxt-hypothesis.yml
@@ -10,11 +10,6 @@ on:
     paths:
       - "packages/unxt-hypothesis/**"
       - ".github/workflows/cd-unxt-hypothesis.yml"
-  workflow_run:
-    workflows:
-      - "Create Package Tags"
-    types:
-      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,11 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Build runs for direct tag pushes or via workflow_run from Create Package Tags
-    # (which handles coordinator tag releases)
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
 
@@ -44,32 +37,14 @@ jobs:
           # Can be removed if switching to hardcoded versions.
           fetch-depth: 0
           persist-credentials: false
-          # For workflow_run events, checkout the exact commit from upstream workflow
-          ref: |
-            ${{ github.event_name == 'workflow_run' &&
-            github.event.workflow_run.head_sha || github.ref }}
-
-      # For workflow_run events, find and export the package-specific tag
-      - name: Find package tag (workflow_run)
-        if: github.event_name == 'workflow_run'
-        uses: ./.github/actions/find-package-tag
-        with:
-          tag_glob: unxt-hypothesis-v*
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.ref }}
 
       - name: Validate git tag (for tagged releases)
-        if: |
-          startsWith(github.ref, 'refs/tags/') || github.event_name ==
-          'workflow_run'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
-          EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_VAR: ${{ github.ref }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="$PACKAGE_TAG"
-          else
-            TAG="${GITHUB_REF_VAR#refs/tags/}"
-          fi
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
           python scripts/validate_tag.py "$TAG" "unxt-hypothesis"
         shell: bash
 
@@ -79,10 +54,7 @@ jobs:
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
 
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            TAG="${PACKAGE_TAG:-}"
-            TRIGGER_EVENT="push"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             TRIGGER_EVENT="push"
           else

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -83,6 +83,7 @@ jobs:
           TAGS_TO_PUSH=()
 
           UNXT_API_TAG_CREATED="false"
+          UNXT_HYPOTHESIS_TAG_CREATED="false"
 
           # Check and create each package tag
           for PACKAGE in "${PACKAGES[@]}"; do
@@ -119,6 +120,9 @@ jobs:
               if [ "$PACKAGE" = "unxt-api" ]; then
                 UNXT_API_TAG_CREATED="true"
               fi
+              if [ "$PACKAGE" = "unxt-hypothesis" ]; then
+                UNXT_HYPOTHESIS_TAG_CREATED="true"
+              fi
             fi
           done
 
@@ -132,6 +136,9 @@ jobs:
             echo "trigger_unxt_api_cd=false" >> "$GITHUB_OUTPUT"
             echo "unxt_api_tag=unxt-api-v${VERSION}" >> "$GITHUB_OUTPUT"
             echo "unxt_api_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "trigger_unxt_hypothesis_cd=false" >> "$GITHUB_OUTPUT"
+            echo "unxt_hypothesis_tag=unxt-hypothesis-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "unxt_hypothesis_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -145,6 +152,9 @@ jobs:
           echo "trigger_unxt_api_cd=${UNXT_API_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "unxt_api_tag=unxt-api-v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "unxt_api_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "trigger_unxt_hypothesis_cd=${UNXT_HYPOTHESIS_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "unxt_hypothesis_tag=unxt-hypothesis-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "unxt_hypothesis_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
         if: |
@@ -171,3 +181,16 @@ jobs:
           tag_ref: ${{ steps.create_tags.outputs.unxt_api_tag }}
           tag_sha: ${{ steps.create_tags.outputs.unxt_api_tag_sha }}
           trigger_cd: ${{ steps.create_tags.outputs.trigger_unxt_api_cd }}
+
+      - name: Trigger CD - unxt-hypothesis for auto-created unxt-hypothesis tag
+        if: |
+          steps.create_tags.outputs.trigger_unxt_hypothesis_cd == 'true' ||
+          (steps.create_tags.outputs.unxt_hypothesis_tag != '' &&
+          steps.create_tags.outputs.trigger_unxt_hypothesis_cd == 'false')
+        uses: ./.github/actions/dispatch-package-cd
+        with:
+          workflow_id: cd-unxt-hypothesis.yml
+          workflow_name: CD - unxt-hypothesis
+          tag_ref: ${{ steps.create_tags.outputs.unxt_hypothesis_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.unxt_hypothesis_tag_sha }}
+          trigger_cd: ${{ steps.create_tags.outputs.trigger_unxt_hypothesis_cd }}

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -193,4 +193,5 @@ jobs:
           workflow_name: CD - unxt-hypothesis
           tag_ref: ${{ steps.create_tags.outputs.unxt_hypothesis_tag }}
           tag_sha: ${{ steps.create_tags.outputs.unxt_hypothesis_tag_sha }}
-          trigger_cd: ${{ steps.create_tags.outputs.trigger_unxt_hypothesis_cd }}
+          trigger_cd:
+            ${{ steps.create_tags.outputs.trigger_unxt_hypothesis_cd }}


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/unxt/security/code-scanning/18](https://github.com/GalacticDynamics/unxt/security/code-scanning/18)

General fix: do not execute repository code from `workflow_run` in a privileged/default-branch workflow. Restrict execution to trusted events (`push` to `main`, tags, manual dispatch), or isolate `workflow_run` into a non-privileged workflow that does not restore/use shared caches or run sensitive release logic.

Best minimal fix here (without changing normal release behavior on `push`/tags): remove `workflow_run` from triggers and from job conditions, and remove `workflow_run`-specific checkout/tag logic. Concretely in `.github/workflows/cd-unxt-hypothesis.yml`:
- Delete the `on.workflow_run` block (lines 13–17).
- Remove `workflow_run` branch from `jobs.build.if`.
- Simplify `checkout.ref` to `${{ github.ref }}`.
- Remove the `Find package tag (workflow_run)` step.
- Update `Validate git tag` to run only on tag pushes and always derive tag from `github.ref`.
- Simplify metadata emission by removing `workflow_run` branch and using existing push/tag/manual logic.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
