### PR TITLE
🐛 fix: avoid numpy 2.5 NDArray ScalarT leak under beartype

### DIFF
--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 import equinox as eqx
 import numpy as np
-import numpy.typing as npt
 from astropy.units import CompositeUnit
 from jax.typing import ArrayLike
 from jaxtyping import Array
@@ -195,7 +194,7 @@ class NumPyCompatMixin:
 
     __array_namespace__: Callable[[], Any]
 
-    def __array__(self, *args: object, **kw: object) -> npt.NDArray[Any]:
+    def __array__(self, *args: object, **kw: object) -> np.ndarray:
         """Return the array as a numpy array, stripping the units.
 
         Examples

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -8,8 +8,8 @@ __all__ = ("StaticQuantity",)
 from typing import Any, final
 
 import equinox as eqx
+import numpy as np
 import wadler_lindig as wl
-from numpy.typing import NDArray
 from plum import add_promotion_rule, parametric
 
 from .base_parametric import AbstractParametricQuantity
@@ -74,7 +74,7 @@ class StaticQuantity(AbstractParametricQuantity):
         """Return the hash of the quantity."""
         return hash((self.value, self.unit))
 
-    def __eq__(self, other: Any, /) -> bool | NDArray[bool]:  # type: ignore[override]
+    def __eq__(self, other: Any, /) -> bool | np.ndarray:  # type: ignore[override]
         """Return structural equality for static quantities."""
         if isinstance(other, StaticQuantity):
             return self.unit == other.unit and self.value == other.value

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -13,7 +13,6 @@ import plum
 import quax
 import wadler_lindig as wl
 from jaxtyping import Array, ArrayLike
-from numpy.typing import NDArray
 
 import quaxed.numpy as jnp
 
@@ -140,7 +139,7 @@ class StaticValue:
         return wl.pformat(self, short_arrays=False, max_width=80)
 
     @override
-    def __eq__(self, other: object, /) -> bool | NDArray[np.bool_]:  # type: ignore[override]
+    def __eq__(self, other: object, /) -> bool | np.ndarray:  # type: ignore[override]
         if isinstance(other, StaticValue):
             return np.array_equal(self._array, other._array)
         if isinstance(other, Array):
@@ -149,7 +148,7 @@ class StaticValue:
             return np.equal(self._array, other)
         return NotImplemented
 
-    def __ne__(self, other: object, /) -> bool | NDArray[np.bool_]:  # type: ignore[override]
+    def __ne__(self, other: object, /) -> bool | np.ndarray:  # type: ignore[override]
         if isinstance(other, StaticValue):
             return not bool(np.array_equal(self._array, other._array))
         if isinstance(other, Array):
@@ -158,22 +157,22 @@ class StaticValue:
             return np.not_equal(self._array, other)
         return NotImplemented
 
-    def __lt__(self, other: Any, /) -> NDArray[np.bool_]:
+    def __lt__(self, other: Any, /) -> np.ndarray:
         if isinstance(other, StaticValue):
             other = other._array
         return self._array < other
 
-    def __le__(self, other: Any, /) -> NDArray[np.bool_]:
+    def __le__(self, other: Any, /) -> np.ndarray:
         if isinstance(other, StaticValue):
             other = other._array
         return self._array <= other
 
-    def __gt__(self, other: Any, /) -> NDArray[np.bool_]:
+    def __gt__(self, other: Any, /) -> np.ndarray:
         if isinstance(other, StaticValue):
             other = other._array
         return self._array > other
 
-    def __ge__(self, other: Any, /) -> NDArray[np.bool_]:
+    def __ge__(self, other: Any, /) -> np.ndarray:
         if isinstance(other, StaticValue):
             other = other._array
         return self._array >= other


### PR DESCRIPTION
## Problem

The **Newest supported deps** CI job (Python 3.14, `uv sync --upgrade`) fails at `import unxt` under runtime typechecking:

```
beartype.roar.BeartypeDecorHintNonpepNumpyException: ... NumPy data type ScalarT
invalid (i.e., neither data type nor coercible into data type).
```

numpy **2.5.0** turned `numpy.typing.NDArray` into a PEP-695 type alias whose body carries the unbound `ScalarT` TypeVar (bound to `numpy.generic`). beartype **0.22.9** (the latest release — nothing to bump to) can't resolve it, so every `npt.NDArray[...]` annotation on a beartyped function breaks import. This is independent of any feature work — it reproduces on a clean `main`.

## Fix

Replace the `npt.NDArray[...]` annotations with bare `np.ndarray` — beartype then does a plain `isinstance` check with no dtype introspection, sidestepping the `ScalarT` leak. Affected sites:

- `NumPyCompatMixin.__array__` (`mixins.py`)
- `StaticValue.__eq__/__ne__/__lt__/__le__/__gt__/__ge__` (`value.py`)
- `StaticQuantity.__eq__` (`static_quantity.py`)

Unused `numpy.typing` imports dropped. The annotations only narrowed to `np.bool_`/`Any` dtypes anyway, so no meaningful type information is lost.

## Verification

With `numpy==2.5.0` on Python 3.14 and `UNXT_ENABLE_RUNTIME_TYPECHECKING=beartype.beartype`:
- `import unxt` now succeeds.
- Affected modules' tests + doctests pass (94 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)