### PR TITLE
🎨 style: use the u.Q alias instead of u.Quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Quantities combine values with units, providing type-safe unitful arithmetic.
 ```python
 import jax.numpy as jnp
 
-x = u.Quantity(jnp.arange(1, 5, dtype=float), "km")
+x = u.Q(jnp.arange(1, 5, dtype=float), "km")
 print(x)
 # Quantity['length']([1., 2., 3., 4.], unit='km')
 ```
@@ -243,7 +243,7 @@ print(x + x)
 print(2 * x)
 # Quantity["length"]([2.0, 4.0, 6.0, 8.0], unit="km")
 
-y = u.Quantity(jnp.arange(4, 8, dtype=float), "yr")
+y = u.Q(jnp.arange(4, 8, dtype=float), "yr")
 
 print(x / y)
 # Quantity['speed']([0.25, 0.4 , 0.5 , 0.57142857], unit='km / yr')
@@ -273,7 +273,7 @@ print(x.uconvert("m"))  # via method
 Since `Quantity` is parametric, it can do runtime dimension checking!
 
 ```python
-LengthQuantity = u.Quantity["length"]
+LengthQuantity = u.Q["length"]
 print(LengthQuantity(2, "km"))
 # Quantity['length'](2, unit='km')
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -68,7 +68,7 @@ For example, `unxt` provides a `Quantity.from_` method that can convert an `astr
 >>> aq
 <Quantity 1. m>
 
->>> xq = u.Quantity.from_(aq)  # unxt Quantity
+>>> xq = u.Q.from_(aq)  # unxt Quantity
 >>> xq
 Quantity(Array(1., dtype=float32), unit='m')
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -23,7 +23,7 @@ u.config.quantity_repr.short_arrays = "compact"
 u.config.quantity_repr.use_short_name = True
 u.config.quantity_repr.named_unit = False
 
-q = u.Quantity([1, 2, 3], "m")
+q = u.Q([1, 2, 3], "m")
 print(repr(q))  # Q([1, 2, 3], 'm')
 ```
 
@@ -34,7 +34,7 @@ For temporary changes, use the context manager API with either the root config o
 ```{code-block} python
 >>> # Option 1: Use root config with double-underscore notation
 >>> with u.config.override(quantity_repr__short_arrays="compact", quantity_repr__use_short_name=True):
-...     q = u.Quantity([1.0, 2.0, 3.0], "m")
+...     q = u.Q([1.0, 2.0, 3.0], "m")
 ...     print(repr(q))
 Q([1., 2., 3.], unit='m')
 ```
@@ -42,7 +42,7 @@ Q([1., 2., 3.], unit='m')
 ```{code-block} python
 >>> # Option 2: Use nested config directly (cleaner for many options)
 >>> with u.config.quantity_repr.override(short_arrays="compact", use_short_name=True):
-...     q = u.Quantity([1.0, 2.0, 3.0], "m")
+...     q = u.Q([1.0, 2.0, 3.0], "m")
 ...     print(repr(q))
 Q([1., 2., 3.], unit='m')
 ```
@@ -76,7 +76,7 @@ Options:
 <!-- skip: start -->
 
 ```{code-block} python
->>> q = u.Quantity([1.0, 2.0, 3.0], "m")
+>>> q = u.Q([1.0, 2.0, 3.0], "m")
 
 >>> u.config.quantity_repr.short_arrays = False
 >>> print(repr(q))  # Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
@@ -98,7 +98,7 @@ Use class short names where available (for example, `Quantity` -> `Q`).
 - **Default**: `False`
 
 ```{code-block} python
->>> q = u.Quantity(1.0, "m")
+>>> q = u.Q(1.0, "m")
 
 >>> # Default behavior (use_short_name=False)
 >>> with u.config.quantity_repr.override(use_short_name=False):
@@ -119,7 +119,7 @@ Display units as `unit='m'` instead of positional `'m'`.
 - **Default**: `True`
 
 ```{code-block} python
->>> q = u.Quantity(1.0, "m")
+>>> q = u.Q(1.0, "m")
 
 >>> # Default behavior (named_unit=True)
 >>> with u.config.quantity_repr.override(named_unit=False):
@@ -140,7 +140,7 @@ Include type parameters in `repr()` for parametric quantities.
 - **Default**: `False`
 
 ```{code-block} python
->>> q = u.Quantity["length"](1.0, "m")
+>>> q = u.Q["length"](1.0, "m")
 
 >>> with u.config.quantity_repr.override(include_params=False):
 ...     print(repr(q))
@@ -159,7 +159,7 @@ Indentation width for nested structures in `repr()`.
 - **Default**: `4`
 
 ```{code-block} python
->>> q = u.Quantity([[1.0, 2.0], [3.0, 4.0]], "m")
+>>> q = u.Q([[1.0, 2.0], [3.0, 4.0]], "m")
 >>> print(repr(q))  # Default indentation (4 spaces)
 Quantity(Array([[1., 2.],
                 [3., 4.]], dtype=float32), unit='m')
@@ -177,7 +177,7 @@ Controls how arrays are displayed in `str()`.
 - **Default**: `"compact"`
 
 ```{code-block} python
->>> q = u.Quantity([1.0, 2.0, 3.0], "m")
+>>> q = u.Q([1.0, 2.0, 3.0], "m")
 >>> print(str(q))  # Default behavior (compact)
 Quantity['length']([1., 2., 3.], unit='m')
 
@@ -198,7 +198,7 @@ Display units as named keyword in `str()`.
 - **Default**: `True`
 
 ```{code-block} python
->>> q = u.Quantity(1.0, "m")
+>>> q = u.Q(1.0, "m")
 >>> print(str(q))  # Default behavior (named)
 Quantity['length'](1., unit='m')
 
@@ -215,7 +215,7 @@ Use short class names in `str()` representation.
 - **Default**: `False`
 
 ```{code-block} python
->>> q = u.Quantity(1.0, "m")
+>>> q = u.Q(1.0, "m")
 >>> print(str(q))
 Quantity['length'](1., unit='m')
 
@@ -279,7 +279,7 @@ Use context managers for temporary changes that are automatically restored. Ther
 print(f"Original: {u.config.quantity_repr.short_arrays}")
 
 with u.config.override(quantity_repr__short_arrays="compact", quantity_repr__use_short_name=True):
-    q = u.Quantity([1.0, 2.0, 3.0], "m")
+    q = u.Q([1.0, 2.0, 3.0], "m")
     print(repr(q))  # Q([1., 2., 3.], unit='m')
     print(f"Inside context: {u.config.quantity_repr.short_arrays}")
 
@@ -291,7 +291,7 @@ print(f"After context: {u.config.quantity_repr.short_arrays}")
 ```{code-block} python
 # Cleaner syntax when configuring multiple options for one display method
 with u.config.quantity_repr.override(short_arrays="compact", use_short_name=True, named_unit=False):
-    q = u.Quantity([1.0, 2.0, 3.0], "m")
+    q = u.Q([1.0, 2.0, 3.0], "m")
     print(repr(q))  # Q([1., 2., 3.], 'm')
 ```
 
@@ -319,7 +319,7 @@ You can override both repr and str configs simultaneously:
 ...     quantity_repr__short_arrays="compact",
 ...     quantity_str__short_arrays=True
 ... ):
-...     q = u.Quantity([1.0, 2.0, 3.0], "m")
+...     q = u.Q([1.0, 2.0, 3.0], "m")
 ...     print(repr(q), str(q))
 Quantity([1., 2., 3.], unit='m') Quantity['length'](f32[3], unit='m')
 >>>
@@ -328,7 +328,7 @@ Quantity([1., 2., 3.], unit='m') Quantity['length'](f32[3], unit='m')
 ...     u.config.quantity_repr.override(short_arrays="compact"),
 ...     u.config.quantity_str.override(short_arrays=True)
 ... ):
-...         q = u.Quantity([1.0, 2.0, 3.0], "m")
+...         q = u.Q([1.0, 2.0, 3.0], "m")
 ...         print(repr(q), str(q))
 Quantity([1., 2., 3.], unit='m') Quantity['length'](f32[3], unit='m')
 ```
@@ -343,7 +343,7 @@ Overrides are thread-local, meaning each thread has its own independent override
 >>> import threading
 >>> def worker(name: str, setting: str | bool) -> None:
 ...     with u.config.quantity_repr.override(short_arrays=setting):
-...         q = u.Quantity([1, 2, 3], "m")
+...         q = u.Q([1, 2, 3], "m")
 ...         print(f"{name}: {repr(q)}")
 >>> thread1 = threading.Thread(target=worker, args=("Thread 1", "compact"))
 >>> thread2 = threading.Thread(target=worker, args=("Thread 2", True))
@@ -405,7 +405,7 @@ Apply to the nested config instances:
 <!-- skip: end -->
 
 ```{code-block} python
->>> q = u.Quantity([1.0, 2.0, 3.0], "m")
+>>> q = u.Q([1.0, 2.0, 3.0], "m")
 >>> with u.config.quantity_repr.override(cfg):
 ...     print(repr(q))
 Q([1., 2., 3.], unit='m')

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -7,7 +7,7 @@
 ```{code-block} python
 >>> import unxt as u
 
->>> u.Quantity(5, "m")
+>>> u.Q(5, "m")
 Quantity(Array(5, dtype=int32...), unit='m')
 ```
 
@@ -47,7 +47,7 @@ There are many more options available with `Quantity.from_`. For a complete list
 <!-- skip: next -->
 
 ```{code-block} python
->>> u.Quantity.from_.methods
+>>> u.Q.from_.methods
 List of 9 method(s):
     [0] from_(cls: type, value: typing.Union[ArrayLike, ...], unit: typing.Any, *,
     dtype) -> unxt...quantity...AbstractQuantity

--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -267,7 +267,7 @@ import functools as ft
 
 
 @ft.partial(jax.jit, static_argnames=("constant",))
-def function(x, *, constant=u.Quantity(3.26, "lyr")):
+def function(x, *, constant=u.Q(3.26, "lyr")):
     ...
 ```
 

--- a/docs/guides/type-checking.md
+++ b/docs/guides/type-checking.md
@@ -20,9 +20,9 @@ from jaxtyping import Float
 import unxt as u
 
 def function(
-    x: Float[u.Quantity["length"], "N"],
-    t: Float[u.Quantity["time"], "N"],
-) -> Float[u.Quantity["speed"], "N"]:
+    x: Float[u.Q["length"], "N"],
+    t: Float[u.Q["time"], "N"],
+) -> Float[u.Q["speed"], "N"]:
     return x / t
 
 ```
@@ -83,9 +83,9 @@ Here's an example:
 
 >>> @jaxtyped(typechecker=typechecker)
 ... def velocity(
-...     x: Shaped[u.Quantity["length"], "N"],
-...     t: Shaped[u.Quantity["time"], "N"],
-... ) -> Shaped[u.Quantity["speed"], "N"]:
+...     x: Shaped[u.Q["length"], "N"],
+...     t: Shaped[u.Q["time"], "N"],
+... ) -> Shaped[u.Q["speed"], "N"]:
 ...     return x / t
 
 >>> x = u.Q([2.], "m")
@@ -111,7 +111,7 @@ Now for some examples.
 When a `Quantity` is constructed it is parametrized by the unit's dimension. This can be specified explicitly
 
 ```{code-block}
->>> u.Quantity["length"](1, "m")
+>>> u.Q["length"](1, "m")
 Quantity['length'](Array(1, dtype=int32, ...), unit='m')
 ```
 
@@ -126,7 +126,7 @@ When given explicitly Quantity will check the input dimensions. Here a length-pa
 
 ```{code-block} python
 >>> try:
-...     u.Quantity["length"](1, "s")
+...     u.Q["length"](1, "s")
 ... except Exception as e:
 ...     print(e)
 Physical type mismatch.
@@ -137,7 +137,7 @@ That should catch some bugs!
 The act of filling a `Quantity`'s parameters and its construction may be separated
 
 ```{code-block} python
->>> LengthQuantity = u.Quantity["length"]
+>>> LengthQuantity = u.Q["length"]
 >>> LengthQuantity
 <class 'unxt...Quantity[PhysicalType('length')]'>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -238,7 +238,7 @@ You can use unit system units to create quantities:
 
 ```{code-block} python
 
->>> q = u.Quantity(10, usys["velocity"])
+>>> q = u.Q(10, usys["velocity"])
 >>> q
 Quantity(Array(10, dtype=int32...), unit='m / s')
 
@@ -285,7 +285,7 @@ Create a `Quantity` by passing a JAX array-compatible object and a unit:
 
 >>> import unxt as u
 
->>> x = u.Quantity([1.0, 2.0, 3.0], unit="m")  # or u.Q(...) for short
+>>> x = u.Q([1.0, 2.0, 3.0], unit="m")  # or u.Q(...) for short
 >>> x
 Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -285,7 +285,7 @@ Create a `Quantity` by passing a JAX array-compatible object and a unit:
 
 >>> import unxt as u
 
->>> x = u.Q([1.0, 2.0, 3.0], unit="m")  # or u.Q(...) for short
+>>> x = u.Q([1.0, 2.0, 3.0], unit="m")  # same as u.Quantity(...)
 >>> x
 Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 ```

--- a/docs/interop/astropy.md
+++ b/docs/interop/astropy.md
@@ -63,7 +63,7 @@ Converting an [Astropy Quantity][astropy-Quantity] to a [unxt Quantity][unxt-Qua
 >>> aq
 <Quantity 1. m>
 
->>> xq = u.Quantity.from_(aq)  # unxt Quantity
+>>> xq = u.Q.from_(aq)  # unxt Quantity
 >>> xq
 Quantity(Array(1., dtype=float32), unit='m')
 ```
@@ -73,7 +73,7 @@ Alternatively, the multiple-dispatch library on which `unxt` is built enables 2-
 ```{code-block} python
 >>> from plum import convert
 
->>> convert(aq, u.Quantity)
+>>> convert(aq, u.Q)
 Quantity(Array(1., dtype=float32), unit='m')
 
 >>> convert(xq, apyu.Quantity)

--- a/docs/interop/dataclassish.md
+++ b/docs/interop/dataclassish.md
@@ -115,7 +115,7 @@ The `Quantity` type includes dimension parametrization and dimension checking.
 
 ```python
 # Create a quantity with dimension checking
-distance = u.Quantity(10.0, "m")
+distance = u.Q(10.0, "m")
 print(f"Quantity: {distance}")
 print(f"Type: {type(distance)}")
 

--- a/packages/unxt-api/docs/index.md
+++ b/packages/unxt-api/docs/index.md
@@ -201,7 +201,7 @@ import unxt as u
 
 
 @dispatch
-def your_function(q: u.Quantity, /):
+def your_function(q: u.Q, /):
     """Work with unxt quantities."""
     return q * 2
 ```

--- a/packages/unxt-api/src/unxt_api/_src/quantity.py
+++ b/packages/unxt-api/src/unxt_api/_src/quantity.py
@@ -50,7 +50,7 @@ def uconvert(u: Any, x: Any, /) -> Any:
     --------
     >>> import unxt as u  # implements `unxt_api.uconvert`
 
-    >>> q = u.Quantity(1, "km")
+    >>> q = u.Q(1, "km")
     >>> u.uconvert(u.unit("m"), q)
     Quantity(Array(1000., dtype=float32, ...), unit='m')
 
@@ -75,7 +75,7 @@ def ustrip(*args: Any) -> Any:
     --------
     >>> import unxt as u  # implements `unxt_api.ustrip`
 
-    >>> q = u.Quantity(1, "km")
+    >>> q = u.Q(1, "km")
     >>> ustrip(u.unit("m"), q)
     Array(1000., dtype=float32, ...)
 

--- a/packages/unxt-hypothesis/README.md
+++ b/packages/unxt-hypothesis/README.md
@@ -76,7 +76,7 @@ def test_any_unit(unit):
 # Use with quantities for generic physics tests
 @given(q=ust.quantities(unit=ust.units(ust.named_dimensions())))
 def test_quantity_any_dimension(q):
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert u.dimension_of(q) in [u.dimension(name) for name in ust.DIMENSION_NAMES]
 ```
 
@@ -222,10 +222,10 @@ def test_quantity_via_from_type(q):
     assert u.dimension_of(q) is not None
 
 
-@given(q=st.from_type(u.Quantity))
+@given(q=st.from_type(u.Q))
 def test_quantity_class_via_from_type(q):
     """Test Quantity instances generated via st.from_type()."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
 
 
 @given(bq=st.from_type(u.quantity.BareQuantity))
@@ -260,7 +260,7 @@ def test_unitsystem_via_from_type(usys):
 The following types are automatically registered:
 
 - `u.AbstractQuantity` → generates `Quantity` instances
-- `u.Quantity` → generates `Quantity` instances with dimension checking
+- `u.Q` → generates `Quantity` instances with dimension checking
 - `u.quantity.BareQuantity` → generates `BareQuantity` instances (no dimension checking)
 - `u.quantity.StaticQuantity` → generates `StaticQuantity` instances with `StaticValue` wrapper (for non-traced values)
 - `u.Angle` → generates `Angle` instances with angle dimension

--- a/packages/unxt-hypothesis/docs/index.md
+++ b/packages/unxt-hypothesis/docs/index.md
@@ -107,7 +107,7 @@ def test_units_any_dimension(unit):
 # Quantities from any dimension
 @given(q=ust.quantities(unit=ust.units(ust.named_dimensions())))
 def test_quantities_any_dimension(q):
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
 ```
 
 See also: `ust.DIMENSION_NAMES` for the full set of names, and `unxt.dimension` to construct dimensions directly from names. You can use `st.sampled_from(ust.DIMENSION_NAMES)` to create custom strategies using these names.
@@ -484,7 +484,7 @@ from hypothesis import given, strategies as st
 import unxt as u
 
 
-def calculate_momentum(mass: u.Quantity, velocity: u.Quantity) -> u.Quantity:
+def calculate_momentum(mass: u.Q, velocity: u.Q) -> u.Q:
     """Calculate momentum: p = m * v"""
     return mass * velocity
 

--- a/packages/unxt-hypothesis/docs/testing-guide.md
+++ b/packages/unxt-hypothesis/docs/testing-guide.md
@@ -189,10 +189,10 @@ def test_any_quantity(q):
 
 
 # Quantity generates Quantity instances with dimension checking
-@given(q=st.from_type(u.Quantity))
+@given(q=st.from_type(u.Q))
 def test_regular_quantity(q):
     """Test with standard Quantity instances."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
 
 
 # BareQuantity generates instances without dimension checking
@@ -254,7 +254,7 @@ Example combining both approaches:
 
 ```python
 # Generic test using st.from_type()
-@given(q1=st.from_type(u.Quantity), q2=st.from_type(u.Quantity))
+@given(q1=st.from_type(u.Q), q2=st.from_type(u.Q))
 def test_quantity_equality_reflexive(q1, q2):
     """Quantity equality is reflexive."""
     assert q1 == q1
@@ -585,7 +585,7 @@ def test_distance_range(distance):
 
 #### Using the quantity_cls Parameter
 
-The `quantity_cls` parameter controls the type of quantity object created. By default, it's `u.Quantity`, but you can specify `u.Angle` or other quantity subclasses:
+The `quantity_cls` parameter controls the type of quantity object created. By default, it's `u.Q`, but you can specify `u.Angle` or other quantity subclasses:
 
 ```python
 # Generate Angle objects
@@ -601,7 +601,7 @@ def test_angle_generation(angle):
 @given(distance=ust.quantities("kpc", shape=()))
 def test_distance_generation(distance):
     """Generate Quantity instances (default quantity_cls)."""
-    assert isinstance(distance, u.Quantity)
+    assert isinstance(distance, u.Q)
     assert distance.unit == u.unit("kpc")
 
 

--- a/packages/unxt-hypothesis/src/unxt_hypothesis/_src/quantities.py
+++ b/packages/unxt-hypothesis/src/unxt_hypothesis/_src/quantities.py
@@ -32,7 +32,7 @@ def quantities(
     | st.SearchStrategy[u.AbstractUnit | u.AbstractDimension]
     | u.AbstractDimension = units(),  # noqa: B008
     *,
-    quantity_cls: type[u.AbstractQuantity] = u.Quantity,
+    quantity_cls: type[u.AbstractQuantity] = u.Q,
     dtype: Any | st.SearchStrategy[np.dtype] = jnp.float32,
     shape: int | tuple[int, ...] | st.SearchStrategy[int | tuple[int, ...]] = (),
     elements: st.SearchStrategy[float] | None = None,
@@ -351,10 +351,8 @@ def angles(
 
 # Register type strategy for Hypothesis's st.from_type()
 # Note: Pass the callable, not an invoked strategy
-st.register_type_strategy(
-    u.AbstractQuantity, lambda _: quantities(quantity_cls=u.Quantity)
-)
-st.register_type_strategy(u.Quantity, lambda typ: quantities(quantity_cls=typ))
+st.register_type_strategy(u.AbstractQuantity, lambda _: quantities(quantity_cls=u.Q))
+st.register_type_strategy(u.Q, lambda typ: quantities(quantity_cls=typ))
 st.register_type_strategy(
     u.quantity.BareQuantity, lambda typ: quantities(quantity_cls=typ)
 )

--- a/packages/unxt-hypothesis/tests/test_from_type.py
+++ b/packages/unxt-hypothesis/tests/test_from_type.py
@@ -26,11 +26,11 @@ def test_from_type_angle(a: u.Angle) -> None:
     assert u.dimension_of(a) == u.dimension("angle")
 
 
-@given(q=st.from_type(u.Quantity))
+@given(q=st.from_type(u.Q))
 @settings(max_examples=20)
-def test_from_type_quantity(q: u.Quantity) -> None:
+def test_from_type_quantity(q: u.Q) -> None:
     """Test st.from_type() with Quantity."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     # Should have a dimension
     assert u.dimension_of(q) is not None
 

--- a/packages/unxt-hypothesis/tests/test_quantities.py
+++ b/packages/unxt-hypothesis/tests/test_quantities.py
@@ -11,45 +11,45 @@ import unxt_hypothesis as ust
 
 @given(q=ust.quantities(unit="m"))
 @settings(max_examples=50)
-def test_scalar_length(q: u.Quantity) -> None:
+def test_scalar_length(q: u.Q) -> None:
     """Test scalar length quantity generation."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     assert u.dimension_of(q) == u.dimension("length")
 
 
 @given(q=ust.quantities(unit="m/s", shape=3))
 @settings(max_examples=50)
-def test_vector_velocity(q: u.Quantity) -> None:
+def test_vector_velocity(q: u.Q) -> None:
     """Test 1D velocity quantity generation."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     assert u.dimension_of(q) == u.dimension("velocity")
 
 
 @given(q=ust.quantities(unit="kg", shape=(2, 3)))
 @settings(max_examples=50)
-def test_2d_mass(q: u.Quantity) -> None:
+def test_2d_mass(q: u.Q) -> None:
     """Test 2D mass quantity generation."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (2, 3)
     assert u.dimension_of(q) == u.dimension("mass")
 
 
 @given(q=ust.quantities(unit="J", dtype=jnp.float32))
 @settings(max_examples=30)
-def test_float32_energy_dtype(q: u.Quantity) -> None:
+def test_float32_energy_dtype(q: u.Q) -> None:
     """Test float32 dtype for energy."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.dtype == jnp.float32
     assert u.dimension_of(q) == u.dimension("energy")
 
 
 @given(q=ust.quantities(unit="s", dtype=jnp.float32, shape=5))
 @settings(max_examples=30)
-def test_float32_time_dtype(q: u.Quantity) -> None:
+def test_float32_time_dtype(q: u.Q) -> None:
     """Test float32 dtype for time."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.dtype == jnp.float32
     assert q.shape == (5,)
     assert u.dimension_of(q) == u.dimension("time")
@@ -59,9 +59,9 @@ def test_float32_time_dtype(q: u.Quantity) -> None:
     q=ust.quantities(unit="m", shape=st.tuples(st.integers(1, 5), st.integers(1, 5)))
 )
 @settings(max_examples=30)
-def test_variable_shape_strategy(q: u.Quantity) -> None:
+def test_variable_shape_strategy(q: u.Q) -> None:
     """Test with a shape strategy."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert len(q.shape) == 2
     assert all(1 <= s <= 5 for s in q.shape)
     assert u.dimension_of(q) == u.dimension("length")
@@ -75,9 +75,9 @@ def test_variable_shape_strategy(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30, deadline=None)
-def test_custom_elements(q: u.Quantity) -> None:
+def test_custom_elements(q: u.Q) -> None:
     """Test with custom element strategy."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     # All values should be between 0 and 100
     assert jnp.all((q.value >= 0) & (q.value <= 100))
@@ -85,9 +85,9 @@ def test_custom_elements(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit="m", shape=10, unique=True))
 @settings(max_examples=20, deadline=None)
-def test_unique_elements(q: u.Quantity) -> None:
+def test_unique_elements(q: u.Q) -> None:
     """Test unique elements constraint."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (10,)
     # All elements should be unique
     assert len(jnp.unique(q.value)) == 10
@@ -95,49 +95,49 @@ def test_unique_elements(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit="m", static_value=True))
 @settings(max_examples=30)
-def test_static_value_generation(q: u.Quantity) -> None:
+def test_static_value_generation(q: u.Q) -> None:
     """Test StaticValue wrapping for generated quantities."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert isinstance(q.value, u.quantity.StaticValue)
 
 
 @given(q=ust.quantities(unit="rad"))
 @settings(max_examples=30)
-def test_angle_unit(q: u.Quantity) -> None:
+def test_angle_unit(q: u.Q) -> None:
     """Test with angle unit."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert u.dimension_of(q) == u.dimension("angle")
 
 
 @given(q=ust.quantities(unit="N"))
 @settings(max_examples=30)
-def test_force_unit(q: u.Quantity) -> None:
+def test_force_unit(q: u.Q) -> None:
     """Test with force unit."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert u.dimension_of(q) == u.dimension("force")
 
 
 @given(q=ust.quantities(unit="Pa"))
 @settings(max_examples=30)
-def test_pressure_unit(q: u.Quantity) -> None:
+def test_pressure_unit(q: u.Q) -> None:
     """Test with pressure unit."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert u.dimension_of(q) == u.dimension("pressure")
 
 
 @given(q=ust.quantities(unit="kpc"))
 @settings(max_examples=30)
-def test_astronomical_unit(q: u.Quantity) -> None:
+def test_astronomical_unit(q: u.Q) -> None:
     """Test with astronomical unit."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert u.dimension_of(q) == u.dimension("length")
 
 
 @given(q=ust.quantities(unit="km/s", shape=(3,)))
 @settings(max_examples=30)
-def test_compound_unit(q: u.Quantity) -> None:
+def test_compound_unit(q: u.Q) -> None:
     """Test with compound unit."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     assert u.dimension_of(q) == u.dimension("velocity")
 
@@ -162,9 +162,9 @@ def test_accepts_shape_tuple() -> None:
 
 @given(q=ust.quantities(unit="eV", shape=()))
 @settings(max_examples=20)
-def test_explicit_scalar_shape(q: u.Quantity) -> None:
+def test_explicit_scalar_shape(q: u.Q) -> None:
     """Test explicit scalar shape ()."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     assert u.dimension_of(q) == u.dimension("energy")
 
@@ -174,9 +174,9 @@ def test_explicit_scalar_shape(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit=ust.units("length"), shape=3))
 @settings(max_examples=50)
-def test_length_varying_units(q: u.Quantity) -> None:
+def test_length_varying_units(q: u.Q) -> None:
     """Test length quantity with varying units from units strategy."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     # Should always have length dimension
     assert u.dimension_of(q) == u.dimension("length")
@@ -184,27 +184,27 @@ def test_length_varying_units(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit=ust.units("velocity"), shape=()))
 @settings(max_examples=50)
-def test_scalar_velocity_varying_units(q: u.Quantity) -> None:
+def test_scalar_velocity_varying_units(q: u.Q) -> None:
     """Test scalar velocity with varying units."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     assert u.dimension_of(q) == u.dimension("velocity")
 
 
 @given(q=ust.quantities(unit=ust.units("mass"), shape=(2, 3)))
 @settings(max_examples=30)
-def test_2d_mass_varying_units(q: u.Quantity) -> None:
+def test_2d_mass_varying_units(q: u.Q) -> None:
     """Test 2D mass quantity with varying units."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (2, 3)
     assert u.dimension_of(q) == u.dimension("mass")
 
 
 @given(q=ust.quantities(unit=ust.units("energy", max_complexity=3), dtype=jnp.float32))
 @settings(max_examples=30)
-def test_energy_complex_units(q: u.Quantity) -> None:
+def test_energy_complex_units(q: u.Q) -> None:
     """Test energy with complex compound units."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.dtype == jnp.float32
     assert u.dimension_of(q) == u.dimension("energy")
 
@@ -217,9 +217,9 @@ def test_energy_complex_units(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_length_non_integer_powers(q: u.Quantity) -> None:
+def test_length_non_integer_powers(q: u.Q) -> None:
     """Test length with non-integer power units."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (5,)
     assert q.dtype == jnp.float32
     assert u.dimension_of(q) == u.dimension("length")
@@ -232,9 +232,9 @@ def test_length_non_integer_powers(q: u.Quantity) -> None:
 
 @given(q=ust.quantities("m", dtype=st.sampled_from([jnp.float32, jnp.int32])))
 @settings(max_examples=50)
-def test_dtype_strategy_float_types(q: u.Quantity) -> None:
+def test_dtype_strategy_float_types(q: u.Q) -> None:
     """Test dtype as a strategy with different types."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.dtype in (jnp.float32, jnp.int32)
     assert u.dimension_of(q) == u.dimension("length")
 
@@ -247,9 +247,9 @@ def test_dtype_strategy_float_types(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_dtype_strategy_with_complex(q: u.Quantity) -> None:
+def test_dtype_strategy_with_complex(q: u.Q) -> None:
     """Test dtype strategy including complex types."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     assert q.dtype in (jnp.float32, jnp.complex64)
 
@@ -262,9 +262,9 @@ def test_dtype_strategy_with_complex(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=20)
-def test_dtype_strategy_just_float32(q: u.Quantity) -> None:
+def test_dtype_strategy_just_float32(q: u.Q) -> None:
     """Test using st.just for a single dtype via strategy."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.dtype == jnp.float32
     assert q.shape == (2, 3)
 
@@ -276,27 +276,27 @@ def test_dtype_strategy_just_float32(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit=u.dimension("length"), shape=3))
 @settings(max_examples=50)
-def test_unit_from_length_dimension(q: u.Quantity) -> None:
+def test_unit_from_length_dimension(q: u.Q) -> None:
     """Test generating units from length dimension."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     assert u.dimension_of(q) == u.dimension("length")
 
 
 @given(q=ust.quantities(unit=u.dimension("velocity"), shape=()))
 @settings(max_examples=50)
-def test_unit_from_velocity_dimension(q: u.Quantity) -> None:
+def test_unit_from_velocity_dimension(q: u.Q) -> None:
     """Test generating units from velocity dimension."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     assert u.dimension_of(q) == u.dimension("velocity")
 
 
 @given(q=ust.quantities(unit=u.dimension("mass"), shape=(2, 3), dtype=jnp.float32))
 @settings(max_examples=30)
-def test_unit_from_mass_dimension_with_dtype(q: u.Quantity) -> None:
+def test_unit_from_mass_dimension_with_dtype(q: u.Q) -> None:
     """Test dimension with explicit dtype."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (2, 3)
     assert q.dtype == jnp.float32
     assert u.dimension_of(q) == u.dimension("mass")
@@ -304,9 +304,9 @@ def test_unit_from_mass_dimension_with_dtype(q: u.Quantity) -> None:
 
 @given(q=ust.quantities(unit=u.dimension("energy"), shape=5))
 @settings(max_examples=30)
-def test_unit_from_energy_dimension(q: u.Quantity) -> None:
+def test_unit_from_energy_dimension(q: u.Q) -> None:
     """Test generating units from energy dimension."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (5,)
     assert u.dimension_of(q) == u.dimension("energy")
 
@@ -323,9 +323,9 @@ def test_unit_from_energy_dimension(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=50)
-def test_unit_from_dimension_strategy(q: u.Quantity) -> None:
+def test_unit_from_dimension_strategy(q: u.Q) -> None:
     """Test generating units from a strategy of dimensions."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     dim = u.dimension_of(q)
     assert dim in (u.dimension("length"), u.dimension("mass"))
@@ -339,9 +339,9 @@ def test_unit_from_dimension_strategy(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=40)
-def test_dimension_strategy_kinematic_quantities(q: u.Quantity) -> None:
+def test_dimension_strategy_kinematic_quantities(q: u.Q) -> None:
     """Test dimension strategy for kinematic quantities."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3,)
     assert q.dtype == jnp.float32
     dim = u.dimension_of(q)
@@ -355,9 +355,9 @@ def test_dimension_strategy_kinematic_quantities(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_dimension_strategy_angle_dimensionless(q: u.Quantity) -> None:
+def test_dimension_strategy_angle_dimensionless(q: u.Q) -> None:
     """Test dimension strategy with angle and dimensionless."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (2, 2)
     dim = u.dimension_of(q)
     assert dim in (u.dimension("angle"), u.dimension("dimensionless"))
@@ -376,9 +376,9 @@ def test_dimension_strategy_angle_dimensionless(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=40)
-def test_combined_dimension_and_dtype_strategies(q: u.Quantity) -> None:
+def test_combined_dimension_and_dtype_strategies(q: u.Q) -> None:
     """Test combining dimension and dtype strategies."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == ()
     assert q.dtype in (jnp.float32, jnp.int32)
     dim = u.dimension_of(q)
@@ -393,9 +393,9 @@ def test_combined_dimension_and_dtype_strategies(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_force_dimension_with_dtype_strategy(q: u.Quantity) -> None:
+def test_force_dimension_with_dtype_strategy(q: u.Q) -> None:
     """Test force dimension with varying dtype."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (3, 3)
     assert q.dtype in (jnp.float32, jnp.complex64)
     assert u.dimension_of(q) == u.dimension("force")
@@ -412,9 +412,9 @@ def test_force_dimension_with_dtype_strategy(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=50)
-def test_positive_distance_elements(q: u.Quantity) -> None:
+def test_positive_distance_elements(q: u.Q) -> None:
     """Test elements parameter for positive distances."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.unit == u.unit("kpc")
     assert q.shape == (3,)
     # All values should be non-negative (suitable for distances)
@@ -430,9 +430,9 @@ def test_positive_distance_elements(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=50)
-def test_longitude_angle_range(q: u.Quantity) -> None:
+def test_longitude_angle_range(q: u.Q) -> None:
     """Test elements for longitude angles (0-360 degrees)."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.unit == u.unit("deg")
     assert 0 <= q.value <= 360
 
@@ -445,9 +445,9 @@ def test_longitude_angle_range(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_latitude_angle_range(q: u.Quantity) -> None:
+def test_latitude_angle_range(q: u.Q) -> None:
     """Test elements for latitude angles (-90 to 90 degrees)."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.unit == u.unit("deg")
     assert q.shape == (100,)
     assert jnp.all(q.value >= -90)
@@ -462,9 +462,9 @@ def test_latitude_angle_range(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_azimuthal_angle_radians(q: u.Quantity) -> None:
+def test_azimuthal_angle_radians(q: u.Q) -> None:
     """Test elements for azimuthal angles in radians (0 to 2π)."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.unit == u.unit("rad")
     assert q.shape == (5, 5)
     assert jnp.all(q.value >= 0)
@@ -479,9 +479,9 @@ def test_azimuthal_angle_radians(q: u.Quantity) -> None:
     )
 )
 @settings(max_examples=30)
-def test_physical_length_scale(q: u.Quantity) -> None:
+def test_physical_length_scale(q: u.Q) -> None:
     """Test elements for physical lengths with realistic bounds."""
-    assert isinstance(q, u.Quantity)
+    assert isinstance(q, u.Q)
     assert q.shape == (10,)
     # All values in reasonable range (1 meter to 1 kilometer)
     assert jnp.all(q.value >= 1.0)
@@ -559,10 +559,10 @@ def test_quantities_angle_class(angle: u.Angle) -> None:
     assert angle.shape == (3,)
 
 
-@given(quantity=ust.quantities("m", quantity_cls=u.Quantity, shape=()))
+@given(quantity=ust.quantities("m", quantity_cls=u.Q, shape=()))
 @settings(max_examples=30)
-def test_quantities_quantity_class(quantity: u.Quantity) -> None:
+def test_quantities_quantity_class(quantity: u.Q) -> None:
     """Test creating Quantity instances via quantity_cls parameter."""
-    assert isinstance(quantity, u.Quantity)
+    assert isinstance(quantity, u.Q)
     assert quantity.unit == u.unit("m")
     assert quantity.shape == ()

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -63,7 +63,7 @@ def from_(
     >>> import unxt as u
     >>> import astropy.units as apyu
 
-    >>> u.Quantity.from_(apyu.Quantity(1, "m"))
+    >>> u.Q.from_(apyu.Quantity(1, "m"))
     Quantity(Array(1., dtype=float32), unit='m')
 
     """
@@ -85,7 +85,7 @@ def from_(
     >>> import unxt as u
     >>> import astropy.units as apyu
 
-    >>> u.Quantity.from_(apyu.Quantity(1, "m"), "cm")
+    >>> u.Q.from_(apyu.Quantity(1, "m"), "cm")
     Quantity(Array(100., dtype=float32), unit='cm')
 
     """
@@ -235,11 +235,11 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     >>> import astropy.units as apyu
     >>> import unxt as u
 
-    >>> x = u.Quantity(1000, "m")
+    >>> x = u.Q(1000, "m")
     >>> u.uconvert(u.unit("km"), x)
     Quantity(Array(1., dtype=float32, ...), unit='km')
 
-    >>> x = u.Quantity([1, 2, 3], "Kelvin")
+    >>> x = u.Q([1, 2, 3], "Kelvin")
     >>> with apyu.add_enabled_equivalencies(apyu.temperature()):
     ...     y = x.uconvert("deg_C")
     >>> y
@@ -300,7 +300,7 @@ def ustrip(flag: type[AllowValue], u: Any, x: AstropyQuantity, /) -> Any:
     Examples
     --------
     >>> import unxt as u
-    >>> q = u.Quantity(1000, "m")
+    >>> q = u.Q(1000, "m")
     >>> u.ustrip(AllowValue, "km", q)
     Array(1., dtype=float32, ...)
 

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -101,7 +101,7 @@ class QuantityReprConfig(LocalConfigurable):
     >>> with u.config.quantity_repr.override(
     ...     short_arrays="compact", use_short_name=True
     ... ):
-    ...     q = u.Quantity([1, 2, 3], "m")
+    ...     q = u.Q([1, 2, 3], "m")
     ...     print(repr(q))
     Q([1, 2, 3], unit='m')
 
@@ -186,7 +186,7 @@ class QuantityReprConfig(LocalConfigurable):
         >>> with u.config.quantity_repr.override(
         ...     short_arrays="compact", use_short_name=True
         ... ):
-        ...     q = u.Quantity([1, 2, 3], "m")
+        ...     q = u.Q([1, 2, 3], "m")
         ...     print(repr(q))
         Q([1, 2, 3], unit='m')
 
@@ -197,7 +197,7 @@ class QuantityReprConfig(LocalConfigurable):
         >>> cfg.QuantityReprConfig.short_arrays = "compact"
         >>> cfg.QuantityReprConfig.use_short_name = True
         >>> with u.config.quantity_repr.override(cfg):
-        ...     q = u.Quantity([1, 2, 3], "m")
+        ...     q = u.Q([1, 2, 3], "m")
         ...     print(repr(q))
         Q([1, 2, 3], unit='m')
 
@@ -299,7 +299,7 @@ class QuantityStrConfig(LocalConfigurable):
     >>> with u.config.quantity_str.override(
     ...     short_arrays=True, use_short_name=True, include_params=False
     ... ):
-    ...     q = u.Quantity([1, 2, 3], "m")
+    ...     q = u.Q([1, 2, 3], "m")
     ...     print(str(q))
     Q(i32[3], unit='m')
 
@@ -464,7 +464,7 @@ class UnxtConfig(SingletonConfigurable):
     >>> with u.config.override(
     ...     quantity_repr__short_arrays="compact", quantity_repr__use_short_name=True
     ... ):
-    ...     q = u.Quantity([1, 2, 3], "m")
+    ...     q = u.Q([1, 2, 3], "m")
     ...     print(repr(q))
     Q([1, 2, 3], unit='m')
 
@@ -509,7 +509,7 @@ class UnxtConfig(SingletonConfigurable):
         --------
         >>> import unxt as u
         >>> with u.config.override(quantity_repr__short_arrays=True):
-        ...     q = u.Quantity([1.0, 2.0, 3.0], "m")
+        ...     q = u.Q([1.0, 2.0, 3.0], "m")
         ...     print(repr(q))  # Uses compact display
         Quantity(f32[3], unit='m')
 

--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -68,7 +68,7 @@ def grad(
     >>> import jax.numpy as jnp
     >>> import unxt as u
 
-    >>> def cube_volume(x: u.Quantity["length"]) -> u.Quantity["volume"]:
+    >>> def cube_volume(x: u.Q["length"]) -> u.Q["volume"]:
     ...     return x**3
 
     >>> grad_cube_volume = u.experimental.grad(cube_volume, units=("m",))
@@ -130,7 +130,7 @@ def jacfwd(
     >>> import jax.numpy as jnp
     >>> import unxt as u
 
-    >>> def cubbe_volume(x: u.Quantity["length"]) -> u.Quantity["volume"]:
+    >>> def cubbe_volume(x: u.Q["length"]) -> u.Q["volume"]:
     ...     return x**3
 
     >>> jacfwd_cubbe_volume = u.experimental.jacfwd(cubbe_volume, units=("m",))
@@ -197,7 +197,7 @@ def hessian(
     >>> import jax.numpy as jnp
     >>> import unxt as u
 
-    >>> def cubbe_volume(x: u.Quantity["length"]) -> u.Quantity["volume"]:
+    >>> def cubbe_volume(x: u.Q["length"]) -> u.Q["volume"]:
     ...     return x**3
 
     >>> hessian_cubbe_volume = u.experimental.hessian(cubbe_volume, units=("m",))

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -78,40 +78,40 @@ class AbstractQuantity(
 
     From an integer:
 
-    >>> u.Quantity(1, "m")
+    >>> u.Q(1, "m")
     Quantity(Array(1, dtype=int32...), unit='m')
 
     From a float:
 
-    >>> u.Quantity(1.0, "m")
+    >>> u.Q(1.0, "m")
     Quantity(Array(1., dtype=float32...), unit='m')
 
     From a list:
 
-    >>> u.Quantity([1, 2, 3], "m")
+    >>> u.Q([1, 2, 3], "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a tuple:
 
-    >>> u.Quantity((1, 2, 3), "m")
+    >>> u.Q((1, 2, 3), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `numpy.ndarray`:
 
     >>> import numpy as np
-    >>> u.Quantity(np.array([1, 2, 3]), "m")
+    >>> u.Q(np.array([1, 2, 3]), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `jax.Array`:
 
     >>> import jax.numpy as jnp
-    >>> u.Quantity(jnp.array([1, 2, 3]), "m")
+    >>> u.Q(jnp.array([1, 2, 3]), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     The unit can also be given as a `astropy.units.Unit`:
 
     >>> import astropy.units as apyu
-    >>> u.Quantity(1, apyu.m)
+    >>> u.Q(1, apyu.m)
     Quantity(Array(1, dtype=int32...), unit='m')
 
     """
@@ -150,7 +150,7 @@ class AbstractQuantity(
         --------
         >>> import unxt as u
 
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> q.uconvert("cm")
         Quantity(Array(100., dtype=float32, ...), unit='cm')
 
@@ -168,7 +168,7 @@ class AbstractQuantity(
         --------
         >>> import unxt as u
 
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> q.ustrip("cm")
         Array(100., dtype=float32, weak_type=True)
 
@@ -225,7 +225,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> u.Quantity(1, "m").dtype
+        >>> u.Q(1, "m").dtype
         dtype('int32')
 
         """
@@ -238,7 +238,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> u.Quantity(1, "m").device
+        >>> u.Q(1, "m").device
         CpuDevice(id=0)
 
         """
@@ -251,7 +251,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[0, 1], [1, 2]], "m")
+        >>> q = u.Q([[0, 1], [1, 2]], "m")
         >>> q.mT
         Quantity(Array([[0, 1],
                                   [1, 2]], dtype=int32), unit='m')
@@ -266,7 +266,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[1]], "m")
+        >>> q = u.Q([[1]], "m")
         >>> q.ndim
         2
 
@@ -280,7 +280,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.size
         3
 
@@ -294,7 +294,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[0, 1], [1, 2]], "m")
+        >>> q = u.Q([[0, 1], [1, 2]], "m")
         >>> q.T
         Quantity(Array([[0, 1],
                                   [1, 2]], dtype=int32), unit='m')
@@ -314,7 +314,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([0, 1], "m")
+        >>> q = u.Q([0, 1], "m")
 
         >>> bool(q[0])
         False
@@ -331,7 +331,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "")
+        >>> q = u.Q(1, "")
         >>> complex(q)
         (1+0j)
 
@@ -352,7 +352,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "")
+        >>> q = u.Q(1, "")
         >>> float(q)
         1.0
 
@@ -374,7 +374,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "")
+        >>> q = u.Q(1, "")
         >>> q.__index__()
         1
 
@@ -387,7 +387,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "")
+        >>> q = u.Q(1, "")
         >>> int(q)
         1
 
@@ -402,7 +402,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> try:
         ...     q[0] = 2
         ... except Exception as e:
@@ -418,7 +418,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> q.to_device(None)
         Quantity(Array(1, dtype=int32...), unit='m')
 
@@ -434,7 +434,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> [x for x in q]
         [Quantity(Array(1, dtype=int32), unit='m'),
          Quantity(Array(2, dtype=int32), unit='m'),
@@ -449,7 +449,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.argmax()
         Array(2, dtype=int32)
 
@@ -462,7 +462,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.argmin()
         Array(0, dtype=int32)
 
@@ -475,7 +475,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.dtype
         dtype('int32')
 
@@ -495,7 +495,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> q.block_until_ready() is q
         True
 
@@ -509,7 +509,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> q.devices()
         {CpuDevice(id=0)}
 
@@ -522,7 +522,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[1, 2], [3, 4]], "m")
+        >>> q = u.Q([[1, 2], [3, 4]], "m")
         >>> q.flatten()
         Quantity(Array([1, 2, 3, 4], dtype=int32), unit='m')
 
@@ -535,7 +535,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.max()
         Quantity(Array(3, dtype=int32), unit='m')
 
@@ -548,7 +548,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.mean()
         Quantity(Array(2., dtype=float32), unit='m')
 
@@ -561,7 +561,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.min()
         Quantity(Array(1, dtype=int32), unit='m')
 
@@ -574,7 +574,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[1, 2], [3, 4]], "m")
+        >>> q = u.Q([[1, 2], [3, 4]], "m")
         >>> q.ravel()
         Quantity(Array([1, 2, 3, 4], dtype=int32), unit='m')
 
@@ -587,7 +587,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3, 4], "m")
+        >>> q = u.Q([1, 2, 3, 4], "m")
         >>> q.reshape(2, 2)
         Quantity(Array([[1, 2],
                                   [3, 4]], dtype=int32), unit='m')
@@ -602,7 +602,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1.1, 2.2, 3.3], "m")
+        >>> q = u.Q([1.1, 2.2, 3.3], "m")
         >>> q.round(0)
         Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
@@ -616,7 +616,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
         >>> q.sharding
         SingleDeviceSharding(device=..., memory_kind=...)
 
@@ -629,7 +629,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([[[1], [2], [3]]], "m")
+        >>> q = u.Q([[[1], [2], [3]]], "m")
         >>> q.squeeze()
         Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
@@ -650,7 +650,7 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity(1, "m")
+        >>> q = u.Q(1, "m")
         >>> try:
         ...     hash(q)
         ... except TypeError as e:
@@ -864,13 +864,13 @@ def from_(
     >>> import unxt as u
 
     >>> x = jnp.array([1.0, 2, 3])
-    >>> u.Quantity.from_(x, "m")
+    >>> u.Q.from_(x, "m")
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
-    >>> u.Quantity.from_([1.0, 2, 3], "m")
+    >>> u.Q.from_([1.0, 2, 3], "m")
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
-    >>> u.Quantity.from_((1.0, 2, 3), "m")
+    >>> u.Q.from_((1.0, 2, 3), "m")
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
     """
@@ -896,7 +896,7 @@ def from_(
     to any subclass of `unxt.AbstractQuantity`.
 
     >>> import unxt as u
-    >>> u.Quantity.from_([1.0, 2, 3], unit="m")
+    >>> u.Q.from_([1.0, 2, 3], unit="m")
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
     """
@@ -916,7 +916,7 @@ def from_(
     any subclass of `AbstractQuantity`.
 
     >>> import unxt as u
-    >>> u.Quantity.from_(value=[1.0, 2, 3], unit="m")
+    >>> u.Q.from_(value=[1.0, 2, 3], unit="m")
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
     """
@@ -937,11 +937,11 @@ def from_(cls: type[AbstractQuantity], mapping: Mapping[str, Any]) -> AbstractQu
     >>> import unxt as u
 
     >>> x = jnp.array([1.0, 2, 3])
-    >>> q = u.Quantity.from_({"value": x, "unit": "m"})
+    >>> q = u.Q.from_({"value": x, "unit": "m"})
     >>> q
     Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
-    >>> u.Quantity.from_({"value": q, "unit": "km"})
+    >>> u.Q.from_({"value": q, "unit": "km"})
     Quantity(Array([0.001, 0.002, 0.003], dtype=float32), unit='km')
 
     """
@@ -967,8 +967,8 @@ def from_(
     --------
     >>> import unxt as u
 
-    >>> q = u.Quantity(1, "m")
-    >>> u.Quantity.from_(q, "cm")
+    >>> q = u.Q(1, "m")
+    >>> u.Q.from_(q, "cm")
     Quantity(Array(100., dtype=float32, ...), unit='cm')
 
     """
@@ -993,8 +993,8 @@ def from_(
     --------
     >>> import unxt as u
 
-    >>> q = u.Quantity(1, "m")
-    >>> u.Quantity.from_(q, None)
+    >>> q = u.Q(1, "m")
+    >>> u.Q.from_(q, None)
     Quantity(Array(1, dtype=int32...), unit='m')
 
     """
@@ -1042,7 +1042,7 @@ class _QuantityIndexUpdateHelper(_IndexUpdateHelper):
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Quantity([1, 2, 3, 4], "m")
+        >>> q = u.Q([1, 2, 3, 4], "m")
         >>> q.at
         _QuantityIndexUpdateHelper(Quantity(Array([1, 2, 3, 4], dtype=int32), unit='m'))
 
@@ -1145,7 +1145,7 @@ def is_any_quantity(obj: Any, /) -> TypeGuard[AbstractQuantity]:
     --------
     >>> import unxt as u
 
-    >>> q = u.Quantity(1, "m")
+    >>> q = u.Q(1, "m")
     >>> is_any_quantity(q)
     True
 
@@ -1190,7 +1190,7 @@ def convert_to_quantity_value(obj: AbstractQuantity, /) -> NoReturn:
     >>> from unxt.quantity import convert_to_quantity_value
 
     >>> try:
-    ...     convert_to_quantity_value(u.Quantity(1, "m"))
+    ...     convert_to_quantity_value(u.Q(1, "m"))
     ... except TypeError as e:
     ...     print(e)
     Cannot convert 'Quantity[PhysicalType('length')]' to a value.

--- a/src/unxt/_src/quantity/base_parametric.py
+++ b/src/unxt/_src/quantity/base_parametric.py
@@ -116,7 +116,7 @@ class AbstractParametricQuantity(AbstractQuantity):
         >>> import copy as pycopy
         >>> import unxt as u
 
-        >>> x = u.Quantity([1, 2, 3], "m")
+        >>> x = u.Q([1, 2, 3], "m")
         >>> pycopy.copy(x)
         Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
@@ -162,7 +162,7 @@ class AbstractParametricQuantity(AbstractQuantity):
         >>> import pickle
         >>> import unxt as u
 
-        >>> x = u.Quantity([1, 2, 3], "m")
+        >>> x = u.Q([1, 2, 3], "m")
         >>> pickle.dumps(x)
         b'...'
 
@@ -214,7 +214,7 @@ class AbstractParametricQuantity(AbstractQuantity):
         >>> import unxt as u
         >>> import wadler_lindig as wl
 
-        >>> q = u.Quantity([1, 2, 3], "m")
+        >>> q = u.Q([1, 2, 3], "m")
 
         The default pretty printing:
 

--- a/src/unxt/_src/quantity/flag.py
+++ b/src/unxt/_src/quantity/flag.py
@@ -128,7 +128,7 @@ def ustrip(flag: type[AllowValue], x: AbstractQuantity, /) -> Any:
 
     >>> x = u.Q(1, "kpc")
     >>> y = u.ustrip(AllowValue, x)
-    >>> not isinstance(y, u.Quantity)
+    >>> not isinstance(y, u.Q)
     True
     >>> y == 1
     Array(True, dtype=bool...)

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -37,7 +37,7 @@ class Quantity(AbstractParametricQuantity):
 
     From an integer:
 
-    >>> u.Quantity(1, "m")
+    >>> u.Q(1, "m")
     Quantity(Array(1, dtype=int32...), unit='m')
 
     From a float:
@@ -47,41 +47,41 @@ class Quantity(AbstractParametricQuantity):
 
     From a list:
 
-    >>> u.Quantity([1, 2, 3], "m")
+    >>> u.Q([1, 2, 3], "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a tuple:
 
-    >>> u.Quantity((1, 2, 3), "m")
+    >>> u.Q((1, 2, 3), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `numpy.ndarray`:
 
     >>> import numpy as np
-    >>> u.Quantity(np.array([1, 2, 3]), "m")
+    >>> u.Q(np.array([1, 2, 3]), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     From a `jax.Array`:
 
     >>> import jax.numpy as jnp
-    >>> u.Quantity(jnp.array([1, 2, 3]), "m")
+    >>> u.Q(jnp.array([1, 2, 3]), "m")
     Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
     The unit can also be given as a units object:
 
-    >>> u.Quantity(1, u.unit("m"))
+    >>> u.Q(1, u.unit("m"))
     Quantity(Array(1, dtype=int32...), unit='m')
 
     In the previous examples, the dimension parameter was inferred from the
     values. It can also be given explicitly:
 
-    >>> u.Quantity["length"](1, "m")
+    >>> u.Q["length"](1, "m")
     Quantity(Array(1, dtype=int32...), unit='m')
 
     This can be used for runtime checking of the input dimension!
 
     >>> try:
-    ...     u.Quantity["length"](1, "s")
+    ...     u.Q["length"](1, "s")
     ... except Exception as e:
     ...     print(e)
     Physical type mismatch.
@@ -91,12 +91,12 @@ class Quantity(AbstractParametricQuantity):
     >>> dims = u.dimension("length")
     >>> dims
     PhysicalType('length')
-    >>> u.Quantity[dims](1.0, "m")
+    >>> u.Q[dims](1.0, "m")
     Quantity(Array(1., dtype=float32...), unit='m')
 
     Or as a unit:
 
-    >>> u.Quantity[u.unit("m")](1.0, "m")
+    >>> u.Q[u.unit("m")](1.0, "m")
     Quantity(Array(1., dtype=float32...), unit='m')
 
     Some tricky cases are when the physical type is unknown:
@@ -108,7 +108,7 @@ class Quantity(AbstractParametricQuantity):
     The dimension can be given as a string in all cases, but is necessary when
     the physical type is unknown:
 
-    >>> print(u.Quantity["m2 kg-1 s-2"](1.0, unit))  # to show the [dim]
+    >>> print(u.Q["m2 kg-1 s-2"](1.0, unit))  # to show the [dim]
     Quantity['m2 kg-1 s-2'](1., unit='m2 / (kg s2)')
 
     """
@@ -142,8 +142,8 @@ class Quantity(AbstractParametricQuantity):
 
         Normal array quantities return element-wise boolean arrays:
 
-        >>> q1 = u.Quantity([1, 2, 3], "m")
-        >>> q2 = u.Quantity([1, 0, 3], "m")
+        >>> q1 = u.Q([1, 2, 3], "m")
+        >>> q2 = u.Q([1, 0, 3], "m")
         >>> q1 == q2
         Array([ True, False,  True], dtype=bool)
 

--- a/src/unxt/_src/quantity/register_api.py
+++ b/src/unxt/_src/quantity/register_api.py
@@ -49,12 +49,12 @@ def dimension_of(obj: type[AbstractParametricQuantity], /) -> AbstractDimension:
     >>> import unxt as u
 
     >>> try:
-    ...     u.dimension_of(u.Quantity)
+    ...     u.dimension_of(u.Q)
     ... except Exception as e:
     ...     print(e)
     can only get dimensions from parametrized Quantity -- Quantity[dim].
 
-    >>> u.dimension_of(u.Quantity["length"])
+    >>> u.dimension_of(u.Q["length"])
     PhysicalType('length')
 
     """

--- a/src/unxt/_src/utils.py
+++ b/src/unxt/_src/utils.py
@@ -73,7 +73,7 @@ def promote_dtypes(*arrays: HasDTypeT) -> tuple[HasDTypeT, ...]:
     >>> x1.dtype, x2.dtype
     (dtype('float32'), dtype('float32'))
 
-    >>> q1 = u.Quantity.from_([1, 2, 3], "m", dtype=int)
+    >>> q1 = u.Q.from_([1, 2, 3], "m", dtype=int)
     >>> q2 = u.Q([4.0, 5, 6], unit="km")
     >>> q1, q2 = promote_dtypes(q1, q2)
     >>> q1.dtype, q2.dtype

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -29,13 +29,13 @@ correctness.
 >>> import jax
 >>> import jax.numpy as jnp
 
->>> distance = u.Quantity(100, "m")
+>>> distance = u.Q(100, "m")
 >>> distance
 Quantity(Array(100, dtype=int32...), unit='m')
 
 Create from arrays
 
->>> velocities = u.Quantity([10, 20, 30], "m/s")
+>>> velocities = u.Q([10, 20, 30], "m/s")
 >>> velocities
 Quantity(Array([10, 20, 30], dtype=int32), unit='m / s')
 

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -104,7 +104,7 @@ class TestUconvertValueWithAstropyQuantity:
         q = u.Q(5000, "m")
         result = u.uconvert_value("km", "m", q)
 
-        assert isinstance(result, u.Quantity)
+        assert isinstance(result, u.Q)
         assert jnp.isclose(result.value, 5.0)
         assert result.unit == u.unit("km")
 
@@ -118,7 +118,7 @@ class TestUconvertValueWithAstropyQuantity:
         q = u.Q([1000, 2000, 5000], "m")
         result = u.uconvert_value("km", "m", q)
 
-        assert isinstance(result, u.Quantity)
+        assert isinstance(result, u.Q)
         assert np.allclose(result.value, [1.0, 2.0, 5.0])
         assert result.unit == u.unit("km")
 

--- a/tests/integration/equinox/test_module.py
+++ b/tests/integration/equinox/test_module.py
@@ -11,6 +11,6 @@ def quantity_as_module_field():
     class TestModule(eqx.Module):
         """Test module."""
 
-        field: u.Quantity = u.Q(1.0, "m")
+        field: u.Q = u.Q(1.0, "m")
 
     assert TestModule().field == u.Q(1.0, "m")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -699,7 +699,7 @@ def test_config_context_manager_with_quantity() -> None:
         u.config.quantity_repr.short_arrays = False
         u.config.quantity_repr.use_short_name = False
 
-        q = u.Quantity([1, 2, 3], "m")
+        q = u.Q([1, 2, 3], "m")
 
         # Default repr (with short_arrays=False, use_short_name=False)
         default_repr = repr(q)

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -178,13 +178,13 @@ def test_uconvert_value_with_quantity():
     # Convert a Quantity object using uconvert_value
     q = u.Q(1, "km")
     result = u.uconvert_value("m", "km", q)
-    assert isinstance(result, u.Quantity)
+    assert isinstance(result, u.Q)
     assert jnp.isclose(result.value, 1000.0)
     assert result.unit == u.unit("m")
 
     # With unit objects
     result = u.uconvert_value(u.unit("m"), u.unit("km"), q)
-    assert isinstance(result, u.Quantity)
+    assert isinstance(result, u.Q)
     assert jnp.isclose(result.value, 1000.0)
     assert result.unit == u.unit("m")
 
@@ -233,7 +233,7 @@ def test_uconvert_value_with_array_quantities():
     q = u.Q([1, 2, 3], "km")
     result = u.uconvert_value("m", "km", q)
 
-    assert isinstance(result, u.Quantity)
+    assert isinstance(result, u.Q)
     assert np.allclose(result.value, [1000.0, 2000.0, 3000.0])
     assert result.unit == u.unit("m")
 

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -69,8 +69,8 @@ class TestShortName:
 
     def test_quantity_has_short_name(self):
         """Test that Quantity has a short_name class variable."""
-        assert hasattr(u.Quantity, "short_name")
-        assert u.Quantity.short_name == "Q"
+        assert hasattr(u.Q, "short_name")
+        assert u.Q.short_name == "Q"
 
     def test_barequantity_no_short_name(self):
         """Test that BareQuantity doesn't have a short_name or it's None."""
@@ -165,7 +165,7 @@ class TestStringConversionWithJIT:
         """
 
         @jax.jit
-        def process_with_str(q: u.Quantity) -> u.Quantity:
+        def process_with_str(q: u.Q) -> u.Q:
             # Call str() on the tracer to verify it doesn't raise
             _ = str(q)
             # Return the quantity multiplied by 2
@@ -198,7 +198,7 @@ class TestStringConversionWithJIT:
         """Test that str(Quantity) works reliably in multiple JIT calls."""
 
         @jax.jit
-        def process_and_stringify(q: u.Quantity) -> u.Quantity:
+        def process_and_stringify(q: u.Q) -> u.Q:
             # Multiple str() calls shouldn't affect the computation
             _ = str(q)
             q_doubled = q * 2

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -87,7 +87,7 @@ def test_static_quantity_promotes_to_quantity() -> None:
 def test_static_quantity_subtraction_with_quantity() -> None:
     """StaticQuantity subtraction with Quantity promotes to Quantity."""
     sq = u.StaticQuantity(np.array(1.0), "s")
-    q = u.Quantity(0.5, "s")
+    q = u.Q(0.5, "s")
 
     # Quantity - StaticQuantity -> Quantity
     result1 = q - sq
@@ -114,7 +114,7 @@ def test_static_quantity_subtraction_preserves_static() -> None:
 def test_static_quantity_addition_with_quantity() -> None:
     """StaticQuantity addition with Quantity promotes to Quantity."""
     sq = u.StaticQuantity(np.array(1.0), "s")
-    q = u.Quantity(0.5, "s")
+    q = u.Q(0.5, "s")
 
     # Quantity + StaticQuantity -> Quantity
     result1 = q + sq
@@ -141,7 +141,7 @@ def test_static_quantity_addition_preserves_static() -> None:
 def test_static_quantity_multiplication_with_quantity() -> None:
     """StaticQuantity multiplication with Quantity promotes to Quantity."""
     sq = u.StaticQuantity(2.0, "m")
-    q = u.Quantity(3.0, "s")
+    q = u.Q(3.0, "s")
 
     # Quantity * StaticQuantity -> Quantity
     result1 = q * sq
@@ -196,7 +196,7 @@ def test_static_quantity_integer_power_preserves_static_array() -> None:
 def test_static_quantity_division_with_quantity() -> None:
     """StaticQuantity division with Quantity promotes to Quantity."""
     sq = u.StaticQuantity(6.0, "m")
-    q = u.Quantity(2.0, "s")
+    q = u.Q(2.0, "s")
 
     # Quantity / StaticQuantity -> Quantity
     result1 = q / sq
@@ -238,7 +238,7 @@ def test_static_quantity_division_integer_inputs() -> None:
 def test_static_quantity_modulo_with_quantity() -> None:
     """StaticQuantity modulo with Quantity promotes to Quantity."""
     sq = u.StaticQuantity(7.0, "m")
-    q = u.Quantity(3.0, "m")
+    q = u.Q(3.0, "m")
 
     # Quantity % StaticQuantity -> Quantity (via promotion)
     result1 = q % sq


### PR DESCRIPTION
## What

Replace `u.Quantity` with the `u.Q` convenience alias across the codebase (src, tests, docs, packages) — 33 files.

## Why it's safe

`Q` is `Quantity` — `u.Q is u.Quantity` evaluates to `True` — so this is a purely cosmetic alias migration with **no behavior change**.

- Only the `unxt`-aliased token was changed: the substitution `\bu\.Quantity\b → u.Q` was applied only where `u` is `import unxt as u`. Verified no file aliases astropy as `u` (astropy is always `apyu`).
- **astropy's `apyu.Quantity` references are deliberately left untouched** (the word-boundary match skips them).
- Doctest *outputs* (`Quantity(...)` reprs) are unchanged — only call-sites/`isinstance`/subscripts converted.

## Verification

- Full suite: **2916 passed, 50 skipped, 14 xfailed**.
- ruff check + format, codespell, commitizen: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)