### PR TITLE
♻️ refactor: namespace the unxt config under `[tool.unxts.unxt]`

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -221,13 +221,13 @@ Indentation width for nested structures in `str()`.
 The configuration uses a hierarchical format matching the nested structure:
 
 ```toml
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = "compact"
 use_short_name = true
 named_unit = false
 indent = 4
 
-[tool.unxt.quantity.str]
+[tool.unxts.unxt.quantity.str]
 short_arrays = true
 named_unit = false
 use_short_name = false
@@ -239,7 +239,7 @@ You only need to set the options you want to override.
 Minimal example:
 
 ```toml
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = "compact"
 use_short_name = true
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -111,6 +111,17 @@ The `include_params` display option — whether `repr()`/`str()` show the `['len
 
 Defaults are unchanged (`repr` hides the parameter, `str` shows it). The other display settings (`short_arrays`, `use_short_name`, `named_unit`, `indent`) remain in `unxt.config`. See the [parametric quantity guide](packages/unxts.parametric/index.md#configuration).
 
+### Config file section renamed to `[tool.unxts.unxt]`
+
+`unxt`'s `pyproject.toml` display configuration moved from `[tool.unxt...]` to `[tool.unxts.unxt...]`, matching the shared `unxts.*` namespace (alongside `[tool.unxts.parametric...]`). Rename any existing sections:
+
+| v1                          | v2                                |
+| --------------------------- | --------------------------------- |
+| `[tool.unxt.quantity.repr]` | `[tool.unxts.unxt.quantity.repr]` |
+| `[tool.unxt.quantity.str]`  | `[tool.unxts.unxt.quantity.str]`  |
+
+In-code configuration via `u.config` is unchanged.
+
 ---
 
 ## Deprecation: `BareQuantity`

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -696,8 +696,9 @@ def _load_toml_config_from_pyproject(
     path : Path
         Path to pyproject.toml file
     tool_path : tuple of str
-        Keys under ``[tool]`` to navigate into (e.g. ``("unxt",)`` or
-        ``("unxts", "parametric")``). Defaults to unxt's own section.
+        Keys under ``[tool]`` to navigate into (e.g. ``("unxts", "unxt")`` or
+        ``("unxts", "parametric")``). Defaults to unxt's own section,
+        ``[tool.unxts.unxt]``.
     path_to_class : dict
         Mapping from TOML sub-path to Config class name (passed through to
         :func:`_walk_toml_config`).

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -621,7 +621,7 @@ def _walk_toml_config(
     Parameters
     ----------
     data : dict
-        Nested dictionary from parsed TOML (e.g., tool.unxt section)
+        Nested dictionary from parsed TOML (e.g., tool.unxts.unxt section)
     path : tuple of str
         Current path in the nested structure (e.g., ("quantity", "repr"))
     path_to_class : dict
@@ -638,8 +638,8 @@ def _walk_toml_config(
     --------
     >>> import tomllib
     >>> from pathlib import Path
-    >>> toml = '[tool.unxt.quantity.repr]\nshort_arrays = "compact"\n'
-    >>> data = tomllib.loads(toml)["tool"]["unxt"]
+    >>> toml = '[tool.unxts.unxt.quantity.repr]\nshort_arrays = "compact"\n'
+    >>> data = tomllib.loads(toml)["tool"]["unxts"]["unxt"]
     >>> configs = _walk_toml_config(data)
     >>> "QuantityReprConfig" in configs
     True
@@ -672,7 +672,7 @@ def _load_toml_config_from_pyproject(
     path: Path,
     /,
     *,
-    tool_path: tuple[str, ...] = ("unxt",),
+    tool_path: tuple[str, ...] = ("unxts", "unxt"),
     path_to_class: dict[tuple[str, ...], str] | None = None,
 ) -> Config:
     """Load a ``[tool.<...>]`` section from a ``pyproject.toml`` file.
@@ -680,12 +680,12 @@ def _load_toml_config_from_pyproject(
     Supports both nested sections and dotted keys:
 
     Nested sections:
-        [tool.unxt.quantity.repr]
+        [tool.unxts.unxt.quantity.repr]
         short_arrays = "compact"
         use_short_name = true
 
     Dotted keys:
-        [tool.unxt]
+        [tool.unxts.unxt]
         quantity.repr.short_arrays = "compact"
         quantity.repr.use_short_name = true
 
@@ -758,7 +758,7 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
 
     This function:
     1. Searches for nearest pyproject.toml from cwd
-    2. Loads [tool.unxt] configuration
+    2. Loads [tool.unxts.unxt] configuration
     3. Applies valid settings to config instances
     4. Silently ignores invalid values or missing files
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -82,7 +82,7 @@ def test_load_toml_config_from_pyproject(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """\
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = "compact"
 use_short_name = true
 """,
@@ -105,7 +105,7 @@ def test_load_toml_config_no_tool_section(tmp_path: Path) -> None:
 
 
 def test_load_toml_config_no_unxt_section(tmp_path: Path) -> None:
-    """Test _load_toml_config_from_pyproject with no [tool.unxt] section."""
+    """Test _load_toml_config_from_pyproject with no [tool.unxts.unxt] section."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         "[tool.other]\nenabled = true\n",
@@ -210,7 +210,7 @@ def test_auto_load_toml_from_pyproject_on_import(tmp_path: Path) -> None:
 name = "demo-project"
 version = "0.1.0"
 
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = "compact"
 use_short_name = true
 named_unit = false
@@ -232,7 +232,7 @@ def test_auto_load_uses_nearest_pyproject(tmp_path: Path) -> None:
 
     _ = (root / "pyproject.toml").write_text(
         """\
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = false
 use_short_name = false
 """,
@@ -240,7 +240,7 @@ use_short_name = false
     )
     _ = (pkg / "pyproject.toml").write_text(
         """\
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 short_arrays = "compact"
 use_short_name = true
 """,
@@ -253,7 +253,7 @@ use_short_name = true
 
 
 def test_auto_load_ignores_pyproject_without_tool_unxt(tmp_path: Path) -> None:
-    """Import should keep defaults if pyproject.toml has no [tool.unxt] section."""
+    """Keep defaults when pyproject.toml has no [tool.unxts.unxt] section."""
     project = tmp_path / "no_unxt_config"
     project.mkdir()
     _ = (project / "pyproject.toml").write_text(
@@ -284,12 +284,12 @@ def test_auto_load_ignores_invalid_toml_entries(tmp_path: Path) -> None:
 name = "demo-project"
 version = "0.1.0"
 
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 use_short_name = true
 indent = "not-an-int"
 typo_option = true
 
-[tool.unxt.quantity.str]
+[tool.unxts.unxt.quantity.str]
 indent = "not-an-int"
 """,
         encoding="utf-8",
@@ -313,7 +313,7 @@ def test_auto_load_dotted_key_syntax(tmp_path: Path) -> None:
 name = "demo-project"
 version = "0.1.0"
 
-[tool.unxt]
+[tool.unxts.unxt]
 quantity.repr.use_short_name = true
 quantity.repr.short_arrays = "compact"
 quantity.str.use_short_name = true
@@ -339,12 +339,12 @@ name = "demo-project"
 version = "0.1.0"
 
 # Dotted key syntax for repr config
-[tool.unxt]
+[tool.unxts.unxt]
 quantity.repr.use_short_name = true
 quantity.repr.short_arrays = "compact"
 
 # Nested section syntax for str config
-[tool.unxt.quantity.str]
+[tool.unxts.unxt.quantity.str]
 named_unit = false
 use_short_name = true
 """,
@@ -358,7 +358,7 @@ use_short_name = true
 
 
 def test_auto_load_empty_tool_unxt_section(tmp_path: Path) -> None:
-    """Empty [tool.unxt] section should not affect defaults."""
+    """Empty [tool.unxts.unxt] section should not affect defaults."""
     project = tmp_path / "empty_unxt"
     project.mkdir()
     _ = (project / "pyproject.toml").write_text(
@@ -367,7 +367,7 @@ def test_auto_load_empty_tool_unxt_section(tmp_path: Path) -> None:
 name = "demo-project"
 version = "0.1.0"
 
-[tool.unxt]
+[tool.unxts.unxt]
 """,
         encoding="utf-8",
     )
@@ -380,19 +380,19 @@ version = "0.1.0"
 
 
 def test_auto_load_unknown_toml_sections_ignored(tmp_path: Path) -> None:
-    """Unknown sections under [tool.unxt] should be silently ignored."""
+    """Unknown sections under [tool.unxts.unxt] should be silently ignored."""
     project = tmp_path / "unknown_sections"
     project.mkdir()
     _ = (project / "pyproject.toml").write_text(
         """\
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 use_short_name = true
 
-[tool.unxt.future_feature]
+[tool.unxts.unxt.future_feature]
 enabled = true
 some_value = 42
 
-[tool.unxt.another.unknown.path]
+[tool.unxts.unxt.another.unknown.path]
 value = "ignored"
 """,
         encoding="utf-8",
@@ -456,7 +456,7 @@ tool = "not-a-dict"
 
 
 def test_auto_load_non_dict_unxt_section(tmp_path: Path) -> None:
-    """Non-dict [tool.unxt] section should be ignored without error."""
+    """Non-dict [tool.unxts.unxt] section should be ignored without error."""
     project = tmp_path / "non_dict_unxt"
     project.mkdir()
     _ = (project / "pyproject.toml").write_text(
@@ -864,7 +864,7 @@ def test_auto_load_handles_oserror_gracefully(tmp_path: Path) -> None:
     project.mkdir()
     pyproject = project / "pyproject.toml"
     pyproject.write_text(
-        "[tool.unxt.quantity.repr]\nuse_short_name = true\n", encoding="utf-8"
+        "[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n", encoding="utf-8"
     )
 
     # Patch pathlib.Path.open before importing unxt in the subprocess so
@@ -902,7 +902,7 @@ def test_auto_load_handles_keyerror_in_toml(tmp_path: Path) -> None:
     pyproject = project / "pyproject.toml"
     pyproject.write_text(
         """\
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 use_short_name = true
 """,
         encoding="utf-8",
@@ -990,7 +990,7 @@ dev-dependencies = [
     "pytest>=8.0",
 ]
 
-[tool.unxt.quantity.repr]
+[tool.unxts.unxt.quantity.repr]
 # Configure unxt for compact notebook output
 short_arrays = "compact"
 use_short_name = true


### PR DESCRIPTION
## Summary

Follow-up to #684. `unxt`'s `pyproject.toml` display configuration now loads from **`[tool.unxts.unxt...]`** instead of `[tool.unxt...]`, so the whole family shares one `[tool.unxts.*]` namespace:

- `[tool.unxts.unxt.quantity.repr]` / `[...str]` — core `unxt` display config
- `[tool.unxts.parametric.quantity.repr]` / `[...str]` — `unxts.parametric` (`include_params`)

This uses the `tool_path` parameter that #684 added to `_load_toml_config_from_pyproject`; only the core config's default section changes.

## Changes

- `src/unxt/_src/config.py`: default `_load_toml_config_from_pyproject` `tool_path` to `("unxts", "unxt")`; update docstrings/examples.
- `tests/unit/test_config.py`: retarget the TOML fixtures.
- `docs/guides/configuration.md`: update the `pyproject.toml` example; migration guide gains a note for the section rename.

## Breaking change

Users with a `[tool.unxt.quantity.repr]` / `[tool.unxt.quantity.str]` section must rename it to `[tool.unxts.unxt...]`. In-code configuration via `u.config` is unchanged. Since v2 is already a major break (and the section was silently unread before), this rides along in the same major.

## Testing

- `pytest src/unxt/_src/config.py tests/unit/test_config.py docs/guides/configuration.md` — green (loads from the new section; keeps defaults when absent).
- ruff / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)