### PR TITLE
Backport PR #666 on branch versions/v1.11.x (build(deps): bump quax to >=0.3.4)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -20,7 +20,7 @@ As an example, consider the following code snippets:
 
 >>> q = u.Q(1, 'm')
 >>> q
-Quantity(Array(1, dtype=int32, weak_type=True), unit='m')
+Quantity(Array(1, dtype=int32...), unit='m')
 ```
 
 First we'll show the object-oriented API:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -124,12 +124,12 @@ Display units as `unit='m'` instead of positional `'m'`.
 >>> # Default behavior (named_unit=True)
 >>> with u.config.quantity_repr.override(named_unit=False):
 ...     print(repr(q))
-Quantity(Array(1., dtype=float32, ...), 'm')
+Quantity(Array(1., dtype=float32...), 'm')
 
 >>> # With named_unit=True
 >>> with u.config.quantity_repr.override(named_unit=True):
 ...     print(repr(q))
-Quantity(Array(1., dtype=float32, ...), unit='m')
+Quantity(Array(1., dtype=float32...), unit='m')
 ```
 
 ### `include_params`
@@ -144,11 +144,11 @@ Include type parameters in `repr()` for parametric quantities.
 
 >>> with u.config.quantity_repr.override(include_params=False):
 ...     print(repr(q))
-Quantity(Array(1., dtype=float32, weak_type=True), unit='m')
+Quantity(Array(1., dtype=float32...), unit='m')
 
 >>> with u.config.quantity_repr.override(include_params=True):
 ...     print(repr(q))
-Quantity['length'](Array(1., dtype=float32, weak_type=True), unit='m')
+Quantity['length'](Array(1., dtype=float32...), unit='m')
 ```
 
 ### `indent`

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -8,7 +8,7 @@
 >>> import unxt as u
 
 >>> u.Quantity(5, "m")
-Quantity(Array(5, dtype=int32, weak_type=True), unit='m')
+Quantity(Array(5, dtype=int32...), unit='m')
 ```
 
 The constructor will automatically [convert](https://beartype.github.io/plum/conversion_promotion.html#conversion-with-convert) the value to a `jax.Array` (if it is not already one) and convert the unit to a `Unit` object.
@@ -29,7 +29,7 @@ If you want more flexible options to create a `Quantity`, you can use the `Quant
 
 ```{code-block} python
 >>> u.Q.from_(5, "m")  # same as Quantity(5, "m")
-Quantity(Array(5, dtype=int32, ...), unit='m')
+Quantity(Array(5, dtype=int32...), unit='m')
 
 >>> u.Q.from_({"value": [1, 2, 3], "unit": "m"})
 Quantity(Array([1, 2, 3], dtype=int32), unit='m')
@@ -206,16 +206,16 @@ You can perform standard mathematical operations on `Quantity` objects:
 >>> q2 = u.Q(10, "m")
 
 >>> q1 + q2
-Quantity(Array(15, dtype=int32, ...), unit='m')
+Quantity(Array(15, dtype=int32...), unit='m')
 
 >>> q1 * 1.5
 Quantity(Array(7.5, dtype=float32, ...), unit='m')
 
 >>> q1 / q2
-Quantity(Array(0.5, dtype=float32, ...), unit='')
+Quantity(Array(0.5, dtype=float32...), unit='')
 
 >>> q1 ** 2
-Quantity(Array(25, dtype=int32, ...), unit='m2')
+Quantity(Array(25, dtype=int32...), unit='m2')
 
 ```
 
@@ -418,14 +418,14 @@ You can create an {class}`~unxt.quantity.Angle` just like a {class}`~unxt.quanti
 ```{code-block} python
 >>> a = u.Angle(45, "deg")
 >>> a
-Angle(Array(45, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(45, dtype=int32...), unit='deg')
 ```
 
 Just like {class}`~unxt.quantity.Quantity`, you can flexibly create {class}`~unxt.quantity.Angle` objects using the {meth}`~unxt.quantity.Angle.from_` constructor:
 
 ```{code-block} python
 >>> u.Angle.from_(45, "deg")
-Angle(Array(45, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(45, dtype=int32...), unit='deg')
 
 >>> u.Angle.from_([45, 90], "deg")
 Angle(Array([45, 90], dtype=int32), unit='deg')
@@ -442,9 +442,9 @@ Angle(Array([10, 15, 20], dtype=int32), unit='deg')
 ```{code-block} python
 >>> b = u.Angle(30, "deg")
 >>> a + b
-Angle(Array(75, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(75, dtype=int32...), unit='deg')
 >>> 2 * a
-Angle(Array(90, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(90, dtype=int32...), unit='deg')
 >>> a.to("rad")
 Angle(Array(0.7853982, dtype=float32, weak_type=True), unit='rad')
 ```
@@ -468,14 +468,14 @@ A key feature of {class}`~unxt.quantity.Angle` is the ability to wrap values to 
 ```{code-block} python
 >>> a = u.Angle(370, "deg")
 >>> a.wrap_to(u.Q(0, "deg"), u.Q(360, "deg"))
-Angle(Array(10, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(10, dtype=int32...), unit='deg')
 ```
 
 The {meth}`~unxt.quantity.Angle.wrap_to` method has a function counterpart
 
 ```{code-block} python
 >>> u.quantity.wrap_to(a, u.Q(0, "deg"), u.Q(360, "deg"))
-Angle(Array(10, dtype=int32, weak_type=True), unit='deg')
+Angle(Array(10, dtype=int32...), unit='deg')
 ```
 
 ## Working with `StaticQuantity` Objects

--- a/docs/index.md
+++ b/docs/index.md
@@ -240,7 +240,7 @@ You can use unit system units to create quantities:
 
 >>> q = u.Quantity(10, usys["velocity"])
 >>> q
-Quantity(Array(10, dtype=int32, ...), unit='m / s')
+Quantity(Array(10, dtype=int32...), unit='m / s')
 
 ```
 
@@ -516,7 +516,7 @@ JAX Auto-Differentiation (AD) is supported:
 
 >>> grad_f = quaxify(jax.grad(f))
 >>> grad_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32...), unit='m / s')
 
 ```
 
@@ -528,7 +528,7 @@ or using the convenience library
 
 >>> grad_f = qjax.grad(f)
 >>> grad_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32...), unit='m / s')
 
 ```
 
@@ -540,7 +540,7 @@ Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 >>> jac_f = quaxify(jax.jacfwd(f))
 >>> jac_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32...), unit='m / s')
 
 ```
 
@@ -550,7 +550,7 @@ or using the convenience library
 
 >>> jac_f = qjax.jacfwd(f)
 >>> jac_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
+Quantity(Array(0.5, dtype=float32...), unit='m / s')
 
 ```
 
@@ -562,7 +562,7 @@ Quantity(Array(0.5, dtype=float32, weak_type=True), unit='m / s')
 
 >>> hess_f = quaxify(jax.hessian(f))
 >>> hess_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
+Quantity(Array(0.5, dtype=float32...), unit='1 / s')
 
 ```
 
@@ -572,7 +572,7 @@ or using the convenience library
 
 >>> hess_f = qjax.hessian(f)
 >>> hess_f(x, y)
-Quantity(Array(0.5, dtype=float32, weak_type=True), unit='1 / s')
+Quantity(Array(0.5, dtype=float32...), unit='1 / s')
 
 ```
 

--- a/packages/unxt-api/src/unxt_api/_src/quantity.py
+++ b/packages/unxt-api/src/unxt_api/_src/quantity.py
@@ -125,10 +125,10 @@ def wrap_to(x: Any, min: Any, max: Any, /) -> Any:
     >>> min, max = u.Q(0, "deg"), u.Q(360, "deg")
     >>>
     >>> u.quantity.wrap_to(angle, min, max)
-    Angle(Array(10, dtype=int32, ...), unit='deg')
+    Angle(Array(10, dtype=int32...), unit='deg')
     >>>
     >>> u.quantity.wrap_to(angle, min=min, max=max)
-    Angle(Array(10, dtype=int32, ...), unit='deg')
+    Angle(Array(10, dtype=int32...), unit='deg')
 
     """
     raise NotImplementedError  # pragma: no cover

--- a/packages/unxt-hypothesis/tests/test_angles.py
+++ b/packages/unxt-hypothesis/tests/test_angles.py
@@ -20,7 +20,7 @@ def test_basic_angle(angle: u.Angle) -> None:
 def test_angle_with_bounds(angle: u.Angle) -> None:
     """Test angle generation with value bounds."""
     assert isinstance(angle, u.Angle)
-    assert -180 <= angle.to("deg").value <= 180
+    assert -180 <= angle.ustrip("deg") <= 180
 
 
 @given(angle=angles(unit="rad"))
@@ -38,7 +38,7 @@ def test_angle_with_wrapping(angle: u.Angle) -> None:
     assert isinstance(angle, u.Angle)
     # The wrap_to strategy wraps values to [min, max) range
     # but floating point can give us exactly max
-    angle_deg = angle.to("deg").value
+    angle_deg = angle.ustrip("deg")
     assert 0 <= angle_deg <= 360
 
 
@@ -49,7 +49,7 @@ def test_angle_with_symmetric_wrapping(angle: u.Angle) -> None:
     assert isinstance(angle, u.Angle)
     # The wrap_to strategy wraps values to [min, max) range
     # but floating point can give us exactly max
-    angle_deg = angle.to("deg").value
+    angle_deg = angle.ustrip("deg")
     assert -180 <= angle_deg <= 180
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "optional-dependencies>=0.3.2",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
-  "quax>=0.3.2",
+  "quax>=0.3.4",
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",

--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -73,7 +73,7 @@ def grad(
 
     >>> grad_cube_volume = u.experimental.grad(cube_volume, units=("m",))
     >>> grad_cube_volume(u.Q(2.0, "m"))
-    Quantity(Array(12., dtype=float32, weak_type=True), unit='m2')
+    Quantity(Array(12., dtype=float32...), unit='m2')
 
     """
     theunits: tuple[AbstractUnit | None, ...] = tuple(map(unit_or_none, units))
@@ -135,7 +135,7 @@ def jacfwd(
 
     >>> jacfwd_cubbe_volume = u.experimental.jacfwd(cubbe_volume, units=("m",))
     >>> jacfwd_cubbe_volume(u.Q(2.0, "m"))
-    BareQuantity(Array(12., dtype=float32, weak_type=True), unit='m2')
+    BareQuantity(Array(12., dtype=float32...), unit='m2')
 
     """
     argnums = eqx.error_if(
@@ -202,7 +202,7 @@ def hessian(
 
     >>> hessian_cubbe_volume = u.experimental.hessian(cubbe_volume, units=("m",))
     >>> hessian_cubbe_volume(u.Q(2.0, "m"))
-    BareQuantity(Array(12., dtype=float32, weak_type=True), unit='m')
+    BareQuantity(Array(12., dtype=float32...), unit='m')
 
     """
     theunits: tuple[AbstractUnit, ...] = tuple(map(unit_or_none, units))

--- a/src/unxt/_src/quantity/angle.py
+++ b/src/unxt/_src/quantity/angle.py
@@ -25,13 +25,13 @@ class Angle(AbstractAngle):
 
     >>> q = u.Angle(1, "rad")
     >>> q
-    Angle(Array(1, dtype=int32, ...), unit='rad')
+    Angle(Array(1, dtype=int32...), unit='rad')
 
     Wrap an Angle to a range:
 
     >>> q = u.Angle(370, "deg")
     >>> q.wrap_to(u.Q(0, "deg"), u.Q(360, "deg"))
-    Angle(Array(10, dtype=int32, ...), unit='deg')
+    Angle(Array(10, dtype=int32...), unit='deg')
 
     Create an Angle array:
 

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -79,12 +79,12 @@ class AbstractQuantity(
     From an integer:
 
     >>> u.Quantity(1, "m")
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     From a float:
 
     >>> u.Quantity(1.0, "m")
-    Quantity(Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     From a list:
 
@@ -112,7 +112,7 @@ class AbstractQuantity(
 
     >>> import astropy.units as apyu
     >>> u.Quantity(1, apyu.m)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
 
@@ -420,7 +420,7 @@ class AbstractQuantity(
         >>> import unxt as u
         >>> q = u.Quantity(1, "m")
         >>> q.to_device(None)
-        Quantity(Array(1, dtype=int32, weak_type=True), unit='m')
+        Quantity(Array(1, dtype=int32...), unit='m')
 
         """
         return replace(self, value=self.value.to_device(device))
@@ -995,7 +995,7 @@ def from_(
 
     >>> q = u.Quantity(1, "m")
     >>> u.Quantity.from_(q, None)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
     value = jnp.asarray(value, dtype=dtype)

--- a/src/unxt/_src/quantity/base_angle.py
+++ b/src/unxt/_src/quantity/base_angle.py
@@ -32,7 +32,7 @@ class AbstractAngle(AbstractQuantity):
     >>> from unxt import Angle
 
     >>> Angle(90, "deg")
-    Angle(Array(90, dtype=int32, ...), unit='deg')
+    Angle(Array(90, dtype=int32...), unit='deg')
 
     Angles have to have dimensions of angle.
 
@@ -75,7 +75,7 @@ class AbstractAngle(AbstractQuantity):
         >>> import unxt as u
         >>> angle = u.Angle(370, "deg")
         >>> angle.wrap_to(min=u.Q(0, "deg"), max=u.Q(360, "deg"))
-        Angle(Array(10, dtype=int32, ...), unit='deg')
+        Angle(Array(10, dtype=int32...), unit='deg')
 
         """
         return uapi.wrap_to(self, min, max)

--- a/src/unxt/_src/quantity/flag.py
+++ b/src/unxt/_src/quantity/flag.py
@@ -131,7 +131,7 @@ def ustrip(flag: type[AllowValue], x: AbstractQuantity, /) -> Any:
     >>> not isinstance(y, u.Quantity)
     True
     >>> y == 1
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     """
     return uapi.ustrip(x)

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -38,12 +38,12 @@ class Quantity(AbstractParametricQuantity):
     From an integer:
 
     >>> u.Quantity(1, "m")
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     From a float:
 
     >>> u.Q(1.0, "m")
-    Quantity(Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     From a list:
 
@@ -70,13 +70,13 @@ class Quantity(AbstractParametricQuantity):
     The unit can also be given as a units object:
 
     >>> u.Quantity(1, u.unit("m"))
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     In the previous examples, the dimension parameter was inferred from the
     values. It can also be given explicitly:
 
     >>> u.Quantity["length"](1, "m")
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     This can be used for runtime checking of the input dimension!
 
@@ -92,12 +92,12 @@ class Quantity(AbstractParametricQuantity):
     >>> dims
     PhysicalType('length')
     >>> u.Quantity[dims](1.0, "m")
-    Quantity(Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     Or as a unit:
 
     >>> u.Quantity[u.unit("m")](1.0, "m")
-    Quantity(Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     Some tricky cases are when the physical type is unknown:
 

--- a/src/unxt/_src/quantity/register_api.py
+++ b/src/unxt/_src/quantity/register_api.py
@@ -177,7 +177,7 @@ def uconvert_value(uto: Any, ufrom: Any, x: AbstractQuantity, /) -> AbstractQuan
 
     >>> q = u.Q(1, "km")
     >>> u.uconvert_value("m", "km", q)
-    Quantity(Array(1000., dtype=float32, ...), unit='m')
+    Quantity(Array(1000., dtype=float32...), unit='m')
 
     """
     x = eqx.error_if(
@@ -202,7 +202,7 @@ def uconvert(ustr: str, x: AbstractQuantity, /) -> AbstractQuantity:
 
     >>> x = Quantity(1000, "m")
     >>> uconvert("km", x)
-    Quantity(Array(1., dtype=float32, ...), unit='km')
+    Quantity(Array(1., dtype=float32...), unit='km')
 
     """
     return uconvert(uapi.unit(ustr), x)
@@ -219,7 +219,7 @@ def uconvert(usys: AbstractUnitSystem, x: AbstractQuantity, /) -> AbstractQuanti
 
     >>> q = Quantity(1e17, "km")
     >>> uconvert(galactic, q)
-    Quantity(Array(3.2407792, dtype=float32, ...), unit='kpc')
+    Quantity(Array(3.2407792, dtype=float32...), unit='kpc')
 
     """
     return uconvert(usys[uapi.dimension_of(x)], x)
@@ -245,7 +245,7 @@ def ustrip(x: AbstractQuantity, /) -> Array | np.ndarray:
 
     >>> q = u.Q(1000, "m")
     >>> u.ustrip(q)
-    Array(1000, dtype=int32, weak_type=True)
+    Array(1000, dtype=int32...)
 
     >>> u.ustrip(q) is q.value
     True
@@ -265,7 +265,7 @@ def ustrip(u: AbstractUnit, x: AbstractQuantity, /) -> Array | np.ndarray:
 
     >>> q = u.Q(1000, "m")
     >>> u.ustrip(u.unit("km"), q)
-    Array(1., dtype=float32, ...)
+    Array(1., dtype=float32...)
 
     """
     return uapi.ustrip(uapi.uconvert(u, x))
@@ -281,7 +281,7 @@ def ustrip(u: str, x: AbstractQuantity, /) -> Array | np.ndarray:
 
     >>> q = u.Q(1000, "m")
     >>> u.ustrip("km", q)
-    Array(1., dtype=float32, ...)
+    Array(1., dtype=float32...)
 
     """
     return uapi.ustrip(uapi.unit(u), x)
@@ -298,7 +298,7 @@ def ustrip(u: AbstractUnitSystem, x: AbstractQuantity, /) -> Array | np.ndarray:
 
     >>> q = u.Q(1e17, "km")
     >>> u.ustrip(galactic, q)
-    Array(3.2407792, dtype=float32, weak_type=True)
+    Array(3.2407792, dtype=float32...)
 
     """
     return uapi.ustrip(u[uapi.dimension_of(x)], x)
@@ -375,7 +375,7 @@ def wrap_to(
 
     >>> angle = u.Angle(370, "deg")
     >>> u.quantity.wrap_to(angle, min=u.Q(0, "deg"), max=u.Q(360, "deg"))
-    Angle(Array(10, dtype=int32, ...), unit='deg')
+    Angle(Array(10, dtype=int32...), unit='deg')
 
     """
     minv, maxv = min.ustrip(angle.unit), max.ustrip(angle.unit)

--- a/src/unxt/_src/quantity/register_conversions.py
+++ b/src/unxt/_src/quantity/register_conversions.py
@@ -22,7 +22,7 @@ def quantity_to_unchecked(q: AbstractQuantity, /) -> BareQuantity:
 
     >>> q = Quantity(1, "m")
     >>> convert(q, BareQuantity)
-    BareQuantity(Array(1, dtype=int32, weak_type=True), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     The self-conversion doesn't copy the object:
 
@@ -48,10 +48,10 @@ def quantity_to_checked(q: AbstractQuantity, /) -> Quantity:
 
     >>> q = BareQuantity(1, "m")
     >>> q
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     >>> convert(q, Quantity)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     The self-conversion doesn't copy the object:
 
@@ -76,10 +76,10 @@ def convert_quantity_to_angle(q: AbstractQuantity, /) -> Angle:
     >>> from unxt.quantity import Angle, BareQuantity
     >>> q = BareQuantity(1, "rad")
     >>> q
-    BareQuantity(Array(1, dtype=int32, ...), unit='rad')
+    BareQuantity(Array(1, dtype=int32...), unit='rad')
 
     >>> convert(q, Angle)
-    Angle(Array(1, dtype=int32, ...), unit='rad')
+    Angle(Array(1, dtype=int32...), unit='rad')
 
     The self-conversion doesn't copy the object:
 

--- a/src/unxt/_src/quantity/register_dispatches.py
+++ b/src/unxt/_src/quantity/register_dispatches.py
@@ -68,7 +68,7 @@ def empty_like(
     >>> from unxt import Quantity
 
     >>> jnp.empty_like(Quantity(5, "m"))
-    Quantity(Array(0, dtype=int32, ...), unit='m')
+    Quantity(Array(0, dtype=int32...), unit='m')
 
     """
     out = plum.type_unparametrized(x)(jax_xp.empty_like(x.value, **kwargs), unit=x.unit)
@@ -90,7 +90,7 @@ def full(
     >>> from unxt import Quantity
 
     >>> jnp.full((2, 2), Quantity(5, "m"))
-    Quantity(Array([[5, 5], [5, 5]], dtype=int32, ...), unit='m')
+    Quantity(Array([[5, 5], [5, 5]], dtype=int32...), unit='m')
 
     """
     fill_val = ustrip(fill_value.unit, fill_value)
@@ -112,7 +112,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), fill_value=Quantity(10, "m"))
-    Quantity(Array(10, dtype=int32, ...), unit='m')
+    Quantity(Array(10, dtype=int32...), unit='m')
 
     """
     # re-dispatch to the correct implementation
@@ -131,7 +131,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), 100.0)
-    Quantity(Array(100, dtype=int32, ...), unit='m')
+    Quantity(Array(100, dtype=int32...), unit='m')
 
     """
     return plum.type_unparametrized(x)(
@@ -151,7 +151,7 @@ def full_like(
     >>> from unxt import Quantity
 
     >>> jnp.full_like(Quantity(5, "m"), Quantity(10, "m"))
-    Quantity(Array(10, dtype=int32, ...), unit='m')
+    Quantity(Array(10, dtype=int32...), unit='m')
 
     """
     fill_val = ustrip(x.unit, fill_value)
@@ -221,7 +221,7 @@ def ones_like(
     >>> from unxt import Quantity
 
     >>> jnp.ones_like(Quantity(5, "m"))
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
     cls = plum.type_unparametrized(x)
@@ -244,7 +244,7 @@ def zeros_like(
     >>> from unxt import Quantity
 
     >>> jnp.zeros_like(Quantity(5, "m"))
-    Quantity(Array(0, dtype=int32, ...), unit='m')
+    Quantity(Array(0, dtype=int32...), unit='m')
 
     """
     cls = plum.type_unparametrized(x)

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -64,15 +64,15 @@ def abs_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.Q(-1, "m")
     >>> jnp.abs(q)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
     >>> abs(q)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     >>> q = u.quantity.BareQuantity(-1, "m")
     >>> jnp.abs(q)
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
     >>> abs(q)
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     """
     return replace(x, value=qlax.abs(ustrip(x)))
@@ -92,11 +92,11 @@ def acos_p_aq(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(-1, "")
     >>> jnp.acos(q).round(4)
-    BareQuantity(Array(3.1416, dtype=float32, weak_type=True), unit='rad')
+    BareQuantity(Array(3.1416, dtype=float32...), unit='rad')
 
     >>> q = u.Q(-1, "")
     >>> jnp.acos(q).round(4)
-    Quantity(Array(3.1416, dtype=float32, ...), unit='rad')
+    Quantity(Array(3.1416, dtype=float32...), unit='rad')
 
     """
     x_ = ustrip(one, x)
@@ -117,11 +117,11 @@ def acosh_p_aq(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(2.0, "")
     >>> jnp.acosh(q)
-    BareQuantity(Array(1.316958, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(1.316958, dtype=float32...), unit='rad')
 
     >>> q = u.Q(2.0, "")
     >>> jnp.acosh(q)
-    Quantity(Array(1.316958, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.316958, dtype=float32...), unit='rad')
 
     """
     x_ = ustrip(one, x)
@@ -144,23 +144,23 @@ def add_p_aqaq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "km")
     >>> q2 = u.quantity.BareQuantity(500.0, "m")
     >>> jnp.add(q1, q2)
-    BareQuantity(Array(1.5, dtype=float32, ...), unit='km')
+    BareQuantity(Array(1.5, dtype=float32...), unit='km')
     >>> q1 + q2
-    BareQuantity(Array(1.5, dtype=float32, ...), unit='km')
+    BareQuantity(Array(1.5, dtype=float32...), unit='km')
 
     >>> q1 = u.Q(1, "km")
     >>> q2 = u.Q(500.0, "m")
     >>> jnp.add(q1, q2)
-    Quantity(Array(1.5, dtype=float32, ...), unit='km')
+    Quantity(Array(1.5, dtype=float32...), unit='km')
     >>> q1 + q2
-    Quantity(Array(1.5, dtype=float32, ...), unit='km')
+    Quantity(Array(1.5, dtype=float32...), unit='km')
 
     >>> q1 = u.quantity.BareQuantity(1, "km")
     >>> q2 = u.Q(500.0, "m")
     >>> jnp.add(q1, q2)
-    Quantity(Array(1.5, dtype=float32, weak_type=True), unit='km')
+    Quantity(Array(1.5, dtype=float32...), unit='km')
     >>> q1 + q2
-    Quantity(Array(1.5, dtype=float32, weak_type=True), unit='km')
+    Quantity(Array(1.5, dtype=float32...), unit='km')
 
     """
     x, y = promote(x, y)
@@ -202,15 +202,15 @@ def add_p_vaq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
 
     >>> y = u.quantity.BareQuantity(100.0, "")
     >>> jnp.add(x, y)
-    BareQuantity(Array(600., dtype=float32, ...), unit='')
+    BareQuantity(Array(600., dtype=float32...), unit='')
 
     >>> x + y
-    BareQuantity(Array(600., dtype=float32, ...), unit='')
+    BareQuantity(Array(600., dtype=float32...), unit='')
 
     >>> q2 = u.quantity.BareQuantity(1.0, "km")
     >>> q3 = u.quantity.BareQuantity(1_000.0, "m")
     >>> jnp.add(x, q2 / q3)
-    BareQuantity(Array(501., dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(501., dtype=float32...), unit='')
 
     `unxt.Quantity`:
 
@@ -224,15 +224,15 @@ def add_p_vaq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
 
     >>> q2 = u.Q(100.0, "")
     >>> jnp.add(x, q2)
-    Quantity(Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32...), unit='')
 
     >>> x + q2
-    Quantity(Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32...), unit='')
 
     >>> q2 = u.Q(1.0, "km")
     >>> q3 = u.Q(1_000.0, "m")
     >>> jnp.add(x, q2 / q3)
-    Quantity(Array(501., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(501., dtype=float32...), unit='')
 
     """
     y = uconvert(one, y)
@@ -268,15 +268,15 @@ def add_p_aqv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     >>> q1 = u.quantity.BareQuantity(100.0, "")
     >>> jnp.add(q1, y)
-    BareQuantity(Array(600., dtype=float32, ...), unit='')
+    BareQuantity(Array(600., dtype=float32...), unit='')
 
     >>> q1 + y
-    BareQuantity(Array(600., dtype=float32, ...), unit='')
+    BareQuantity(Array(600., dtype=float32...), unit='')
 
     >>> q2 = u.quantity.BareQuantity(1.0, "km")
     >>> q3 = u.quantity.BareQuantity(1_000.0, "m")
     >>> jnp.add(q2 / q3, y)
-    BareQuantity(Array(501., dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(501., dtype=float32...), unit='')
 
     `unxt.Quantity`:
 
@@ -296,15 +296,15 @@ def add_p_aqv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     >>> q1 = u.Q(100.0, "")
     >>> jnp.add(q1, y)
-    Quantity(Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32...), unit='')
 
     >>> q1 + y
-    Quantity(Array(600., dtype=float32, ...), unit='')
+    Quantity(Array(600., dtype=float32...), unit='')
 
     >>> q2 = u.Q(1.0, "km")
     >>> q3 = u.Q(1_000.0, "m")
     >>> jnp.add(q2 / q3, y)
-    Quantity(Array(501., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(501., dtype=float32...), unit='')
 
     """
     x = uconvert(one, x)
@@ -355,12 +355,12 @@ def and_p_aq(x1: ABCQ, x2: ABCQ, /) -> ArrayLike:
     >>> x1 = u.quantity.BareQuantity(1, "")
     >>> x2 = u.quantity.BareQuantity(2, "")
     >>> jnp.bitwise_and(x1, x2)
-    Array(0, dtype=int32, ...)
+    Array(0, dtype=int32...)
 
     >>> x1 = u.Q(1, "")
     >>> x2 = u.Q(2, "")
     >>> jnp.bitwise_and(x1, x2)
-    Array(0, dtype=int32, ...)
+    Array(0, dtype=int32...)
 
     """
     return lax.and_p.bind(ustrip(one, x1), ustrip(one, x2))
@@ -453,7 +453,7 @@ def asin_p_aq(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.asin(q)
-    BareQuantity(Array(1.5707964, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(1.5707964, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.asin(ustrip(one, x)), unit=radian)
@@ -470,7 +470,7 @@ def asin_p_q(x: ABCPQ["dimensionless"]) -> ABCPQ["angle"]:
 
     >>> q = u.Q(1, "")
     >>> jnp.asin(q)
-    Quantity(Array(1.5707964, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.5707964, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.asin(ustrip(one, x)), unit=radian)
@@ -490,7 +490,7 @@ def asinh_p_aq(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(2, "")
     >>> jnp.asinh(q)
-    BareQuantity(Array(1.4436355, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(1.4436355, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.asinh(ustrip(one, x)), unit=radian)
@@ -507,7 +507,7 @@ def asinh_p_q(x: ABCPQ["dimensionless"]) -> ABCPQ["angle"]:
 
     >>> q = u.Q(2, "")
     >>> jnp.asinh(q)
-    Quantity(Array(1.4436355, dtype=float32, ...), unit='rad')
+    Quantity(Array(1.4436355, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.asinh(ustrip(one, x)), unit=radian)
@@ -527,7 +527,7 @@ def atan2_p_aqaq(x: ABCQ, y: ABCQ) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "m")
     >>> q2 = u.quantity.BareQuantity(3.0, "m")
     >>> jnp.atan2(q1, q2)
-    BareQuantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
@@ -545,7 +545,7 @@ def atan2_p_qq(x: ABCPQ, y: ABCPQ) -> ABCPQ["radian"]:
     >>> q1 = u.Q(1, "m")
     >>> q2 = u.Q(3.0, "m")
     >>> jnp.atan2(q1, q2)
-    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
@@ -567,7 +567,7 @@ def atan2_p_vaq(x: ArrayLike, y: ABCQ) -> ABCQ:
     >>> x1 = jnp.asarray(1.0)
     >>> q2 = u.quantity.BareQuantity(3, "")
     >>> jnp.atan2(x1, q2)
-    BareQuantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     yv = ustrip(one, y)
@@ -584,7 +584,7 @@ def atan2_p_vq(x: ArrayLike, y: ABCPQ["dimensionless"]) -> ABCPQ["angle"]:
     >>> x1 = jnp.asarray(1.0)
     >>> q2 = u.Q(3, "")
     >>> jnp.atan2(x1, q2)
-    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     yv = ustrip(one, y)
@@ -605,7 +605,7 @@ def atan2_p_aqv(x: ABCQ, y: ArrayLike) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1.0, "")
     >>> x2 = jnp.asarray(3)
     >>> jnp.atan2(q1, x2)
-    BareQuantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     xv = ustrip(one, x)
@@ -622,7 +622,7 @@ def atan2_p_qv(x: ABCPQ["dimensionless"], y: ArrayLike) -> ABCPQ["angle"]:
     >>> q1 = u.Q(1.0, "")
     >>> x2 = jnp.asarray(3)
     >>> jnp.atan2(q1, x2)
-    Quantity(Array(0.32175055, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.32175055, dtype=float32...), unit='rad')
 
     """
     xv = ustrip(one, x)
@@ -642,7 +642,7 @@ def atan_p_aq(x: ABCQ) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.atan(q)
-    BareQuantity(Array(0.7853982, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(0.7853982, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.atan(ustrip(one, x)), unit=radian)
@@ -657,7 +657,7 @@ def atan_p_q(x: ABCPQ["dimensionless"]) -> ABCPQ["angle"]:
     >>> import quaxed.numpy as jnp
     >>> q = u.Q(1, "")
     >>> jnp.atan(q)
-    Quantity(Array(0.7853982, dtype=float32, ...), unit='rad')
+    Quantity(Array(0.7853982, dtype=float32...), unit='rad')
 
     """
     return Quantity(lax.atan(ustrip(one, x)), unit=radian)
@@ -676,7 +676,7 @@ def atanh_p_aq(x: ABCQ) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(2, "")
     >>> jnp.atanh(q)
-    BareQuantity(Array(nan, dtype=float32, ...), unit='rad')
+    BareQuantity(Array(nan, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.atanh(ustrip(one, x)), unit=radian)
@@ -691,7 +691,7 @@ def atanh_p_q(x: ABCPQ["dimensionless"]) -> ABCPQ["angle"]:
     >>> import quaxed.numpy as jnp
     >>> q = u.Q(2, "")
     >>> jnp.atanh(q)
-    Quantity(Array(nan, dtype=float32, ...), unit='rad')
+    Quantity(Array(nan, dtype=float32...), unit='rad')
 
     """
     return type_np(x)(lax.atanh(ustrip(one, x)), unit=radian)
@@ -710,11 +710,11 @@ def bessel_i0e_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
 
     >>> x = u.quantity.BareQuantity(1.0, "")
     >>> qlax.bessel_i0e(x)
-    BareQuantity(Array(0.46575963, dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(0.46575963, dtype=float32...), unit='')
 
     >>> x = u.Q(1.0, "")
     >>> qlax.bessel_i0e(x)
-    Quantity(Array(0.46575963, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.46575963, dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.bessel_i0e_p.bind(ustrip(one, x), **kwargs))
@@ -730,11 +730,11 @@ def bessel_i1e_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
 
     >>> x = u.quantity.BareQuantity(1.0, "")
     >>> qlax.bessel_i1e(x)
-    BareQuantity(Array(0.20791042, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.20791042, dtype=float32...), unit='')
 
     >>> x = u.Q(1.0, "")
     >>> qlax.bessel_i1e(x)
-    Quantity(Array(0.20791042, dtype=float32, ...), unit='')
+    Quantity(Array(0.20791042, dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.bessel_i1e_p.bind(ustrip(one, x), **kwargs))
@@ -788,11 +788,11 @@ def cbrt_p_q(x: ABCQ, /, **kw: Any) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(8, "m3")
     >>> jnp.cbrt(q)
-    BareQuantity(Array(2., dtype=float32, ...), unit='m')
+    BareQuantity(Array(2., dtype=float32...), unit='m')
 
     >>> q = u.Q(8, "m3")
     >>> jnp.cbrt(q)
-    Quantity(Array(2., dtype=float32, ...), unit='m')
+    Quantity(Array(2., dtype=float32...), unit='m')
 
     """
     return type_np(x)(lax.cbrt_p.bind(ustrip(x), **kw), unit=x.unit ** (1 / 3))
@@ -810,7 +810,7 @@ def cbrt_p_abstractangle(x: AbstractAngle, /, **kw: Any) -> ABCQ:
 
     >>> q = u.Angle(8, "rad")
     >>> jnp.cbrt(q)
-    Quantity(Array(2., dtype=float32, ...), unit='rad(1/3)')
+    Quantity(Array(2., dtype=float32...), unit='rad(1/3)')
 
     """
     return cbrt_p_q(convert(x, Quantity), **kw)
@@ -829,11 +829,11 @@ def ceil_p(x: ABCQ, /) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(1.5, "m")
     >>> jnp.ceil(q)
-    BareQuantity(Array(2., dtype=float32, ...), unit='m')
+    BareQuantity(Array(2., dtype=float32...), unit='m')
 
     >>> q = u.Q(1.5, "m")
     >>> jnp.ceil(q)
-    Quantity(Array(2., dtype=float32, ...), unit='m')
+    Quantity(Array(2., dtype=float32...), unit='m')
 
     """
     return replace(x, value=qlax.ceil(ustrip(x)))
@@ -1007,11 +1007,11 @@ def clz_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> qlax.clz(q)
-    BareQuantity(Array(31, dtype=int32, ...), unit='')
+    BareQuantity(Array(31, dtype=int32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> qlax.clz(q)
-    Quantity(Array(31, dtype=int32, ...), unit='')
+    Quantity(Array(31, dtype=int32...), unit='')
 
     """
     return replace(x, value=lax.clz_p.bind(ustrip(x)))
@@ -1032,12 +1032,12 @@ def complex_p(x: ABCQ, y: ABCQ) -> ABCQ:
     >>> x = u.quantity.BareQuantity(1.0, "m")
     >>> y = u.quantity.BareQuantity(2.0, "m")
     >>> lax.complex(x, y)
-    BareQuantity(Array(1.+2.j, dtype=complex64, ...), unit='m')
+    BareQuantity(Array(1.+2.j, dtype=complex64...), unit='m')
 
     >>> x = u.Q(1.0, "m")
     >>> y = u.Q(2.0, "m")
     >>> lax.complex(x, y)
-    Quantity(Array(1.+2.j, dtype=complex64, ...), unit='m')
+    Quantity(Array(1.+2.j, dtype=complex64...), unit='m')
 
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
@@ -1144,6 +1144,88 @@ def concatenate_p_vqnd(operand0: ArrayLike, *operands: ABCQ, dimension: Any) -> 
 
 
 # ==============================================================================
+# Stack
+
+if hasattr(lax, "stack_p"):
+
+    @quax.register(lax.stack_p)
+    def stack_p_aq(*operands: ABCQ, axis: int) -> ABCQ:
+        """Stack quantities along a new axis.
+
+        Examples
+        --------
+        >>> import quaxed.numpy as jnp
+        >>> import unxt as u
+        >>> q1 = u.quantity.BareQuantity([1.0, 2.0], "km")
+        >>> q2 = u.quantity.BareQuantity([3_000.0, 4_000.0], "m")
+        >>> jnp.stack([q1, q2]).round(2)
+        BareQuantity(Array([[1., 2.],
+                            [3., 4.]], dtype=float32), unit='km')
+
+        >>> q1 = u.Q([1.0, 2.0], "km")
+        >>> q2 = u.Q([3_000.0, 4_000.0], "m")
+        >>> jnp.stack([q1, q2]).round(2)
+        Quantity(Array([[1., 2.],
+                        [3., 4.]], dtype=float32), unit='km')
+
+        """
+        operand0 = operands[0]
+        u = operand0.unit
+        return replace(
+            operand0,
+            value=lax.stack([ustrip(u, op) for op in operands], axis=axis),
+        )
+
+    # ---------------------------
+
+    @quax.register(lax.stack_p, precedence=1)
+    def stack_p_qnd(
+        operand0: ABCPQ["dimensionless"],
+        *operands: ABCPQ["dimensionless"] | ArrayLike,
+        axis: int,
+    ) -> ABCPQ["dimensionless"]:
+        """Stack dimensionless quantities and arrays along a new axis.
+
+        Examples
+        --------
+        >>> import quaxed.numpy as jnp
+        >>> import unxt as u
+        >>> q1 = u.Q([0.5, 0.5], "")
+        >>> q2 = jnp.asarray([1.0, 2.0])
+        >>> jnp.stack([q1, q2])
+        Quantity(Array([[0.5, 0.5],
+                        [1. , 2. ]], dtype=float32), unit='')
+
+        """
+        value = lax.stack(
+            [
+                (ustrip(one, op) if hasattr(op, "unit") else op)
+                for op in (operand0, *operands)
+            ],
+            axis=axis,
+        )
+        return type_np(operand0)(value, unit=one)
+
+    @quax.register(lax.stack_p)
+    def stack_p_vqnd(operand0: ArrayLike, *operands: ABCQ, axis: int) -> ABCQ:
+        """Stack arrays and dimensionless quantities along a new axis.
+
+        Examples
+        --------
+        >>> import quaxed.numpy as jnp
+        >>> import unxt as u
+        >>> arr = jnp.asarray([1.0, 2.0])
+        >>> q = u.Q([0.5, 0.5], "")
+        >>> jnp.stack([arr, q])
+        Quantity(Array([[1. , 2. ],
+                        [0.5, 0.5]], dtype=float32), unit='')
+
+        """
+        arrs = [operand0, *(ustrip(one, op) for op in operands)]
+        return Quantity(lax.stack(arrs, axis=axis), unit=one)
+
+
+# ==============================================================================
 
 
 @quax.register(lax.cond_p)  # TODO: implement
@@ -1178,11 +1260,11 @@ def conj_p(x: ABCQ, *, input_dtype: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1 + 2j, "m")
     >>> jnp.conj(q)
-    BareQuantity(Array(1.-2.j, dtype=complex64, ...), unit='m')
+    BareQuantity(Array(1.-2.j, dtype=complex64...), unit='m')
 
     >>> q = u.Q(1 + 2j, "m")
     >>> jnp.conj(q)
-    Quantity(Array(1.-2.j, dtype=complex64, ...), unit='m')
+    Quantity(Array(1.-2.j, dtype=complex64...), unit='m')
 
     """
     del input_dtype  # TODO: use this?
@@ -1220,11 +1302,11 @@ def copy_p(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "m")
     >>> jnp.copy(q)
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     >>> q = u.Q(1, "m")
     >>> jnp.copy(q)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
     return replace(x, value=lax.copy_p.bind(ustrip(x)))  # type: ignore[no-untyped-call]
@@ -1244,11 +1326,11 @@ def cos_p_aq(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "rad")
     >>> jnp.cos(q)
-    BareQuantity(Array(0.5403023, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.5403023, dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.cos(q)
-    BareQuantity(Array(0.5403023, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.5403023, dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.cos_p.bind(_to_val_rad_or_one(x), **kw), unit=one)
@@ -1265,11 +1347,11 @@ def cos_p_q(x: ABCPQ["angle"] | Q["dimensionless"], /, **kw: Any) -> Q["dimensio
 
     >>> q = u.Q(1, "rad")
     >>> jnp.cos(q)
-    Quantity(Array(0.5403023, dtype=float32, ...), unit='')
+    Quantity(Array(0.5403023, dtype=float32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> jnp.cos(q)
-    Quantity(Array(0.5403023, dtype=float32, ...), unit='')
+    Quantity(Array(0.5403023, dtype=float32...), unit='')
 
     """
     return Quantity(lax.cos_p.bind(_to_val_rad_or_one(x), **kw), unit=one)
@@ -1286,7 +1368,7 @@ def cos_p_abstractangle(x: AbstractAngle, /, **kw: Any) -> Quantity:
 
     >>> q = u.Angle(0, "deg")
     >>> jnp.cos(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return cos_p_q(convert(x, Quantity), **kw)
@@ -1306,11 +1388,11 @@ def cosh_p_aq(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "rad")
     >>> jnp.cosh(q)
-    BareQuantity(Array(1.5430806, dtype=float32, ...), unit='')
+    BareQuantity(Array(1.5430806, dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.cosh(q)
-    BareQuantity(Array(1.5430806, dtype=float32, ...), unit='')
+    BareQuantity(Array(1.5430806, dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.cosh(_to_val_rad_or_one(x)), unit=one)
@@ -1327,11 +1409,11 @@ def cosh_p_q(x: ABCPQ["angle"] | Q["dimensionless"]) -> ABCPQ["dimensionless"]:
 
     >>> q = u.Q(1, "rad")
     >>> jnp.cosh(q)
-    Quantity(Array(1.5430806, dtype=float32, ...), unit='')
+    Quantity(Array(1.5430806, dtype=float32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> jnp.cosh(q)
-    Quantity(Array(1.5430806, dtype=float32, ...), unit='')
+    Quantity(Array(1.5430806, dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.cosh(_to_val_rad_or_one(x)), unit=one)
@@ -1724,11 +1806,11 @@ def device_put_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "m")
     >>> device_put(q)
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     >>> q = u.Q(1, "m")
     >>> device_put(q)
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
     return jt.map(lambda y: lax.device_put_p.bind(y, **kw), x)  # type: ignore[no-untyped-call]
@@ -1748,11 +1830,11 @@ def digamma_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1.0, "")
     >>> lax.digamma(q)
-    BareQuantity(Array(-0.5772154, dtype=float32, ...), unit='')
+    BareQuantity(Array(-0.5772154, dtype=float32...), unit='')
 
     >>> q = u.Q(1.0, "")
     >>> lax.digamma(q)
-    Quantity(Array(-0.5772154, dtype=float32, ...), unit='')
+    Quantity(Array(-0.5772154, dtype=float32...), unit='')
 
     """
     return replace(x, value=qlax.digamma(ustrip(one, x)))
@@ -1810,16 +1892,16 @@ def div_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "m")
     >>> q2 = u.quantity.BareQuantity(2, "s")
     >>> jnp.divide(q1, q2)
-    BareQuantity(Array(0.5, dtype=float32, ...), unit='m / s')
+    BareQuantity(Array(0.5, dtype=float32...), unit='m / s')
     >>> q1 / q2
-    BareQuantity(Array(0.5, dtype=float32, ...), unit='m / s')
+    BareQuantity(Array(0.5, dtype=float32...), unit='m / s')
 
     >>> q1 = u.Q(1, "m")
     >>> q2 = u.Q(2, "s")
     >>> jnp.divide(q1, q2)
-    Quantity(Array(0.5, dtype=float32, ...), unit='m / s')
+    Quantity(Array(0.5, dtype=float32...), unit='m / s')
     >>> q1 / q2
-    Quantity(Array(0.5, dtype=float32, ...), unit='m / s')
+    Quantity(Array(0.5, dtype=float32...), unit='m / s')
 
     """
     x, y = promote(x, y)
@@ -1870,15 +1952,15 @@ def div_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(6.0, "m")
     >>> jnp.divide(q, y)
-    BareQuantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    BareQuantity(Array([6., 3., 2.], dtype=float32...), unit='m')
     >>> q / y
-    BareQuantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    BareQuantity(Array([6., 3., 2.], dtype=float32...), unit='m')
 
     >>> q = u.Q(6.0, "m")
     >>> jnp.divide(q, y)
-    Quantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    Quantity(Array([6., 3., 2.], dtype=float32...), unit='m')
     >>> q / y
-    Quantity(Array([6., 3., 2.], dtype=float32, ...), unit='m')
+    Quantity(Array([6., 3., 2.], dtype=float32...), unit='m')
 
     """
     return replace(x, value=ustrip(x) / y)
@@ -1897,7 +1979,7 @@ def div_p_a(x: AbstractAngle, y: AbstractAngle, /) -> ABCQ:
     >>> angle = u.Angle(1, "deg")
     >>> q = u.Q(2, "km")
     >>> jnp.divide(q, angle)
-    Quantity(Array(2., dtype=float32, ...), unit='km / deg')
+    Quantity(Array(2., dtype=float32...), unit='km / deg')
 
     """
     x, y = promote(x, y)
@@ -2129,16 +2211,16 @@ def eq_p_qq(x: ABCQ, y: ABCQ) -> ArrayLike:
     >>> q1 = u.quantity.BareQuantity(1, "m")
     >>> q2 = u.quantity.BareQuantity(1, "m")
     >>> jnp.equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 == q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1, "m")
     >>> q2 = u.Q(1, "m")
     >>> jnp.equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 == q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     """
     xv = ustrip(x)
@@ -2260,11 +2342,11 @@ def erf_inv_p(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(0.5, "")
     >>> lax.erf_inv(q)
-    BareQuantity(Array(0.47693628, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.47693628, dtype=float32...), unit='')
 
     >>> q = u.Q(0.5, "")
     >>> lax.erf_inv(q)
-    Quantity(Array(0.47693628, dtype=float32, ...), unit='')
+    Quantity(Array(0.47693628, dtype=float32...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -2285,11 +2367,11 @@ def erf_p(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(0.5, "")
     >>> lax.erf(q)
-    BareQuantity(Array(0.5204999, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.5204999, dtype=float32...), unit='')
 
     >>> q = u.Q(0.5, "")
     >>> lax.erf(q)
-    Quantity(Array(0.5204999, dtype=float32, ...), unit='')
+    Quantity(Array(0.5204999, dtype=float32...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -2310,11 +2392,11 @@ def erfc_p(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(0.5, "")
     >>> lax.erfc(q)
-    BareQuantity(Array(0.47950017, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.47950017, dtype=float32...), unit='')
 
     >>> q = u.Q(0.5, "")
     >>> lax.erfc(q)
-    Quantity(Array(0.47950017, dtype=float32, ...), unit='')
+    Quantity(Array(0.47950017, dtype=float32...), unit='')
 
     """
     # TODO: can this support non-dimensionless quantities?
@@ -2335,11 +2417,11 @@ def exp2_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(3, "")
     >>> jnp.exp2(q)
-    BareQuantity(Array(8., dtype=float32, ...), unit='')
+    BareQuantity(Array(8., dtype=float32...), unit='')
 
     >>> q = u.Q(3, "")
     >>> jnp.exp2(q)
-    Quantity(Array(8., dtype=float32, ...), unit='')
+    Quantity(Array(8., dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.exp2_p.bind(ustrip(one, x), **kw))
@@ -2359,16 +2441,16 @@ def exp_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.exp(q)
-    BareQuantity(Array(2.7182817, dtype=float32, ...), unit='')
+    BareQuantity(Array(2.7182817, dtype=float32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> jnp.exp(q)
-    Quantity(Array(2.7182817, dtype=float32, ...), unit='')
+    Quantity(Array(2.7182817, dtype=float32...), unit='')
 
     Euler's crown jewel:
 
     >>> jnp.exp(u.Q(jnp.pi * 1j, "")) + 1
-    Quantity(Array(0.-8.742278e-08j, dtype=complex64, ...), unit='')
+    Quantity(Array(0.-8.742278e-08j, dtype=complex64...), unit='')
 
     Pretty close to zero!
 
@@ -2391,11 +2473,11 @@ def expm1_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(0, "")
     >>> jnp.expm1(q)
-    BareQuantity(Array(0., dtype=float32, ...), unit='')
+    BareQuantity(Array(0., dtype=float32...), unit='')
 
     >>> q = u.Q(0, "")
     >>> jnp.expm1(q)
-    Quantity(Array(0., dtype=float32, ...), unit='')
+    Quantity(Array(0., dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.expm1_p.bind(ustrip(one, x), **kw))
@@ -2442,11 +2524,11 @@ def floor_p(x: ABCQ) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(1.5, "")
     >>> jnp.floor(q)
-    BareQuantity(Array(1., dtype=float32, ...), unit='')
+    BareQuantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.Q(1.5, "")
     >>> jnp.floor(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return replace(x, value=qlax.floor(ustrip(x)))
@@ -2479,16 +2561,16 @@ def ge_p_qq(x: ABCQ, y: ABCQ) -> ArrayLike:
     >>> q1 = u.quantity.BareQuantity(1_001.0, "m")
     >>> q2 = u.quantity.BareQuantity(1.0, "km")
     >>> jnp.greater_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 >= q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1_001.0, "m")
     >>> q2 = u.Q(1.0, "km")
     >>> jnp.greater_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 >= q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     """
     xv = ustrip(x)
@@ -2513,11 +2595,11 @@ def ge_p_vq(x: ArrayLike, y: ABCQ, /) -> ArrayLike:
 
     >>> q2 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.greater_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "")
     >>> jnp.greater_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "m")
     >>> try:
@@ -2549,11 +2631,11 @@ def ge_p_qv(x: ABCQ, y: ArrayLike, /) -> ArrayLike:
 
     >>> q1 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.greater_equal(q1, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "")
     >>> jnp.greater_equal(q1, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "m")
     >>> try:
@@ -2586,12 +2668,12 @@ def gt_p_qq(x: ABCQ, y: ABCQ) -> ArrayLike:
     >>> q1 = u.quantity.BareQuantity(1_001.0, "m")
     >>> q2 = u.quantity.BareQuantity(1.0, "km")
     >>> jnp.greater_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1_001.0, "m")
     >>> q2 = u.Q(1.0, "km")
     >>> jnp.greater_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     """
     xv = ustrip(x)
@@ -2618,11 +2700,11 @@ def gt_p_vq(x: ArrayLike, y: ABCQ) -> ArrayLike:
 
     >>> q2 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.greater_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "")
     >>> jnp.greater_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "m")
     >>> try:
@@ -2654,11 +2736,11 @@ def gt_p_qv(x: ABCQ, y: ArrayLike) -> ArrayLike:
 
     >>> q1 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.greater_equal(q1, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "")
     >>> jnp.greater_equal(q1, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "m")
     >>> try:
@@ -2692,16 +2774,16 @@ def igamma_p(a: float | int | ABCQ, x: ABCQ) -> ABCQ:
 
     >>> x = u.quantity.BareQuantity(1.0, "")
     >>> lax.igamma(1.0, x)
-    BareQuantity(Array(0.6321202, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.6321202, dtype=float32...), unit='')
 
     >>> a = u.quantity.BareQuantity(1.0, "")
     >>> lax.igamma(a, x)
-    BareQuantity(Array(0.6321202, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.6321202, dtype=float32...), unit='')
 
     >>> a = u.Q(1.0, "")
     >>> x = u.Q(1.0, "")
     >>> lax.igamma(a, x)
-    Quantity(Array(0.6321202, dtype=float32, ...), unit='')
+    Quantity(Array(0.6321202, dtype=float32...), unit='')
 
     """
     return replace(x, value=qlax.igamma(ustrip(AllowValue, one, a), ustrip(one, x)))
@@ -2721,16 +2803,16 @@ def igammac_p(a: float | int | ABCQ, x: ABCQ) -> ABCQ:
 
     >>> x = u.quantity.BareQuantity(1.0, "")
     >>> qlax.igammac(1.0, x)
-    BareQuantity(Array(0.36787927, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.36787927, dtype=float32...), unit='')
 
     >>> a = u.quantity.BareQuantity(1.0, "")
     >>> qlax.igammac(a, x)
-    BareQuantity(Array(0.36787927, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.36787927, dtype=float32...), unit='')
 
     >>> a = u.Q(1.0, "")
     >>> x = u.Q(1.0, "")
     >>> qlax.igammac(a, x)
-    Quantity(Array(0.36787927, dtype=float32, ...), unit='')
+    Quantity(Array(0.36787927, dtype=float32...), unit='')
 
     """
     return replace(x, value=qlax.igammac(ustrip(AllowValue, one, a), ustrip(one, x)))
@@ -2756,11 +2838,11 @@ def integer_pow_p(x: ABCQ, *, y: Any) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(2, "m")
     >>> q**3
-    BareQuantity(Array(8, dtype=int32, ...), unit='m3')
+    BareQuantity(Array(8, dtype=int32...), unit='m3')
 
     >>> q = u.Q(2, "m")
     >>> q**3
-    Quantity(Array(8, dtype=int32, ...), unit='m3')
+    Quantity(Array(8, dtype=int32...), unit='m3')
 
     >>> q = u.StaticQuantity(2, "m")
     >>> q**3
@@ -2784,7 +2866,7 @@ def integer_pow_p_abstractangle(x: AbstractAngle, /, *, y: Any) -> ABCQ:
     >>> q = u.Angle(2, "deg")
 
     >>> q**3
-    Quantity(Array(8, dtype=int32, ...), unit='deg3')
+    Quantity(Array(8, dtype=int32...), unit='deg3')
 
     """
     return integer_pow_p(convert(x, Quantity), y=y)
@@ -2836,12 +2918,12 @@ def le_p_qq(x: ABCQ, y: ABCQ, /) -> ArrayLike:
     >>> q1 = u.quantity.BareQuantity(1_001.0, "m")
     >>> q2 = u.quantity.BareQuantity(1.0, "km")
     >>> jnp.less_equal(q1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q1 = u.Q(1_001.0, "m")
     >>> q2 = u.Q(1.0, "km")
     >>> jnp.less_equal(q1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     """
     xv = ustrip(x)
@@ -2866,11 +2948,11 @@ def le_p_vq(x: ArrayLike, y: ABCQ, /) -> ArrayLike:
 
     >>> q2 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.less_equal(x1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "")
     >>> jnp.less_equal(x1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q2 = u.Q(1.0, "m")
     >>> try:
@@ -2902,11 +2984,11 @@ def le_p_qv(x: ABCQ, y: ArrayLike, /) -> ArrayLike:
 
     >>> q1 = u.quantity.BareQuantity(1.0, "")
     >>> jnp.less_equal(q1, y1)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "")
     >>> jnp.less_equal(q1, y1)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q1 = u.Q(1.0, "m")
     >>> try:
@@ -2938,11 +3020,11 @@ def lgamma_p(x: ABCQ) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(3, "")
     >>> jsp.special.gammaln(q)
-    BareQuantity(Array(0.6931474, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.6931474, dtype=float32...), unit='')
 
     >>> q = u.Q(3, "")
     >>> jsp.special.gammaln(q)
-    Quantity(Array(0.6931474, dtype=float32, ...), unit='')
+    Quantity(Array(0.6931474, dtype=float32...), unit='')
 
     """
     # TODO: are there any units that this can support?
@@ -2963,11 +3045,11 @@ def log1p_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(-1, "")
     >>> jnp.log1p(q)
-    BareQuantity(Array(-inf, dtype=float32, ...), unit='')
+    BareQuantity(Array(-inf, dtype=float32...), unit='')
 
     >>> q = u.Q(-1, "")
     >>> jnp.log1p(q)
-    Quantity(Array(-inf, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(-inf, dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.log1p_p.bind(ustrip(one, x), **kw))
@@ -2987,11 +3069,11 @@ def log_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> jnp.log(q)
-    BareQuantity(Array(0., dtype=float32, ...), unit='')
+    BareQuantity(Array(0., dtype=float32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> jnp.log(q)
-    Quantity(Array(0., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0., dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.log_p.bind(ustrip(one, x), **kw))
@@ -3011,11 +3093,11 @@ def logistic_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1.0, "")
     >>> qlax.logistic(q)
-    BareQuantity(Array(0.7310586, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.7310586, dtype=float32...), unit='')
 
     >>> q = u.Q(1.0, "")
     >>> qlax.logistic(q)
-    Quantity(Array(0.7310586, dtype=float32, ...), unit='')
+    Quantity(Array(0.7310586, dtype=float32...), unit='')
 
     """
     return replace(x, value=lax.logistic_p.bind(ustrip(one, x), **kw))
@@ -3038,10 +3120,10 @@ def lt_p_qq(x: ABCQ, y: ABCQ, /) -> ArrayLike:
     >>> x = u.quantity.BareQuantity(1.0, "km")
     >>> y = u.quantity.BareQuantity(2000.0, "m")
     >>> x < y
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> jnp.less(x, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> x = u.quantity.BareQuantity([1.0, 2, 3], "km")
     >>> x < y
@@ -3055,10 +3137,10 @@ def lt_p_qq(x: ABCQ, y: ABCQ, /) -> ArrayLike:
     >>> x = u.Q(1.0, "km")
     >>> y = u.Q(2000.0, "m")
     >>> x < y
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> jnp.less(x, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> x = u.Q([1.0, 2, 3], "km")
     >>> x < y
@@ -3152,10 +3234,10 @@ def lt_p_qv(x: ABCQ, y: ArrayLike, /) -> ArrayLike:
     >>> x = u.quantity.BareQuantity(1, "")
     >>> y = 2
     >>> x < y
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> jnp.less(x, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> x = u.quantity.BareQuantity([1, 2, 3], "")
     >>> x < y
@@ -3169,10 +3251,10 @@ def lt_p_qv(x: ABCQ, y: ArrayLike, /) -> ArrayLike:
     >>> x = u.Q(1, "")
     >>> y = 2
     >>> x < y
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> jnp.less(x, y)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> x = u.Q([1, 2, 3], "")
     >>> x < y
@@ -3238,12 +3320,12 @@ def max_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "m")
     >>> q2 = u.quantity.BareQuantity(2, "m")
     >>> jnp.maximum(q1, q2)
-    BareQuantity(Array(2, dtype=int32, ...), unit='m')
+    BareQuantity(Array(2, dtype=int32...), unit='m')
 
     >>> q1 = u.Q(1, "m")
     >>> q2 = u.Q(2, "m")
     >>> jnp.maximum(q1, q2)
-    Quantity(Array(2, dtype=int32, ...), unit='m')
+    Quantity(Array(2, dtype=int32...), unit='m')
 
     """
     yv = ustrip(x.unit, y)
@@ -3404,17 +3486,17 @@ def mul_p_qq(x: ABCQ, y: ABCQ, /, **kw: Any) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(2, "m")
     >>> q2 = u.quantity.BareQuantity(3, "m")
     >>> jnp.multiply(q1, q2)
-    BareQuantity(Array(6, dtype=int32, ...), unit='m2')
+    BareQuantity(Array(6, dtype=int32...), unit='m2')
 
     >>> q1 = u.Q(2, "m")
     >>> q2 = u.Q(3, "m")
     >>> jnp.multiply(q1, q2)
-    Quantity(Array(6, dtype=int32, ...), unit='m2')
+    Quantity(Array(6, dtype=int32...), unit='m2')
 
     >>> q1 = u.quantity.BareQuantity(2, "m")
     >>> q2 = u.Q(3, "m")
     >>> jnp.multiply(q1, q2)
-    Quantity(Array(6, dtype=int32, weak_type=True), unit='m2')
+    Quantity(Array(6, dtype=int32...), unit='m2')
 
     """
     # Promote to a common type
@@ -3436,10 +3518,10 @@ def mul_p_vq(x: ArrayLike, y: ABCQ, /, **kw: Any) -> ABCQ:
     >>> q = u.quantity.BareQuantity(2, "m")
 
     >>> 2.0 * q
-    BareQuantity(Array(4., dtype=float32, ...), unit='m')
+    BareQuantity(Array(4., dtype=float32...), unit='m')
 
     >>> jnp.asarray(2) * q
-    BareQuantity(Array(4, dtype=int32, ...), unit='m')
+    BareQuantity(Array(4, dtype=int32...), unit='m')
 
     >>> jnp.asarray([2, 3]) * q
     BareQuantity(Array([4, 6], dtype=int32), unit='m')
@@ -3447,10 +3529,10 @@ def mul_p_vq(x: ArrayLike, y: ABCQ, /, **kw: Any) -> ABCQ:
     >>> q = u.Q(2, "m")
 
     >>> 2.0 * q
-    Quantity(Array(4., dtype=float32, ...), unit='m')
+    Quantity(Array(4., dtype=float32...), unit='m')
 
     >>> jnp.asarray(2) * q
-    Quantity(Array(4, dtype=int32, ...), unit='m')
+    Quantity(Array(4, dtype=int32...), unit='m')
 
     >>> jnp.asarray([2, 3]) * q
     Quantity(Array([4, 6], dtype=int32), unit='m')
@@ -3471,10 +3553,10 @@ def mul_p_qv(x: ABCQ, y: ArrayLike, /, **kw: Any) -> ABCQ:
     >>> q = u.quantity.BareQuantity(2, "m")
 
     >>> q * 2.0
-    BareQuantity(Array(4., dtype=float32, ...), unit='m')
+    BareQuantity(Array(4., dtype=float32...), unit='m')
 
     >>> q * jnp.asarray(2)
-    BareQuantity(Array(4, dtype=int32, ...), unit='m')
+    BareQuantity(Array(4, dtype=int32...), unit='m')
 
     >>> q * jnp.asarray([2, 3])
     BareQuantity(Array([4, 6], dtype=int32), unit='m')
@@ -3482,10 +3564,10 @@ def mul_p_qv(x: ABCQ, y: ArrayLike, /, **kw: Any) -> ABCQ:
     >>> q = u.Q(2, "m")
 
     >>> q * 2.0
-    Quantity(Array(4., dtype=float32, ...), unit='m')
+    Quantity(Array(4., dtype=float32...), unit='m')
 
     >>> q * jnp.asarray(2)
-    Quantity(Array(4, dtype=int32, weak_type=True), unit='m')
+    Quantity(Array(4, dtype=int32...), unit='m')
 
     >>> q * jnp.asarray([2, 3])
     Quantity(Array([4, 6], dtype=int32), unit='m')
@@ -3530,28 +3612,28 @@ def ne_p_qq(x: ABCQ, y: ABCQ, /) -> ArrayLike:
     >>> q1 = u.quantity.BareQuantity(1, "m")
     >>> q2 = u.quantity.BareQuantity(2, "m")
     >>> jnp.not_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 != q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.quantity.BareQuantity(1, "m")
     >>> jnp.not_equal(q1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> q1 != q2
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> q1 = u.Q(1, "m")
     >>> q2 = u.Q(2, "m")
     >>> jnp.not_equal(q1, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 != q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1, "m")
     >>> jnp.not_equal(q1, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> q1 != q2
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     """
     if not is_unit_convertible(x.unit, y.unit):
@@ -3572,28 +3654,28 @@ def ne_p_vq(x: ArrayLike, y: ABCQ, /) -> ArrayLike:
     >>> x = 1
     >>> q2 = u.quantity.BareQuantity(2, "")
     >>> jnp.not_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> x != q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.quantity.BareQuantity(1, "")
     >>> jnp.not_equal(x, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> x != q2
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> x = u.Q(1, "")
     >>> q2 = u.Q(2, "")
     >>> jnp.not_equal(x, q2)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> x != q2
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q2 = u.Q(1, "")
     >>> jnp.not_equal(x, q2)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> x != q2
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     """
     yv = ustrip(y)
@@ -3617,28 +3699,28 @@ def ne_p_qv(x: ABCQ, y: ArrayLike, /) -> ArrayLike:
     >>> x = 1
     >>> q1 = u.quantity.BareQuantity(2, "")
     >>> jnp.not_equal(q1, x)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 != x
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.quantity.BareQuantity(1, "")
     >>> jnp.not_equal(q1, x)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> q1 != x
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     >>> x = u.Q(1, "")
     >>> q1 = u.Q(2, "")
     >>> jnp.not_equal(q1, x)
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
     >>> q1 != x
-    Array(True, dtype=bool, ...)
+    Array(True, dtype=bool...)
 
     >>> q1 = u.Q(1, "")
     >>> jnp.not_equal(q1, x)
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
     >>> q1 != x
-    Array(False, dtype=bool, ...)
+    Array(False, dtype=bool...)
 
     """
     xv = ustrip(x)
@@ -3668,11 +3750,11 @@ def neg_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "m")
     >>> -q
-    BareQuantity(Array(-1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(-1, dtype=int32...), unit='m')
 
     >>> q = u.Q(1, "m")
     >>> -q
-    Quantity(Array(-1, dtype=int32, weak_type=True), unit='m')
+    Quantity(Array(-1, dtype=int32...), unit='m')
 
     """
     return replace(x, value=qlax.neg(ustrip(x)))
@@ -3692,12 +3774,12 @@ def nextafter_p(x1: ABCQ, x2: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "")
     >>> q2 = u.quantity.BareQuantity(2, "")
     >>> jnp.nextafter(q1, q2)
-    BareQuantity(Array(1.0000001, dtype=float32, ...), unit='')
+    BareQuantity(Array(1.0000001, dtype=float32...), unit='')
 
     >>> q1 = u.Q(1, "")
     >>> q2 = u.Q(2, "")
     >>> jnp.nextafter(q1, q2)
-    Quantity(Array(1.0000001, dtype=float32, ...), unit='')
+    Quantity(Array(1.0000001, dtype=float32...), unit='')
 
     """
     u = unit_of(x1)
@@ -3717,11 +3799,11 @@ def not_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> ~q
-    BareQuantity(Array(-2, dtype=int32, weak_type=True), unit='')
+    BareQuantity(Array(-2, dtype=int32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> ~q
-    Quantity(Array(-2, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(-2, dtype=int32...), unit='')
 
     """
     return replace(x, value=qlax.bitwise_not(ustrip(one, x)))
@@ -3741,12 +3823,12 @@ def or_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "")
     >>> q2 = u.quantity.BareQuantity(2, "")
     >>> jnp.bitwise_or(q1, q2)
-    BareQuantity(Array(3, dtype=int32, ...), unit='')
+    BareQuantity(Array(3, dtype=int32...), unit='')
 
     >>> q1 = u.Q(1, "")
     >>> q2 = u.Q(2, "")
     >>> jnp.bitwise_or(q1, q2)
-    Quantity(Array(3, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(3, dtype=int32...), unit='')
 
     """
     return replace(x, value=qlax.bitwise_or(ustrip(one, x), ustrip(one, y)))
@@ -3852,11 +3934,11 @@ def polygamma_p(m: ArrayLike, x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(3.0, "")
     >>> qlax.polygamma(1.0, q)
-    BareQuantity(Array(0.39493403, dtype=float32, ...), unit='')
+    BareQuantity(Array(0.39493403, dtype=float32...), unit='')
 
     >>> q = u.Q(3.0, "")
     >>> qlax.polygamma(1.0, q)
-    Quantity(Array(0.39493403, dtype=float32, ...), unit='')
+    Quantity(Array(0.39493403, dtype=float32...), unit='')
 
     """
     return replace(x, value=qlax.polygamma(m, ustrip(one, x)))
@@ -3875,11 +3957,11 @@ def population_count_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(3, "")
     >>> qlax.population_count(q)
-    BareQuantity(Array(2, dtype=int32, ...), unit='')
+    BareQuantity(Array(2, dtype=int32...), unit='')
 
     >>> q = u.Q(3, "")
     >>> qlax.population_count(q)
-    Quantity(Array(2, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(2, dtype=int32...), unit='')
 
     """
     return replace(x, value=lax.population_count(ustrip(one, x)))
@@ -3900,15 +3982,15 @@ def pow_p_qq(x: ABCQ, y: ABCPQ["dimensionless"], /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(2.0, "m")
     >>> p = u.Q(3, "")
     >>> jnp.power(q1, p)
-    BareQuantity(Array(8., dtype=float32, ...), unit='m3')
+    BareQuantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**p
-    BareQuantity(Array(8., dtype=float32, ...), unit='m3')
+    BareQuantity(Array(8., dtype=float32...), unit='m3')
 
     >>> q1 = u.Q(2.0, "m")
     >>> jnp.power(q1, p)
-    Quantity(Array(8., dtype=float32, ...), unit='m3')
+    Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**p
-    Quantity(Array(8., dtype=float32, ...), unit='m3')
+    Quantity(Array(8., dtype=float32...), unit='m3')
 
     Non-scalar exponents raise a ValueError:
 
@@ -3940,15 +4022,15 @@ def pow_p_qf(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(2.0, "m")
     >>> y = jnp.array(3)
     >>> jnp.power(q1, y)
-    BareQuantity(Array(8., dtype=float32, weak_type=True), unit='m3')
+    BareQuantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**y
-    BareQuantity(Array(8., dtype=float32, weak_type=True), unit='m3')
+    BareQuantity(Array(8., dtype=float32...), unit='m3')
 
     >>> q1 = u.Q(2.0, "m")
     >>> jnp.power(q1, y)
-    Quantity(Array(8., dtype=float32, weak_type=True), unit='m3')
+    Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**y
-    Quantity(Array(8., dtype=float32, weak_type=True), unit='m3')
+    Quantity(Array(8., dtype=float32...), unit='m3')
 
     """
     return type_np(x)(value=qlax.pow(ustrip(x), y), unit=x.unit**y)
@@ -3984,7 +4066,7 @@ def pow_p_abstractangle_arraylike(x: AbstractAngle, y: ArrayLike, /) -> ABCQ:
     >>> q1 = u.Angle(10.0, "deg")
     >>> y = 3.0
     >>> q1**y
-    Quantity(Array(1000., dtype=float32, ...), unit='deg3')
+    Quantity(Array(1000., dtype=float32...), unit='deg3')
 
     """
     return pow_p_qf(convert(x, Quantity), y)
@@ -4003,16 +4085,16 @@ def real_p(x: ABCQ, /) -> ABCQ:
     >>> import unxt as u
 
     >>> jnp.real(u.quantity.BareQuantity(1.0, "m"))
-    BareQuantity(Array(1., dtype=float32, ...), unit='m')
+    BareQuantity(Array(1., dtype=float32...), unit='m')
 
     >>> jnp.real(u.quantity.BareQuantity(1 + 2j, "m"))
-    BareQuantity(Array(1., dtype=float32, ...), unit='m')
+    BareQuantity(Array(1., dtype=float32...), unit='m')
 
     >>> jnp.real(u.Q(1.0, "m"))
-    Quantity(Array(1., dtype=float32, ...), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     >>> jnp.real(u.Q(1 + 2j, "m"))
-    Quantity(Array(1., dtype=float32, weak_type=True), unit='m')
+    Quantity(Array(1., dtype=float32...), unit='m')
 
     """
     return replace(x, value=qlax.real(ustrip(x)))
@@ -4086,12 +4168,12 @@ def regularized_incomplete_beta_q(
     >>> b = u.quantity.BareQuantity(3.0, "")
     >>> x = 0.5
     >>> jsp.betainc(a, b, x).round(7)
-    Array(0.6874998, dtype=float32, weak_type=True)
+    Array(0.6874998, dtype=float32...)
 
     >>> a = u.Q(2.0, "")
     >>> b = u.Q(3.0, "")
     >>> jsp.betainc(a, b, x).round(7)
-    Array(0.6874998, dtype=float32, weak_type=True)
+    Array(0.6874998, dtype=float32...)
 
     """
     a = ustrip(AllowValue, one, a)
@@ -4114,11 +4196,11 @@ def regularized_incomplete_beta_q(
     >>> b = 3.0
     >>> x = u.quantity.BareQuantity(0.5, "")
     >>> jsp.betainc(a, b, x).round(7)
-    BareQuantity(Array(0.6874998, dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(0.6874998, dtype=float32...), unit='')
 
     >>> x = u.Q(0.5, "")
     >>> jsp.betainc(a, b, x).round(7)
-    Quantity(Array(0.6874998, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.6874998, dtype=float32...), unit='')
 
     >>> x = u.Q(0.5, "m")
     >>> try:
@@ -4165,12 +4247,12 @@ def rem_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(10, "m")
     >>> q2 = u.quantity.BareQuantity(3, "m")
     >>> q1 % q2
-    BareQuantity(Array(1, dtype=int32, ...), unit='m')
+    BareQuantity(Array(1, dtype=int32...), unit='m')
 
     >>> q1 = u.Q(10, "m")
     >>> q2 = u.Q(3, "m")
     >>> q1 % q2
-    Quantity(Array(1, dtype=int32, ...), unit='m')
+    Quantity(Array(1, dtype=int32...), unit='m')
 
     """
     x, y = promote(x, y)
@@ -4192,7 +4274,7 @@ def rem_p_uqv(
     >>> q1 = u.Q(10, "")
     >>> q2 = jnp.array(3)
     >>> q1 % q2
-    Quantity(Array(1, dtype=int32, ...), unit='')
+    Quantity(Array(1, dtype=int32...), unit='')
 
     """
     return replace(x, value=ustrip(x) % y)
@@ -4264,11 +4346,11 @@ def round_p(x: ABCQ, /, *, rounding_method: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1.234, "m")
     >>> jnp.round(q, 2)
-    BareQuantity(Array(1.23, dtype=float32, ...), unit='m')
+    BareQuantity(Array(1.23, dtype=float32...), unit='m')
 
     >>> q = u.Q(1.234, "m")
     >>> jnp.round(q, 2)
-    Quantity(Array(1.23, dtype=float32, ...), unit='m')
+    Quantity(Array(1.23, dtype=float32...), unit='m')
 
     """
     return replace(x, value=qlax.round(ustrip(x), rounding_method))
@@ -4288,11 +4370,11 @@ def rsqrt_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1 / 4, "m")
     >>> qlax.rsqrt(q)
-    BareQuantity(Array(2., dtype=float32, ...), unit='1 / m(1/2)')
+    BareQuantity(Array(2., dtype=float32...), unit='1 / m(1/2)')
 
     >>> q = u.Q(1 / 4, "m")
     >>> qlax.rsqrt(q)
-    Quantity(Array(2., dtype=float32, ...), unit='1 / m(1/2)')
+    Quantity(Array(2., dtype=float32...), unit='1 / m(1/2)')
 
     """
     return type_np(x)(lax.rsqrt_p.bind(ustrip(x), **kw), unit=x.unit ** (-1 / 2))
@@ -4550,11 +4632,11 @@ def shift_right_arithmetic_p(x: ABCQ, y: ABCQ | float | int, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> qlax.shift_right_arithmetic(q, 2)
-    BareQuantity(Array(0, dtype=int32, ...), unit='')
+    BareQuantity(Array(0, dtype=int32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> qlax.shift_right_arithmetic(q, 2)
-    Quantity(Array(0, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(0, dtype=int32...), unit='')
 
     """
     return replace(
@@ -4575,11 +4657,11 @@ def sign_p(x: ABCQ, /) -> ArrayLike:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(10, "m")
     >>> jnp.sign(q)
-    Array(1, dtype=int32, ...)
+    Array(1, dtype=int32...)
 
     >>> q = u.Q(10, "m")
     >>> jnp.sign(q)
-    Array(1, dtype=int32, ...)
+    Array(1, dtype=int32...)
 
     """
     return lax.sign(ustrip(x))
@@ -4599,19 +4681,19 @@ def sin_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(90, "deg")
     >>> jnp.sin(q)
-    BareQuantity(Array(1., dtype=float32, ...), unit='')
+    BareQuantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(jnp.pi / 2, "")
     >>> jnp.sin(q)
-    BareQuantity(Array(1., dtype=float32, ...), unit='')
+    BareQuantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.Q(90, "deg")
     >>> jnp.sin(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.Q(jnp.pi / 2, "")
     >>> jnp.sin(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.sin_p.bind(_to_val_rad_or_one(x), **kw), unit=one)
@@ -4628,7 +4710,7 @@ def sin_p_abstractangle(x: AbstractAngle, /, **kw: Any) -> ABCQ:
 
     >>> q = u.Angle(90, "deg")
     >>> jnp.sin(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return sin_p(convert(x, Quantity), **kw)
@@ -4648,19 +4730,19 @@ def sinh_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(90, "deg")
     >>> jnp.sinh(q)
-    BareQuantity(Array(2.301299, dtype=float32, ...), unit='')
+    BareQuantity(Array(2.301299, dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(jnp.pi / 2, "")
     >>> jnp.sinh(q)
-    BareQuantity(Array(2.301299, dtype=float32, ...), unit='')
+    BareQuantity(Array(2.301299, dtype=float32...), unit='')
 
     >>> q = u.Q(90, "deg")
     >>> jnp.sinh(q)
-    Quantity(Array(2.301299, dtype=float32, ...), unit='')
+    Quantity(Array(2.301299, dtype=float32...), unit='')
 
     >>> q = u.Q(jnp.pi / 2, "")
     >>> jnp.sinh(q)
-    Quantity(Array(2.301299, dtype=float32, ...), unit='')
+    Quantity(Array(2.301299, dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.sinh(_to_val_rad_or_one(x)), unit=one)
@@ -4680,11 +4762,11 @@ def shift_left_p(x: ABCQ, y: ABCQ | float | int, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1, "")
     >>> qlax.shift_left(q, 2)
-    BareQuantity(Array(4, dtype=int32, ...), unit='')
+    BareQuantity(Array(4, dtype=int32...), unit='')
 
     >>> q = u.Q(1, "")
     >>> qlax.shift_left(q, 2)
-    Quantity(Array(4, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(4, dtype=int32...), unit='')
 
     """
     return replace(x, value=qlax.shift_left(ustrip(x), ustrip(AllowValue, one, y)))
@@ -4766,11 +4848,11 @@ def square_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(3, "m")
     >>> jnp.square(q)
-    BareQuantity(Array(9, dtype=int32, ...), unit='m2')
+    BareQuantity(Array(9, dtype=int32...), unit='m2')
 
     >>> q = u.Q(3, "m")
     >>> jnp.square(q)
-    Quantity(Array(9, dtype=int32, ...), unit='m2')
+    Quantity(Array(9, dtype=int32...), unit='m2')
 
     """
     return type_np(x)(lax.square(ustrip(x)), unit=x.unit**2)
@@ -4789,11 +4871,11 @@ def sqrt_p_q(x: ABCQ, /, **kw: Any) -> ABCQ:
     >>> import unxt as u
     >>> q = u.quantity.BareQuantity(9, "m")
     >>> jnp.sqrt(q)
-    BareQuantity(Array(3., dtype=float32, ...), unit='m(1/2)')
+    BareQuantity(Array(3., dtype=float32...), unit='m(1/2)')
 
     >>> q = u.Q(9, "m")
     >>> jnp.sqrt(q)
-    Quantity(Array(3., dtype=float32, ...), unit='m(1/2)')
+    Quantity(Array(3., dtype=float32...), unit='m(1/2)')
 
     """
     # Apply sqrt to the value and adjust the unit
@@ -4811,7 +4893,7 @@ def sqrt_p_abstractangle(x: AbstractAngle, /, **kw: Any) -> ABCQ:
 
     >>> q = u.Angle(9, "deg")
     >>> jnp.sqrt(q)
-    Quantity(Array(3., dtype=float32, ...), unit='deg(1/2)')
+    Quantity(Array(3., dtype=float32...), unit='deg(1/2)')
 
     """
     return sqrt_p_q(convert(x, Quantity), **kw)
@@ -4855,7 +4937,7 @@ def stop_gradient_p(x: ABCQ, /) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(1.0, "m")
     >>> qlax.stop_gradient(q)
-    BareQuantity(Array(1., dtype=float32, ...), unit='m')
+    BareQuantity(Array(1., dtype=float32...), unit='m')
 
     """
     return replace(x, value=qlax.stop_gradient(ustrip(x)))
@@ -4877,16 +4959,16 @@ def sub_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1.0, "km")
     >>> q2 = u.quantity.BareQuantity(500.0, "m")
     >>> jnp.subtract(q1, q2)
-    BareQuantity(Array(0.5, dtype=float32, ...), unit='km')
+    BareQuantity(Array(0.5, dtype=float32...), unit='km')
     >>> q1 - q2
-    BareQuantity(Array(0.5, dtype=float32, ...), unit='km')
+    BareQuantity(Array(0.5, dtype=float32...), unit='km')
 
     >>> q1 = u.Q(1.0, "km")
     >>> q2 = u.Q(500.0, "m")
     >>> jnp.subtract(q1, q2)
-    Quantity(Array(0.5, dtype=float32, ...), unit='km')
+    Quantity(Array(0.5, dtype=float32...), unit='km')
     >>> q1 - q2
-    Quantity(Array(0.5, dtype=float32, ...), unit='km')
+    Quantity(Array(0.5, dtype=float32...), unit='km')
 
     """
     x, y = promote(x, y)
@@ -4911,17 +4993,17 @@ def sub_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
     >>> x = 1_000
     >>> q = u.quantity.BareQuantity(500.0, "")
     >>> jnp.subtract(x, q)
-    BareQuantity(Array(500., dtype=float32, ...), unit='')
+    BareQuantity(Array(500., dtype=float32...), unit='')
 
     >>> x - q
-    BareQuantity(Array(500., dtype=float32, ...), unit='')
+    BareQuantity(Array(500., dtype=float32...), unit='')
 
     >>> q = u.Q(500.0, "")
     >>> jnp.subtract(x, q)
-    Quantity(Array(500., dtype=float32, ...), unit='')
+    Quantity(Array(500., dtype=float32...), unit='')
 
     >>> x - q
-    Quantity(Array(500., dtype=float32, ...), unit='')
+    Quantity(Array(500., dtype=float32...), unit='')
 
     """
     y = uconvert(one, y)
@@ -4940,17 +5022,17 @@ def sub_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> q = u.quantity.BareQuantity(500.0, "")
     >>> y = 1_000
     >>> jnp.subtract(q, y)
-    BareQuantity(Array(-500., dtype=float32, ...), unit='')
+    BareQuantity(Array(-500., dtype=float32...), unit='')
 
     >>> q - y
-    BareQuantity(Array(-500., dtype=float32, ...), unit='')
+    BareQuantity(Array(-500., dtype=float32...), unit='')
 
     >>> q = u.Q(500.0, "")
     >>> jnp.subtract(q, y)
-    Quantity(Array(-500., dtype=float32, ...), unit='')
+    Quantity(Array(-500., dtype=float32...), unit='')
 
     >>> q - y
-    Quantity(Array(-500., dtype=float32, ...), unit='')
+    Quantity(Array(-500., dtype=float32...), unit='')
 
     """
     x = uconvert(one, x)
@@ -4971,19 +5053,19 @@ def tan_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(45, "deg")
     >>> jnp.tan(q)
-    BareQuantity(Array(1., dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(jnp.pi / 4, "")
     >>> jnp.tan(q)
-    BareQuantity(Array(1., dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.Q(45, "deg")
     >>> jnp.tan(q)
-    Quantity(Array(1., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     >>> q = u.Q(jnp.pi / 4, "")
     >>> jnp.tan(q)
-    Quantity(Array(1., dtype=float32, weak_type=True), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.tan_p.bind(_to_val_rad_or_one(x), **kw), unit=one)
@@ -5000,7 +5082,7 @@ def tan_p_abstractangle(x: AbstractAngle, /, **kw: Any) -> ABCQ:
 
     >>> q = u.Angle(45, "deg")
     >>> jnp.tan(q)
-    Quantity(Array(1., dtype=float32, ...), unit='')
+    Quantity(Array(1., dtype=float32...), unit='')
 
     """
     return tan_p(convert(x, Quantity), **kw)
@@ -5020,19 +5102,19 @@ def tanh_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
     >>> q = u.quantity.BareQuantity(45, "deg")
     >>> jnp.tanh(q)
-    BareQuantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(0.65579426, dtype=float32...), unit='')
 
     >>> q = u.quantity.BareQuantity(jnp.pi / 4, "")
     >>> jnp.tanh(q)
-    BareQuantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    BareQuantity(Array(0.65579426, dtype=float32...), unit='')
 
     >>> q = u.Q(45, "deg")
     >>> jnp.tanh(q)
-    Quantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.65579426, dtype=float32...), unit='')
 
     >>> q = u.Q(jnp.pi / 4, "")
     >>> jnp.tanh(q)
-    Quantity(Array(0.65579426, dtype=float32, weak_type=True), unit='')
+    Quantity(Array(0.65579426, dtype=float32...), unit='')
 
     """
     return type_np(x)(lax.tanh_p.bind(_to_val_rad_or_one(x), **kw), unit=one)
@@ -5107,12 +5189,12 @@ def xor_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     >>> q1 = u.quantity.BareQuantity(1, "")
     >>> q2 = u.quantity.BareQuantity(2, "")
     >>> jnp.bitwise_xor(q1, q2)
-    BareQuantity(Array(3, dtype=int32, ...), unit='')
+    BareQuantity(Array(3, dtype=int32...), unit='')
 
     >>> q1 = u.Q(1, "")
     >>> q2 = u.Q(2, "")
     >>> jnp.bitwise_xor(q1, q2)
-    Quantity(Array(3, dtype=int32, weak_type=True), unit='')
+    Quantity(Array(3, dtype=int32...), unit='')
 
     """
     return replace(x, value=qlax.bitwise_xor(ustrip(one, x), ustrip(one, y)))
@@ -5123,4 +5205,22 @@ def xor_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
 
 @quax.register(lax.zeta_p)
 def zeta_p(x: ABCQ, q: ArrayLike, /) -> ABCQ:
+    """Hurwitz zeta function of a quantity.
+
+    Computes the Hurwitz zeta function ζ(x, q) = Σ(k=0 to ∞) 1/(q+k)^x.
+
+    Examples
+    --------
+    >>> import quaxed.lax as qlax
+    >>> import unxt as u
+
+    >>> x = u.quantity.BareQuantity(2.0, "")
+    >>> qlax.zeta(x, 1.0).round(4)
+    BareQuantity(Array(1.6449, dtype=float32...), unit='')
+
+    >>> x = u.Q(2.0, "")
+    >>> qlax.zeta(x, 1.0).round(4)
+    Quantity(Array(1.6449, dtype=float32...), unit='')
+
+    """
     return replace(x, value=lax.zeta_p.bind(ustrip(x), q))

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -9,11 +9,11 @@ from typing_extensions import override
 
 import jax
 import numpy as np
+import plum
 import quax
 import wadler_lindig as wl
 from jaxtyping import Array, ArrayLike
 from numpy.typing import NDArray
-from plum import dispatch
 
 import quaxed.numpy as jnp
 
@@ -82,12 +82,20 @@ class StaticValue:
 
     @property
     def _jnparray(self) -> Array:
-        """Return the contained array as a JAX array."""
-        return jnp.asarray(self._array)
+        """Return the contained array as a JAX array.
+
+        JAX 0.7.2+ introduces TypedNdArray for type-preserving operations.
+        These are not jax.Array instances but carry dtype information.
+        We need to explicitly convert them to proper arrays while preserving dtype.
+        """
+        out = jnp.asarray(self._array)
+        if not isinstance(out, jax.Array):
+            out = jnp.asarray(out, dtype=out.dtype)
+        return out
 
     # Constructor
     @classmethod
-    @dispatch.abstract
+    @plum.dispatch.abstract
     def from_(cls: type["StaticValue"], *args: Any, **kwargs: Any) -> "StaticValue":
         """Create a `StaticValue` from given arguments."""
         raise NotImplementedError  # pragma: no cover
@@ -266,19 +274,19 @@ def from_(cls: type[StaticValue], value: jax.Array | jax.core.Tracer, /) -> Stat
 # Converters for quantity value field
 
 
-@dispatch.abstract
+@plum.dispatch.abstract
 def convert_to_quantity_value(obj: Any, /) -> Any:
     """Convert for the value field of an `AbstractQuantity` subclass."""
     raise NotImplementedError  # pragma: no cover
 
 
-@dispatch
+@plum.dispatch
 def convert_to_quantity_value(obj: StaticValue, /) -> StaticValue:
     """Allow static values in `Quantity`-like classes."""
     return obj
 
 
-@dispatch
+@plum.dispatch
 def convert_to_quantity_value(obj: quax.ArrayValue, /) -> Any:
     """Convert a `quax.ArrayValue` for the value field.
 
@@ -315,7 +323,7 @@ def convert_to_quantity_value(obj: quax.ArrayValue, /) -> Any:
     return obj
 
 
-@dispatch
+@plum.dispatch
 def convert_to_quantity_value(obj: ArrayLike | list[Any] | tuple[Any, ...], /) -> Array:
     """Convert an array-like object to a `jax.numpy.ndarray`.
 
@@ -326,4 +334,13 @@ def convert_to_quantity_value(obj: ArrayLike | list[Any] | tuple[Any, ...], /) -
     Array([1, 2, 3], dtype=int32)
 
     """
-    return jnp.asarray(obj)
+    out = jnp.asarray(obj)
+
+    # JAX 0.7.2+ introduces TypedInt, TypedFloat, TypedComplex for
+    # type-preserving operations. These are not jax.Array instances but carry
+    # dtype information. We need to explicitly convert them to proper arrays
+    # while preserving dtype.
+    if not isinstance(out, jax.Array):
+        out = jnp.asarray(out, dtype=out.dtype)
+
+    return out

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -31,7 +31,7 @@ correctness.
 
 >>> distance = u.Quantity(100, "m")
 >>> distance
-Quantity(Array(100, dtype=int32, ...), unit='m')
+Quantity(Array(100, dtype=int32...), unit='m')
 
 Create from arrays
 
@@ -45,19 +45,19 @@ Convert units
 
 >>> distance_km = u.uconvert("km", distance)
 >>> distance_km
-Quantity(Array(0.1, dtype=float32, ...), unit='km')
+Quantity(Array(0.1, dtype=float32...), unit='km')
 
 Arithmetic preserves units.
 
 >>> time = u.Q(5, "s")  # use Quantity alias
 >>> velocity = distance / time
 >>> velocity
-Quantity(Array(20., dtype=float32, ...), unit='m / s')
+Quantity(Array(20., dtype=float32...), unit='m / s')
 
 Strip units for numerical operations
 
 >>> u.ustrip("m", distance)
-Array(100, dtype=int32, ...)
+Array(100, dtype=int32...)
 
 
 ### Working with angles:
@@ -66,20 +66,20 @@ Create angle quantities
 
 >>> theta = u.Angle(180, "deg")
 >>> theta
-Angle(Array(180, dtype=int32, ...), unit='deg')
+Angle(Array(180, dtype=int32...), unit='deg')
 
 Convert to radians
 
 >>> theta_rad = u.uconvert("rad", theta)
 >>> theta_rad
-Angle(Array(3.1415927, dtype=float32, ...), unit='rad')
+Angle(Array(3.1415927, dtype=float32...), unit='rad')
 
 Wrap angles to a range
 
 >>> angle = u.Angle(450, "deg")
 >>> wrapped = u.quantity.wrap_to(angle, u.Angle(0, "deg"), u.Angle(360, "deg"))
 >>> wrapped
-Angle(Array(90, dtype=int32, ...), unit='deg')
+Angle(Array(90, dtype=int32...), unit='deg')
 
 
 ### Advanced usage with JAX transformations:
@@ -93,12 +93,12 @@ Quantities work with JAX transformations
 >>> vel = u.Q(10.0, "m/s")
 >>> energy = kinetic_energy(mass, vel)
 >>> energy
-Quantity(Array(100., dtype=float32, ...), unit='m2 kg / s2')
+Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
 
 Convert to standard energy units
 
 >>> u.uconvert("J", energy)
-Quantity(Array(100., dtype=float32, ...), unit='m2 kg / s2')
+Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
 
 JIT compilation works seamlessly
 
@@ -107,7 +107,7 @@ JIT compilation works seamlessly
 ...     return mass * accel
 >>> force = compute_force(u.Q(5.0, "kg"), u.Q(9.8, "m/s^2"))
 >>> force
-Quantity(Array(49., dtype=float32, ...), unit='kg m / s2')
+Quantity(Array(49., dtype=float32...), unit='kg m / s2')
 
 """
 # pylint: disable=duplicate-code

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -1260,6 +1260,57 @@ def test_stack():
     assert jnp.array_equal(got.value, exp.value)
 
 
+def test_stack_axis():
+    """Test `stack` with different axis values."""
+    x = u.Q(jnp.asarray([1, 2, 3], dtype=float), "m")
+    y = u.Q(jnp.asarray([4, 5, 6], dtype=float), "m")
+
+    # Stack along axis=1
+    got = jnp.stack((x, y), axis=1)
+    exp = u.Q(jnp.stack((x.value, y.value), axis=1), "m")
+
+    assert isinstance(got, u.Q)
+    assert got.unit == exp.unit
+    assert jnp.array_equal(got.value, exp.value)
+    assert got.value.shape == (3, 2)
+
+
+def test_stack_unit_conversion():
+    """Test `stack` with unit conversion."""
+    x = u.Q(jnp.asarray([1, 2, 3], dtype=float), "km")
+    y = u.Q(jnp.asarray([4000, 5000, 6000], dtype=float), "m")
+    got = jnp.stack((x, y))
+    exp = u.Q(jnp.asarray([[1, 2, 3], [4, 5, 6]], dtype=float), "km")
+
+    assert isinstance(got, u.Q)
+    assert got.unit == exp.unit
+    assert jnp.allclose(got.value, exp.value)
+
+
+def test_stack_dimensionless_with_array():
+    """Test `stack` with dimensionless quantities and arrays."""
+    x = u.Q(jnp.asarray([1, 2, 3], dtype=float), "")
+    y = jnp.asarray([4, 5, 6], dtype=float)
+    got = jnp.stack((x, y))
+    exp = u.Q(jnp.stack((x.value, y)), "")
+
+    assert isinstance(got, u.Q)
+    assert str(got.unit) == ""
+    assert jnp.array_equal(got.value, exp.value)
+
+
+def test_stack_array_with_dimensionless():
+    """Test `stack` with arrays and dimensionless quantities."""
+    x = jnp.asarray([1, 2, 3], dtype=float)
+    y = u.Q(jnp.asarray([4, 5, 6], dtype=float), "")
+    got = jnp.stack((x, y))
+    exp = u.Q(jnp.stack((x, y.value)), "")
+
+    assert isinstance(got, u.Q)
+    assert str(got.unit) == ""
+    assert jnp.array_equal(got.value, exp.value)
+
+
 # =============================================================================
 # Searching functions
 

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -68,8 +68,8 @@ floats_strategy = st.floats(
 @example(value=[[1.0]])  # list[list[int]]
 def test_properties(value):
     """Test the properties of Quantity."""
-    q = u.Q(value, "m")
-    expected = jnp.asarray(value)
+    q = u.Q(np.array(value), "m")
+    expected = jnp.asarray(np.array(value))
 
     # Test the value
     assert np.array_equal(q.value, expected)

--- a/uv.lock
+++ b/uv.lock
@@ -2766,7 +2766,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.3.2"
+version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -2776,9 +2776,9 @@ dependencies = [
     { name = "plum-dispatch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm')" },
     { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-k8s') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/15/66c9a1a32168726ba0f4adeb158e737a012e2a2ec19c638dfa24f7d4b0ab/quax-0.3.2.tar.gz", hash = "sha256:94a1656c55f813ca5f6e76b69f085c8dcc701673928f7616af1f2536da158f62", size = 171557, upload-time = "2026-05-04T13:43:07.09Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/62/2a192104624d45203fea6fdc6ab89d0e05fc1aae28634a16772680ffb0bf/quax-0.3.4.tar.gz", hash = "sha256:4735e7649543aefa8ca8c024afd03b43392e23f06ffce4942cf3ed037b5483d0", size = 173857, upload-time = "2026-06-10T22:15:36.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/08/ef6ff182c14090127dcb1cb0a7724e327b5a2ef0c0e3e8afcd1c5672441b/quax-0.3.2-py3-none-any.whl", hash = "sha256:d63ea1f6af06711ee256cfd38d19e980b9ded760c58c49a5ccb668d5f2a5c6c3", size = 39313, upload-time = "2026-05-04T13:43:05.48Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1e/1ce20a1193ae3fa19d71fe627802af5762736423f92f9848f3a593304136/quax-0.3.4-py3-none-any.whl", hash = "sha256:716ee1aece3127365852e50392997b4b049b81c04519fe21b881fe5ed7801c00", size = 40129, upload-time = "2026-06-10T22:15:35.563Z" },
 ]
 
 [[package]]
@@ -3750,7 +3750,7 @@ requires-dist = [
     { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.3.2" },
+    { name = "quax", specifier = ">=0.3.4" },
     { name = "quax-blocks", specifier = ">=0.4.1" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "traitlets", specifier = ">=5.0.0" },


### PR DESCRIPTION
* build(deps): bump quax to >=0.3.4
* build: adapt to quax 0.3.4 and JAX 0.7.2+

- Register `lax.stack_p` primitive for Quantity, dimensionless, and array operands, with tests covering axis, unit conversion, and array/quantity mixing
- Handle JAX 0.7.2+ TypedInt/TypedFloat/TypedComplex in `convert_to_quantity_value` by coercing non-`jax.Array` outputs while preserving dtype
- Update doctests and docs to elide `weak_type` in array reprs and prefer `ustrip` over `.to(...).value`

* test: wrap quantity test values in np.array for JAX compatibility
* docs: update doctest reprs for JAX 0.7.2+ Array formatting

Adjust ellipsis placement in `Array(..., dtype=...)` doctest patterns to match the updated JAX repr, and refresh `uv.lock`.

* docs: fix wrap_to doctest repr for JAX 0.7.2+


(cherry picked from commit a790706a4a72198a3d8ca18e3c3f6403fa99426d)