### PR TITLE
✨ feat: add `unxts.linalg` package (`QuantityMatrix`) + docs + CI/CD

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -78,3 +78,19 @@
           - ".github/workflows/cd-unxts-interop-xarray.yml"
           - ".github/workflows/cd-publish-unxts-interop-xarray.yml"
           - ".github/workflows/cd-pr-unxts-interop-xarray.yml"
+
+"🧩 unxts-linalg":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/unxts.linalg/**"
+          - ".github/workflows/cd-unxts-linalg.yml"
+          - ".github/workflows/cd-publish-unxts-linalg.yml"
+          - ".github/workflows/cd-pr-unxts-linalg.yml"
+
+"🧩 unxts-parametric":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/unxts.parametric/**"
+          - ".github/workflows/cd-unxts-parametric.yml"
+          - ".github/workflows/cd-publish-unxts-parametric.yml"
+          - ".github/workflows/cd-pr-unxts-parametric.yml"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -337,3 +337,11 @@
 - name: "🧩 unxts-interop-xarray"
   color: "0366d6"
   description: "Issues/PRs affecting the unxts.interop.xarray namespace package"
+
+- name: "🧩 unxts-linalg"
+  color: "0366d6"
+  description: "Issues/PRs affecting the unxts.linalg namespace package"
+
+- name: "🧩 unxts-parametric"
+  color: "0366d6"
+  description: "Issues/PRs affecting the unxts.parametric namespace package"

--- a/.github/workflows/cd-pr-unxts-linalg.yml
+++ b/.github/workflows/cd-pr-unxts-linalg.yml
@@ -1,0 +1,37 @@
+name: CD PR - unxts-linalg
+
+on:
+  pull_request:
+    paths:
+      - "packages/unxts.linalg/**"
+      - ".github/workflows/cd-unxts-linalg.yml"
+      - ".github/workflows/cd-pr-unxts-linalg.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & inspect package (PR)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Required for hatch-vcs to determine version from git tags.
+          # Can be removed if switching to hardcoded versions.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        with:
+          path: packages/unxts.linalg
+          upload-name-suffix: -unxts-linalg
+          attest-build-provenance-github: false

--- a/.github/workflows/cd-pr-unxts-parametric.yml
+++ b/.github/workflows/cd-pr-unxts-parametric.yml
@@ -1,0 +1,37 @@
+name: CD PR - unxts-parametric
+
+on:
+  pull_request:
+    paths:
+      - "packages/unxts.parametric/**"
+      - ".github/workflows/cd-unxts-parametric.yml"
+      - ".github/workflows/cd-pr-unxts-parametric.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & inspect package (PR)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Required for hatch-vcs to determine version from git tags.
+          # Can be removed if switching to hardcoded versions.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        with:
+          path: packages/unxts.parametric
+          upload-name-suffix: -unxts-parametric
+          attest-build-provenance-github: false

--- a/.github/workflows/cd-publish-unxts-linalg.yml
+++ b/.github/workflows/cd-publish-unxts-linalg.yml
@@ -1,0 +1,216 @@
+name: CD Publish - unxts-linalg
+
+# Stage B: privileged publish workflow.
+# Triggered only after Stage A ("CD - unxts-linalg") completes successfully.
+# Downloads and validates the release-metadata artifact produced by Stage A before
+# publishing, so that no repository code ever executes in a privileged context.
+
+on:
+  workflow_run:
+    workflows:
+      - "CD - unxts-linalg"
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  validate:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      publish_testpypi: ${{ steps.validate.outputs.publish_testpypi }}
+      publish_pypi: ${{ steps.validate.outputs.publish_pypi }}
+
+    steps:
+      - name: Download release metadata artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: release-metadata-unxts-linalg
+          path: .
+
+      - name: Validate metadata and determine publish targets
+        id: validate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            const metadataPath = "release-metadata.json";
+
+            if (!fs.existsSync(metadataPath)) {
+              core.setFailed("Missing release-metadata.json artifact.");
+              return;
+            }
+
+            let metadata;
+            try {
+              metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+            } catch (error) {
+              core.setFailed(`Invalid release-metadata.json: ${error.message}`);
+              return;
+            }
+
+            const { package: pkg, package_tag, head_sha, trigger_event } = metadata;
+            const workflowRun = context.payload.workflow_run;
+
+            // Validate package identity.
+            if (pkg !== "unxts-linalg") {
+              core.setFailed(`Unexpected package in artifact: ${pkg}`);
+              return;
+            }
+
+            // Validate head SHA integrity: artifact must match the triggering run.
+            if (typeof head_sha !== "string" || head_sha.length === 0) {
+              core.setFailed("Invalid head_sha in artifact.");
+              return;
+            }
+            if (head_sha !== workflowRun.head_sha) {
+              core.setFailed(
+                `Artifact head SHA ${head_sha} does not match workflow_run head SHA ${workflowRun.head_sha}.`
+              );
+              return;
+            }
+
+            // Validate trigger_event field (sanity check; gating uses trusted workflow_run context).
+            if (typeof trigger_event !== "string") {
+              core.setFailed("Invalid trigger_event in artifact.");
+              return;
+            }
+
+            // Determine which publish operations to perform.
+            const hasTag = typeof package_tag === "string" && package_tag.length > 0;
+            const isValidTag = hasTag && /^unxts-linalg-v\d+\.\d+\.\d+$/.test(package_tag);
+            if (hasTag && !isValidTag) {
+              core.setFailed(
+                `Invalid package_tag in artifact: ${package_tag}. Expected exact format unxts-linalg-vX.Y.Z.`
+              );
+              return;
+            }
+
+            // Gate publish decisions on trusted GitHub event context, not artifact trigger_event.
+            const trustedEvent = workflowRun.event;
+            const trustedBranch = workflowRun.head_branch;
+
+            // For tagged releases, verify the tag exists and resolves to the triggering commit.
+            let verifiedTag = false;
+            if (hasTag) {
+              try {
+                const refData = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `tags/${package_tag}`,
+                });
+                let tagTargetSha = refData.data.object.sha;
+                // Dereference annotated tags.
+                if (refData.data.object.type === "tag") {
+                  const tagObj = await github.rest.git.getTag({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    tag_sha: tagTargetSha,
+                  });
+                  tagTargetSha = tagObj.data.object.sha;
+                }
+                if (tagTargetSha !== workflowRun.head_sha) {
+                  core.setFailed(
+                    `Tag ${package_tag} resolves to commit ${tagTargetSha}, ` +
+                    `not workflow_run head SHA ${workflowRun.head_sha}.`
+                  );
+                  return;
+                }
+                verifiedTag = true;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(`Tag ${package_tag} does not exist in the repository.`);
+                } else {
+                  core.setFailed(`Failed to verify tag ${package_tag}: ${error.message}`);
+                }
+                return;
+              }
+            }
+
+            let publishTestPyPI = false;
+            let publishPyPI = false;
+
+            if (verifiedTag) {
+              // Tag verified via GitHub API: publish to both registries.
+              publishTestPyPI = true;
+              publishPyPI = true;
+            } else if (trustedEvent === "push" && trustedBranch === "main" && !hasTag) {
+              // Trusted push to main (no tag): publish to TestPyPI only.
+              publishTestPyPI = true;
+            }
+            // workflow_dispatch or other events: no publish.
+
+            core.info(`package_tag: ${package_tag || "(none)"}`);
+            core.info(`trigger_event (artifact): ${trigger_event}`);
+            core.info(`trusted_event: ${trustedEvent}, trusted_branch: ${trustedBranch}`);
+            core.info(`publish_testpypi: ${publishTestPyPI}`);
+            core.info(`publish_pypi: ${publishPyPI}`);
+
+            core.setOutput("publish_testpypi", String(publishTestPyPI));
+            core.setOutput("publish_pypi", String(publishPyPI));
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [validate]
+    if: needs.validate.outputs.publish_testpypi == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/unxts.linalg
+    permissions:
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: Packages-unxts-linalg
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [validate]
+    if: needs.validate.outputs.publish_pypi == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/unxts.linalg
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: Packages-unxts-linalg
+          path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/*
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/cd-publish-unxts-parametric.yml
+++ b/.github/workflows/cd-publish-unxts-parametric.yml
@@ -1,0 +1,216 @@
+name: CD Publish - unxts-parametric
+
+# Stage B: privileged publish workflow.
+# Triggered only after Stage A ("CD - unxts-parametric") completes successfully.
+# Downloads and validates the release-metadata artifact produced by Stage A before
+# publishing, so that no repository code ever executes in a privileged context.
+
+on:
+  workflow_run:
+    workflows:
+      - "CD - unxts-parametric"
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  validate:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      publish_testpypi: ${{ steps.validate.outputs.publish_testpypi }}
+      publish_pypi: ${{ steps.validate.outputs.publish_pypi }}
+
+    steps:
+      - name: Download release metadata artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: release-metadata-unxts-parametric
+          path: .
+
+      - name: Validate metadata and determine publish targets
+        id: validate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            const metadataPath = "release-metadata.json";
+
+            if (!fs.existsSync(metadataPath)) {
+              core.setFailed("Missing release-metadata.json artifact.");
+              return;
+            }
+
+            let metadata;
+            try {
+              metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+            } catch (error) {
+              core.setFailed(`Invalid release-metadata.json: ${error.message}`);
+              return;
+            }
+
+            const { package: pkg, package_tag, head_sha, trigger_event } = metadata;
+            const workflowRun = context.payload.workflow_run;
+
+            // Validate package identity.
+            if (pkg !== "unxts-parametric") {
+              core.setFailed(`Unexpected package in artifact: ${pkg}`);
+              return;
+            }
+
+            // Validate head SHA integrity: artifact must match the triggering run.
+            if (typeof head_sha !== "string" || head_sha.length === 0) {
+              core.setFailed("Invalid head_sha in artifact.");
+              return;
+            }
+            if (head_sha !== workflowRun.head_sha) {
+              core.setFailed(
+                `Artifact head SHA ${head_sha} does not match workflow_run head SHA ${workflowRun.head_sha}.`
+              );
+              return;
+            }
+
+            // Validate trigger_event field (sanity check; gating uses trusted workflow_run context).
+            if (typeof trigger_event !== "string") {
+              core.setFailed("Invalid trigger_event in artifact.");
+              return;
+            }
+
+            // Determine which publish operations to perform.
+            const hasTag = typeof package_tag === "string" && package_tag.length > 0;
+            const isValidTag = hasTag && /^unxts-parametric-v\d+\.\d+\.\d+$/.test(package_tag);
+            if (hasTag && !isValidTag) {
+              core.setFailed(
+                `Invalid package_tag in artifact: ${package_tag}. Expected exact format unxts-parametric-vX.Y.Z.`
+              );
+              return;
+            }
+
+            // Gate publish decisions on trusted GitHub event context, not artifact trigger_event.
+            const trustedEvent = workflowRun.event;
+            const trustedBranch = workflowRun.head_branch;
+
+            // For tagged releases, verify the tag exists and resolves to the triggering commit.
+            let verifiedTag = false;
+            if (hasTag) {
+              try {
+                const refData = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `tags/${package_tag}`,
+                });
+                let tagTargetSha = refData.data.object.sha;
+                // Dereference annotated tags.
+                if (refData.data.object.type === "tag") {
+                  const tagObj = await github.rest.git.getTag({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    tag_sha: tagTargetSha,
+                  });
+                  tagTargetSha = tagObj.data.object.sha;
+                }
+                if (tagTargetSha !== workflowRun.head_sha) {
+                  core.setFailed(
+                    `Tag ${package_tag} resolves to commit ${tagTargetSha}, ` +
+                    `not workflow_run head SHA ${workflowRun.head_sha}.`
+                  );
+                  return;
+                }
+                verifiedTag = true;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(`Tag ${package_tag} does not exist in the repository.`);
+                } else {
+                  core.setFailed(`Failed to verify tag ${package_tag}: ${error.message}`);
+                }
+                return;
+              }
+            }
+
+            let publishTestPyPI = false;
+            let publishPyPI = false;
+
+            if (verifiedTag) {
+              // Tag verified via GitHub API: publish to both registries.
+              publishTestPyPI = true;
+              publishPyPI = true;
+            } else if (trustedEvent === "push" && trustedBranch === "main" && !hasTag) {
+              // Trusted push to main (no tag): publish to TestPyPI only.
+              publishTestPyPI = true;
+            }
+            // workflow_dispatch or other events: no publish.
+
+            core.info(`package_tag: ${package_tag || "(none)"}`);
+            core.info(`trigger_event (artifact): ${trigger_event}`);
+            core.info(`trusted_event: ${trustedEvent}, trusted_branch: ${trustedBranch}`);
+            core.info(`publish_testpypi: ${publishTestPyPI}`);
+            core.info(`publish_pypi: ${publishPyPI}`);
+
+            core.setOutput("publish_testpypi", String(publishTestPyPI));
+            core.setOutput("publish_pypi", String(publishPyPI));
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [validate]
+    if: needs.validate.outputs.publish_testpypi == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/unxts.parametric
+    permissions:
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: Packages-unxts-parametric
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [validate]
+    if: needs.validate.outputs.publish_pypi == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/unxts.parametric
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: Packages-unxts-parametric
+          path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/*
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/cd-unxts-linalg.yml
+++ b/.github/workflows/cd-unxts-linalg.yml
@@ -1,0 +1,92 @@
+name: CD - unxts-linalg
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "unxts-linalg-v*" # Package-specific tags (unxts-linalg-vX.Y.Z)
+    paths:
+      - "packages/unxts.linalg/**"
+      - ".github/workflows/cd-unxts-linalg.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  build:
+    name: Build & inspect package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Required for hatch-vcs to determine version from git tags.
+          # Can be removed if switching to hardcoded versions.
+          fetch-depth: 0
+          persist-credentials: false
+          # This workflow only runs on trusted `push` and `workflow_dispatch` events.
+          # `github.ref` is therefore constrained to repository refs (main/tag or a
+          # manually selected ref) and does not accept untrusted PR fork heads.
+          ref: ${{ github.ref }}
+
+      - name: Validate git tag (for tagged releases)
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
+        env:
+          GITHUB_REF_VAR: ${{ github.ref }}
+        run: |
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
+          python scripts/validate_tag.py "$TAG" "unxts-linalg"
+        shell: bash
+
+      - name: Emit release metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=""
+          fi
+          TRIGGER_EVENT="${EVENT_NAME}"
+
+          jq -n \
+            --arg package "unxts-linalg" \
+            --arg package_tag "${TAG}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg trigger_event "${TRIGGER_EVENT}" \
+            '{"package": $package, "package_tag": $package_tag, "head_sha": $head_sha, "trigger_event": $trigger_event}' \
+            > release-metadata.json
+
+          echo "Release metadata:"
+          cat release-metadata.json
+        shell: bash
+
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        with:
+          path: packages/unxts.linalg
+          upload-name-suffix: -unxts-linalg
+          attest-build-provenance-github: false
+
+      - name: Upload release metadata artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-metadata-unxts-linalg
+          path: release-metadata.json
+          retention-days: 7

--- a/.github/workflows/cd-unxts-parametric.yml
+++ b/.github/workflows/cd-unxts-parametric.yml
@@ -1,0 +1,92 @@
+name: CD - unxts-parametric
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "unxts-parametric-v*" # Package-specific tags (unxts-parametric-vX.Y.Z)
+    paths:
+      - "packages/unxts.parametric/**"
+      - ".github/workflows/cd-unxts-parametric.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  build:
+    name: Build & inspect package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Required for hatch-vcs to determine version from git tags.
+          # Can be removed if switching to hardcoded versions.
+          fetch-depth: 0
+          persist-credentials: false
+          # This workflow only runs on trusted `push` and `workflow_dispatch` events.
+          # `github.ref` is therefore constrained to repository refs (main/tag or a
+          # manually selected ref) and does not accept untrusted PR fork heads.
+          ref: ${{ github.ref }}
+
+      - name: Validate git tag (for tagged releases)
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
+        env:
+          GITHUB_REF_VAR: ${{ github.ref }}
+        run: |
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
+          python scripts/validate_tag.py "$TAG" "unxts-parametric"
+        shell: bash
+
+      - name: Emit release metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=""
+          fi
+          TRIGGER_EVENT="${EVENT_NAME}"
+
+          jq -n \
+            --arg package "unxts-parametric" \
+            --arg package_tag "${TAG}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg trigger_event "${TRIGGER_EVENT}" \
+            '{"package": $package, "package_tag": $package_tag, "head_sha": $head_sha, "trigger_event": $trigger_event}' \
+            > release-metadata.json
+
+          echo "Release metadata:"
+          cat release-metadata.json
+        shell: bash
+
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        with:
+          path: packages/unxts.parametric
+          upload-name-suffix: -unxts-parametric
+          attest-build-provenance-github: false
+
+      - name: Upload release metadata artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-metadata-unxts-parametric
+          path: release-metadata.json
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,83 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # unxts-parametric package tests
+  tests-unxts-parametric:
+    name:
+      unxts-parametric Python ${{ matrix.python-version }} on ${{ matrix.runs-on
+      }}
+    runs-on: ${{ matrix.runs-on }}
+    needs: [setup, format]
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, '🧩 unxts-parametric') ||
+      startsWith(github.head_ref, 'unxts-parametric/')
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
+        runs-on: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          uv sync --no-default-groups --group test --locked --package unxts-parametric
+
+      - name: Test package
+        run: |
+          uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/tests --cov=packages/unxts.parametric/src --cov-report=xml --cov-report=term
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # unxts-linalg package tests
+  tests-unxts-linalg:
+    name:
+      unxts-linalg Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    needs: [setup, format]
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, '🧩 unxts-linalg') ||
+      startsWith(github.head_ref, 'unxts-linalg/')
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
+        runs-on: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          uv sync --no-default-groups --group test --locked --package unxts-linalg
+
+      - name: Test package
+        run: |
+          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/tests --cov=packages/unxts.linalg/src --cov-report=xml --cov-report=term
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   test-oldest:
     name: Check Oldest Dependencies
     runs-on: ${{ matrix.runs-on }}
@@ -468,6 +545,8 @@ jobs:
         tests-unxts-interop-gala,
         tests-unxts-interop-matplotlib,
         tests-unxts-interop-xarray,
+        tests-unxts-parametric,
+        tests-unxts-linalg,
         test-oldest,
         test-newest,
         test-interoperability,
@@ -485,4 +564,5 @@ jobs:
           allowed-skips:
             tests-unxt-api, tests-unxt-hypothesis, tests-unxts-api,
             tests-unxts-hypothesis, tests-unxts-interop-gala,
-            tests-unxts-interop-matplotlib, tests-unxts-interop-xarray
+            tests-unxts-interop-matplotlib, tests-unxts-interop-xarray,
+            tests-unxts-parametric, tests-unxts-linalg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,10 @@ jobs:
 
       - name: Test package
         run: |
+          # src doctests and tests are collected in separate invocations: the
+          # namespace package's leaf dir is imported under one name for src and
+          # another for tests, so co-collecting them double-imports the module.
+          uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/src
           uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/tests --cov=packages/unxts.parametric/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
@@ -425,6 +429,10 @@ jobs:
 
       - name: Test package
         run: |
+          # src doctests and tests are collected in separate invocations: the
+          # namespace package's leaf dir is imported under one name for src and
+          # another for tests, so co-collecting them double-imports the module.
+          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/src
           uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/tests --cov=packages/unxts.linalg/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -60,6 +60,8 @@ jobs:
             echo "  - unxts-interop-gala-v${VERSION}"
             echo "  - unxts-interop-matplotlib-v${VERSION}"
             echo "  - unxts-interop-xarray-v${VERSION}"
+            echo "  - unxts-parametric-v${VERSION}"
+            echo "  - unxts-linalg-v${VERSION}"
             exit 1
           fi
 
@@ -84,7 +86,7 @@ jobs:
           echo "Coordinator tag $TAG points to commit: $COORDINATOR_SHA"
 
           # Define package tags to create
-          PACKAGES=("unxt" "unxt-api" "unxt-hypothesis" "unxts-api" "unxts-hypothesis" "unxts-interop-gala" "unxts-interop-matplotlib" "unxts-interop-xarray")
+          PACKAGES=("unxt" "unxt-api" "unxt-hypothesis" "unxts-api" "unxts-hypothesis" "unxts-interop-gala" "unxts-interop-matplotlib" "unxts-interop-xarray" "unxts-parametric" "unxts-linalg")
           TAGS_TO_PUSH=()
 
           UNXT_API_TAG_CREATED="false"
@@ -94,6 +96,8 @@ jobs:
           UNXTS_INTEROP_GALA_TAG_CREATED="false"
           UNXTS_INTEROP_MATPLOTLIB_TAG_CREATED="false"
           UNXTS_INTEROP_XARRAY_TAG_CREATED="false"
+          UNXTS_PARAMETRIC_TAG_CREATED="false"
+          UNXTS_LINALG_TAG_CREATED="false"
 
           # Check and create each package tag
           for PACKAGE in "${PACKAGES[@]}"; do
@@ -148,6 +152,12 @@ jobs:
               if [ "$PACKAGE" = "unxts-interop-xarray" ]; then
                 UNXTS_INTEROP_XARRAY_TAG_CREATED="true"
               fi
+              if [ "$PACKAGE" = "unxts-parametric" ]; then
+                UNXTS_PARAMETRIC_TAG_CREATED="true"
+              fi
+              if [ "$PACKAGE" = "unxts-linalg" ]; then
+                UNXTS_LINALG_TAG_CREATED="true"
+              fi
             fi
           done
 
@@ -179,6 +189,12 @@ jobs:
             echo "trigger_unxts_interop_xarray_cd=false" >> "$GITHUB_OUTPUT"
             echo "unxts_interop_xarray_tag=unxts-interop-xarray-v${VERSION}" >> "$GITHUB_OUTPUT"
             echo "unxts_interop_xarray_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "trigger_unxts_parametric_cd=false" >> "$GITHUB_OUTPUT"
+            echo "unxts_parametric_tag=unxts-parametric-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "unxts_parametric_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "trigger_unxts_linalg_cd=false" >> "$GITHUB_OUTPUT"
+            echo "unxts_linalg_tag=unxts-linalg-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "unxts_linalg_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -210,6 +226,12 @@ jobs:
           echo "trigger_unxts_interop_xarray_cd=${UNXTS_INTEROP_XARRAY_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "unxts_interop_xarray_tag=unxts-interop-xarray-v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "unxts_interop_xarray_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "trigger_unxts_parametric_cd=${UNXTS_PARAMETRIC_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "unxts_parametric_tag=unxts-parametric-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "unxts_parametric_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+          echo "trigger_unxts_linalg_cd=${UNXTS_LINALG_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "unxts_linalg_tag=unxts-linalg-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "unxts_linalg_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger CD - unxt for auto-created unxt tag
         if: |
@@ -320,3 +342,30 @@ jobs:
           tag_sha: ${{ steps.create_tags.outputs.unxts_interop_xarray_tag_sha }}
           trigger_cd:
             ${{ steps.create_tags.outputs.trigger_unxts_interop_xarray_cd }}
+
+      - name: Trigger CD - unxts-parametric
+        if: |
+          steps.create_tags.outputs.trigger_unxts_parametric_cd == 'true' ||
+          (steps.create_tags.outputs.unxts_parametric_tag != '' &&
+          steps.create_tags.outputs.trigger_unxts_parametric_cd == 'false')
+        uses: ./.github/actions/dispatch-package-cd
+        with:
+          workflow_id: cd-unxts-parametric.yml
+          workflow_name: CD - unxts-parametric
+          tag_ref: ${{ steps.create_tags.outputs.unxts_parametric_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.unxts_parametric_tag_sha }}
+          trigger_cd:
+            ${{ steps.create_tags.outputs.trigger_unxts_parametric_cd }}
+
+      - name: Trigger CD - unxts-linalg
+        if: |
+          steps.create_tags.outputs.trigger_unxts_linalg_cd == 'true' ||
+          (steps.create_tags.outputs.unxts_linalg_tag != '' &&
+          steps.create_tags.outputs.trigger_unxts_linalg_cd == 'false')
+        uses: ./.github/actions/dispatch-package-cd
+        with:
+          workflow_id: cd-unxts-linalg.yml
+          workflow_name: CD - unxts-linalg
+          tag_ref: ${{ steps.create_tags.outputs.unxts_linalg_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.unxts_linalg_tag_sha }}
+          trigger_cd: ${{ steps.create_tags.outputs.trigger_unxts_linalg_cd }}

--- a/conftest.py
+++ b/conftest.py
@@ -72,6 +72,7 @@ class OptDeps(OptionalDependencyEnum):
     GALA = auto()
     UNXTS_INTEROP_GALA = auto()
     UNXTS_INTEROP_MATPLOTLIB = auto()
+    UNXTS_LINALG = auto()
     UNXTS_PARAMETRIC = auto()
 
 
@@ -88,6 +89,9 @@ if not (OptDeps.UNXTS_INTEROP_GALA.installed and OptDeps.GALA.installed):
 if not OptDeps.UNXTS_INTEROP_MATPLOTLIB.installed:
     collect_ignore_glob.append("docs/packages/unxts.interop.matplotlib/*")
     collect_ignore_glob.append("packages/unxts.interop.matplotlib/docs/*")
+if not OptDeps.UNXTS_LINALG.installed:
+    collect_ignore_glob.append("docs/packages/unxts.linalg/*")
+    collect_ignore_glob.append("packages/unxts.linalg/docs/*")
 if not OptDeps.UNXTS_PARAMETRIC.installed:
     collect_ignore_glob.append("docs/packages/unxts.parametric/*")
     collect_ignore_glob.append("packages/unxts.parametric/docs/*")

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ unxt <self>
 unxt-hypothesis <packages/unxt-hypothesis/index>
 unxts.api <packages/unxts.api/index>
 unxts.hypothesis <packages/unxts.hypothesis/index>
+unxts.linalg <packages/unxts.linalg/index>
 unxts.parametric <packages/unxts.parametric/index>
 unxts.interop.gala <packages/unxts.interop.gala/index>
 unxts.interop.matplotlib <packages/unxts.interop.matplotlib/index>

--- a/docs/packages/unxts.linalg
+++ b/docs/packages/unxts.linalg
@@ -1,0 +1,1 @@
+../../packages/unxts.linalg/docs

--- a/packages/unxts.linalg/README.md
+++ b/packages/unxts.linalg/README.md
@@ -2,7 +2,7 @@
 
 Heterogeneous-unit matrices and vectors for [unxt](https://github.com/GalacticDynamics/unxt).
 
-This is the canonical package (`unxts.linalg`). It provides `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a different unit, together with a static `UnitsMatrix` unit structure and unit-aware linear-algebra primitives (`det`, `inv`, and Quax-registered add/sub/matmul/transpose/diag).
+This is the canonical package (`unxts.linalg`). It provides `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a different unit, together with a static `UnitsMatrix` unit structure and unit-aware linear-algebra primitives (`det`, `inv`, the `matmul`/`matvec`/`vecmat`/`vecdot` products, and Quax-registered add/sub, mul/div, matmul, transpose, diag, and reduce-sum rules).
 
 ## Install
 

--- a/packages/unxts.linalg/README.md
+++ b/packages/unxts.linalg/README.md
@@ -1,0 +1,20 @@
+# unxts.linalg
+
+Heterogeneous-unit matrices and vectors for [unxt](https://github.com/GalacticDynamics/unxt).
+
+This is the canonical package (`unxts.linalg`). It provides `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a different unit, together with a static `UnitsMatrix` unit structure and unit-aware linear-algebra primitives (`det`, `inv`, and Quax-registered add/sub/matmul/transpose/diag).
+
+## Install
+
+```bash
+pip install unxts.linalg
+```
+
+## Usage
+
+```python
+import jax.numpy as jnp
+import unxts.linalg as ul
+
+qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+```

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -1,8 +1,19 @@
 # `unxts.linalg`
 
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+quantity-matrix
+units-matrix
+linear-algebra
+tutorial-metric
+sharp-bits
+```
+
 `unxts.linalg` provides `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a **different** unit. It is backed by a single JAX array plus a static `UnitsMatrix` describing the per-element units, and supports both 1-D (heterogeneous vector) and 2-D (heterogeneous matrix) structures.
 
-It is useful for objects whose entries have mixed physical dimensions — Jacobians, metric tensors, and coordinate change-of-basis matrices.
+It is useful for objects whose entries have mixed physical dimensions — Jacobians, metric tensors, and coordinate change-of-basis matrices — where a single scalar unit (as on `unxt.Quantity`) is not expressive enough.
 
 ## Install
 
@@ -29,9 +40,37 @@ pip install unxts.linalg
 Throughout these guides we import `unxt` as `u` and `unxts.linalg` as `ul` (so `QuantityMatrix` is `ul.QM`):
 
 ```{code-block} python
+>>> import jax.numpy as jnp
 >>> import unxt as u
 >>> import unxts.linalg as ul
 ```
+
+## At a glance
+
+A 1-D `QuantityMatrix` is a vector whose entries each have their own unit:
+
+```{code-block} python
+>>> qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+>>> qv.unit.to_string()
+'(m, s, kg)'
+>>> 2 * qv
+QuantityMatrix(Array([2., 4., 6.], dtype=float32), unit='(m, s, kg)')
+```
+
+Indexing a single element yields an ordinary `unxt.Quantity`:
+
+```{code-block} python
+>>> qv[0]
+Quantity(Array(1., dtype=float32), unit='m')
+```
+
+## Guides
+
+- [Quantity matrices](quantity-matrix.md) — constructing `QuantityMatrix`, indexing, unit conversion, and arithmetic.
+- [Units matrices](units-matrix.md) — the immutable, hashable `UnitsMatrix` unit structure.
+- [Linear algebra](linear-algebra.md) — matmul, transpose, `diag`, `det`, and `inv` with per-element unit tracking.
+- [Tutorial: a heterogeneous metric](tutorial-metric.md) — a worked end-to-end example.
+- [Sharp bits](sharp-bits.md) — the 1-D/2-D restriction and the uniform-unit requirements under `jax.jit`.
 
 ## Public API
 

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -1,0 +1,45 @@
+# `unxts.linalg`
+
+`unxts.linalg` provides `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a **different** unit. It is backed by a single JAX array plus a static `UnitsMatrix` describing the per-element units, and supports both 1-D (heterogeneous vector) and 2-D (heterogeneous matrix) structures.
+
+It is useful for objects whose entries have mixed physical dimensions — Jacobians, metric tensors, and coordinate change-of-basis matrices.
+
+## Install
+
+::::{tab-set}
+
+:::{tab-item} uv
+
+```bash
+uv add unxts.linalg
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install unxts.linalg
+```
+
+:::
+
+::::
+
+Throughout these guides we import `unxt` as `u` and `unxts.linalg` as `ul` (so `QuantityMatrix` is `ul.QM`):
+
+```{code-block} python
+>>> import unxt as u
+>>> import unxts.linalg as ul
+```
+
+## Public API
+
+`unxts.linalg` exposes:
+
+- `QuantityMatrix` — the heterogeneous-unit matrix/vector (alias `QM`).
+- `UnitsMatrix` — the immutable, hashable per-element unit structure.
+- `det`, `inv` — unit-tracking determinant and inverse (with their JAX primitives `det_p`, `inv_p`).
+- `cdict_units` — extract per-key units from a component dictionary.
+
+Importing `unxts.linalg` also registers, as import side effects, the Quax primitive rules (add/sub/matmul/transpose/gather/reduce-sum) and the `plum` conversions/dispatch that let `QuantityMatrix` interoperate with the rest of `unxt`.

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -78,7 +78,8 @@ Quantity(Array(1., dtype=float32), unit='m')
 
 - `QuantityMatrix` — the heterogeneous-unit matrix/vector (alias `QM`).
 - `UnitsMatrix` — the immutable, hashable per-element unit structure.
+- `matmul`, `matvec`, `vecmat`, `vecdot` — the four Array-API matrix/vector products, each resolving the batched matrix-vs-vector ambiguity that `@` alone cannot.
 - `det`, `inv` — unit-tracking determinant and inverse (with their JAX primitives `det_p`, `inv_p`).
 - `cdict_units` — extract per-key units from a component dictionary.
 
-Importing `unxts.linalg` also registers, as import side effects, the Quax primitive rules (add/sub/matmul/transpose/gather/reduce-sum) and the `plum` conversions/dispatch that let `QuantityMatrix` interoperate with the rest of `unxt`.
+Importing `unxts.linalg` also registers, as import side effects, the Quax primitive rules (add/sub, mul/div, dot-general/matmul, transpose, gather/diag, reduce-sum) and the `plum` conversions/dispatch that let `QuantityMatrix` interoperate with the rest of `unxt`.

--- a/packages/unxts.linalg/docs/linear-algebra.md
+++ b/packages/unxts.linalg/docs/linear-algebra.md
@@ -1,0 +1,101 @@
+# Linear algebra with unit tracking
+
+The whole point of `QuantityMatrix` is that linear-algebra operations carry the per-element units through the computation. `unxts.linalg` registers Quax rules for the underlying JAX primitives, so the [`quaxed`](https://github.com/GalacticDynamics/quaxed) drop-in `numpy` operators work directly on `QuantityMatrix` objects.
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import quax
+>>> import quaxed.numpy as qnp
+>>> import unxt as u
+>>> import unxts.linalg as ul
+```
+
+## Matrix–vector and matrix–matrix products
+
+`qnp.matmul` contracts the shared axis and multiplies the corresponding units. Here a dimensionless identity leaves a vector's units untouched:
+
+```{code-block} python
+>>> A = ul.QuantityMatrix(jnp.eye(3),
+...                       unit=(("", "", ""), ("", "", ""), ("", "", "")))
+>>> v = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+>>> w = qnp.matmul(A, v)
+>>> w.value
+Array([1., 2., 3.], dtype=float32)
+>>> w.unit.to_string()
+'(m, m, m)'
+```
+
+Units on the contracted axis are combined and converted to a common reference, so mixed units are handled correctly:
+
+```{code-block} python
+>>> A2 = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+...                        unit=(("m", "km"), ("m", "km")))
+>>> v2 = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+>>> qnp.matmul(A2, v2).value
+Array([2001., 4003.], dtype=float32)
+```
+
+A plain JAX array or an ordinary `unxt.Quantity` on one side is treated as dimensionless / uniform-unit respectively.
+
+## Transpose and diagonal
+
+`.T` swaps both the values and the unit structure of a 2-D matrix:
+
+```{code-block} python
+>>> a = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+...                       unit=(("m", "s"), ("kg", "rad")))
+>>> a.T.unit.to_string()
+'((m, kg), (s, rad))'
+```
+
+`.diag()` extracts the diagonal as a 1-D `QuantityMatrix`, operating directly on the static unit structure so it works under `jax.jit`:
+
+```{code-block} python
+>>> M = ul.QuantityMatrix(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
+...                       unit=(("m", "s", "kg"),
+...                             ("m", "s", "kg"),
+...                             ("m", "s", "kg")))
+>>> d = M.diag()
+>>> d.unit.to_string()
+'(m, s, kg)'
+>>> d.value
+Array([1., 2., 3.], dtype=float32)
+```
+
+## Determinant and inverse
+
+`unxts.linalg` provides custom `det` and `inv` primitives with full JAX transform support (JIT, autodiff, vmap). On plain arrays they behave like `jnp.linalg.det` / `jnp.linalg.inv`; on a `QuantityMatrix` (wrapped with `quax.quaxify`) they additionally track units.
+
+The determinant multiplies the main-diagonal units:
+
+```{code-block} python
+>>> from unxts.linalg import det, inv
+>>> G = ul.QuantityMatrix(jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+...                       unit=(("m2", "m2"), ("m2", "m2")))
+>>> quax.quaxify(det)(G)
+Quantity(Array(6., dtype=float32), unit='m4')
+```
+
+The inverse carries the reciprocal units:
+
+```{code-block} python
+>>> B = ul.QuantityMatrix(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
+...                       unit=(("m2", "m2"), ("m2", "m2")))
+>>> r = quax.quaxify(inv)(B)
+>>> r.unit.to_string()
+'((1 / m2, 1 / m2), (1 / m2, 1 / m2))'
+>>> r.value
+Array([[0.25, 0.  ],
+       [0.  , 1.  ]], dtype=float32)
+```
+
+Because `det` and `inv` are real JAX primitives, they compose with `jax.jit`, `jax.grad`, and `jax.vmap` on plain arrays:
+
+```{code-block} python
+>>> import jax
+>>> jax.jit(det)(jnp.array([[2.0, 0.0], [0.0, 3.0]]))
+Array(6., dtype=float32)
+>>> jax.grad(det)(jnp.array([[2.0, 0.0], [0.0, 3.0]]))
+Array([[3., 0.],
+       [0., 2.]], dtype=float32)
+```

--- a/packages/unxts.linalg/docs/linear-algebra.md
+++ b/packages/unxts.linalg/docs/linear-algebra.md
@@ -42,9 +42,9 @@ Array([2001., 4003.], dtype=float32)
 
 A plain JAX array or an ordinary `unxt.Quantity` on one side is treated as dimensionless / uniform-unit respectively.
 
-### Batches: prefer `matvec`/`vecmat` over `matmul`
+### Batches
 
-A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and treats _leading_ axes of the value array as batch dimensions. All four products broadcast those batch axes. But note a subtlety inherited from NumPy: a batched vector's value `(B, K)` is shape-indistinguishable from a matrix, so **`matmul` cannot express a batched matrix-vector product** — use `matvec` (and `vecmat`) for those.
+A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and treats _leading_ axes of the value array as batch dimensions. All four products — and the `@` operator — broadcast those batch axes. The `@` operator dispatches on the _logical_ rank (matrix vs vector), so a batch of matrices applied to a batch of vectors "just works":
 
 ```{code-block} python
 >>> # A batch of 2 matrices applied to a batch of 2 vectors.
@@ -53,10 +53,12 @@ A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and 
 ...     unit=(("m", "m"), ("m", "m")),
 ... )
 >>> vb = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
->>> ul.matvec(Ab, vb).value
+>>> (Ab @ vb).value
 Array([[ 3.,  7.],
        [11., 15.]], dtype=float32)
 ```
+
+There is one subtlety inherited from NumPy: a batched vector's value `(B, K)` is shape-indistinguishable from a matrix, so the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` cannot express a batched matrix-vector product (and `ul.matmul` rejects it with a pointer to `matvec`). Use `@`, `ul.matvec`, or `ul.vecmat` — all of which name the ranks explicitly.
 
 ## Transpose and diagonal
 

--- a/packages/unxts.linalg/docs/linear-algebra.md
+++ b/packages/unxts.linalg/docs/linear-algebra.md
@@ -5,24 +5,29 @@ The whole point of `QuantityMatrix` is that linear-algebra operations carry the 
 ```{code-block} python
 >>> import jax.numpy as jnp
 >>> import quax
->>> import quaxed.numpy as qnp
 >>> import unxt as u
 >>> import unxts.linalg as ul
 ```
 
-## Matrix–vector and matrix–matrix products
+## Matrix and vector products
 
-`qnp.matmul` contracts the shared axis and multiplies the corresponding units. Here a dimensionless identity leaves a vector's units untouched:
+`unxts.linalg` exposes the four NumPy / Array-API contraction functions, each of which contracts the shared axis and multiplies the corresponding per-element units:
+
+| Function          | Operands        | Result            |
+| ----------------- | --------------- | ----------------- |
+| `ul.matmul(A, B)` | matrix × matrix | matrix            |
+| `ul.matvec(A, v)` | matrix × vector | vector            |
+| `ul.vecmat(v, A)` | vector × matrix | vector            |
+| `ul.vecdot(a, b)` | vector · vector | scalar `Quantity` |
+
+`matmul` contracts the shared axis and multiplies the corresponding units — here a dimensionless identity leaves a vector's units untouched:
 
 ```{code-block} python
 >>> A = ul.QuantityMatrix(jnp.eye(3),
 ...                       unit=(("", "", ""), ("", "", ""), ("", "", "")))
 >>> v = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
->>> w = qnp.matmul(A, v)
->>> w.value
+>>> ul.matvec(A, v).value
 Array([1., 2., 3.], dtype=float32)
->>> w.unit.to_string()
-'(m, m, m)'
 ```
 
 Units on the contracted axis are combined and converted to a common reference, so mixed units are handled correctly:
@@ -31,11 +36,27 @@ Units on the contracted axis are combined and converted to a common reference, s
 >>> A2 = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
 ...                        unit=(("m", "km"), ("m", "km")))
 >>> v2 = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
->>> qnp.matmul(A2, v2).value
+>>> ul.matvec(A2, v2).value
 Array([2001., 4003.], dtype=float32)
 ```
 
 A plain JAX array or an ordinary `unxt.Quantity` on one side is treated as dimensionless / uniform-unit respectively.
+
+### Batches: prefer `matvec`/`vecmat` over `matmul`
+
+A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and treats _leading_ axes of the value array as batch dimensions. All four products broadcast those batch axes. But note a subtlety inherited from NumPy: a batched vector's value `(B, K)` is shape-indistinguishable from a matrix, so **`matmul` cannot express a batched matrix-vector product** — use `matvec` (and `vecmat`) for those.
+
+```{code-block} python
+>>> # A batch of 2 matrices applied to a batch of 2 vectors.
+>>> Ab = ul.QuantityMatrix(
+...     jnp.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+...     unit=(("m", "m"), ("m", "m")),
+... )
+>>> vb = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
+>>> ul.matvec(Ab, vb).value
+Array([[ 3.,  7.],
+       [11., 15.]], dtype=float32)
+```
 
 ## Transpose and diagonal
 

--- a/packages/unxts.linalg/docs/quantity-matrix.md
+++ b/packages/unxts.linalg/docs/quantity-matrix.md
@@ -1,0 +1,132 @@
+# Quantity matrices
+
+`QuantityMatrix` (alias `QM`) stores one numeric JAX array together with a static [`UnitsMatrix`](units-matrix.md) that gives the unit of **each** logical element. The shape of the unit structure decides whether the object behaves as a heterogeneous vector (1-D) or matrix (2-D).
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import unxt as u
+>>> import unxts.linalg as ul
+```
+
+## Construction
+
+A 1-D `QuantityMatrix` takes a flat array and a tuple of units, one per element:
+
+```{code-block} python
+>>> qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+>>> qv.value
+Array([1., 2., 3.], dtype=float32)
+>>> qv.unit.to_string()
+'(m, s, kg)'
+>>> qv.ndim, qv.shape
+(1, (3,))
+```
+
+A 2-D `QuantityMatrix` takes a 2-D array and a nested tuple of units:
+
+```{code-block} python
+>>> qm = ul.QuantityMatrix(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
+>>> qm.unit.to_string()
+'((m, s), (kg, rad))'
+>>> qm.ndim, qm.shape
+(2, (2, 2))
+```
+
+Leading dimensions of the value array are treated as batch dimensions; only the trailing 1 or 2 axes are "logical" and must match the unit structure.
+
+`QM` is a short alias for `QuantityMatrix` (mirroring `u.Q` for `Quantity`):
+
+```{code-block} python
+>>> ul.QM is ul.QuantityMatrix
+True
+```
+
+### From a component dictionary
+
+`QuantityMatrix.from_cdict` packs a dict of quantities into a 1-D matrix, preserving each entry's unit:
+
+```{code-block} python
+>>> v = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "s"), "z": u.Q(3.0, "kg")}
+>>> ul.QuantityMatrix.from_cdict(v).unit.to_string()
+'(m, s, kg)'
+```
+
+You may select and reorder a subset of keys:
+
+```{code-block} python
+>>> ul.QuantityMatrix.from_cdict(v, keys=("z", "x")).unit.to_string()
+'(kg, m)'
+```
+
+## Indexing
+
+Indexing a 1-D `QuantityMatrix` returns an ordinary `unxt.Quantity` — the element and its scalar unit:
+
+```{code-block} python
+>>> qv[0]
+Quantity(Array(1., dtype=float32), unit='m')
+>>> qv[2]
+Quantity(Array(3., dtype=float32), unit='kg')
+```
+
+Indexing a row of a 2-D matrix returns a 1-D `QuantityMatrix`, while a full `[i, j]` index returns a scalar `Quantity`:
+
+```{code-block} python
+>>> qm2 = ul.QuantityMatrix(jnp.ones((2, 3)),
+...                         unit=(("m", "s", "kg"), ("rad", "deg", "m")))
+>>> qm2[0]
+QuantityMatrix(Array([1., 1., 1.], dtype=float32), unit='(m, s, kg)')
+>>> qm2[1, 2]
+Quantity(Array(1., dtype=float32), unit='m')
+```
+
+## Arithmetic and unit conversion
+
+Addition and subtraction convert each element of the right operand into the corresponding unit of the left operand before combining; the result adopts the left operand's units:
+
+```{code-block} python
+>>> import quaxed.numpy as qnp
+>>> a = ul.QuantityMatrix(jnp.ones(3), unit=("m", "s", "kg"))
+>>> b = ul.QuantityMatrix(jnp.ones(3), unit=("km", "ms", "g"))
+>>> result = qnp.add(a, b)
+>>> result.unit.to_string()
+'(m, s, kg)'
+>>> result.value
+Array([1001.   ,    1.001,    1.001], dtype=float32)
+```
+
+Scalar multiplication scales the values and leaves the units unchanged:
+
+```{code-block} python
+>>> (2 * a).value
+Array([2., 2., 2.], dtype=float32)
+```
+
+You can convert a whole `QuantityMatrix` to a compatible unit structure with `uconvert`:
+
+```{code-block} python
+>>> q = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+...                       unit=(("m", "rad"), ("m", "rad")))
+>>> target = u.unit((("km", "deg"), ("km", "deg")))
+>>> q.uconvert(target).unit.to_string()
+'((km, deg), (km, deg))'
+```
+
+When every element shares the same unit, a `QuantityMatrix` converts to a plain `unxt.Quantity`:
+
+```{code-block} python
+>>> import plum
+>>> uniform = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+>>> plum.convert(uniform, u.Q)
+Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
+```
+
+Mixed units make that conversion ambiguous, so it is rejected:
+
+```{code-block} python
+>>> try:
+...     plum.convert(qv, u.Q)
+... except ValueError as e:
+...     print(e)
+Cannot convert QuantityMatrix to Quantity unless all units are identical.
+```

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -22,9 +22,9 @@ The unit structure is limited to 1-D (vector) and 2-D (matrix); there is no supp
 rejected
 ```
 
-## `det` and `inv` assume compatible units
+## `det` and `inv` and their unit assumptions
 
-`det` uses the product of the **main-diagonal** units, and `inv` assumes a **uniform** unit that it can reciprocate. These are exactly right for diagonal metrics and for matrices whose cofactor products share one physical dimension (the common case for coordinate metrics), but they are not general heterogeneous-unit determinants/inverses. Both require a 2-D matrix:
+`det` uses the product of the **main-diagonal** units, and `inv` requires a **uniform** unit that it can reciprocate — it raises `ValueError` on a heterogeneous-unit matrix, because a matrix inverse mixes entries and the per-element reciprocal would be wrong. These are exactly right for diagonal metrics and for matrices whose cofactor products share one physical dimension (the common case for coordinate metrics), but they are not general heterogeneous-unit determinants/inverses. Both require a 2-D matrix:
 
 ```{code-block} python
 >>> import quax

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -51,6 +51,10 @@ The `.diag()` **method** operates on the static unit structure and works for het
 
 By contrast `qnp.diag` lowers to a `gather`, whose indices are traced under `jit`; there the unit of each output element cannot be resolved individually, so **all units must be equal**. Prefer the `.diag()` method for heterogeneous-unit matrices.
 
+## `matmul` can't do a _batched_ matrix-vector product
+
+A batched vector's value `(B, K)` is shape-indistinguishable from a matrix, so `matmul` (`@`) can only do batched matrix-vector when the shapes happen to coincide, and otherwise raises. Use `unxts.linalg.matvec` (and `vecmat`) for matrix-vector / vector-matrix products — they name the operand ranks explicitly and broadcast the batch axis correctly. See [Linear algebra](linear-algebra.md#batches-prefer-matvecvecmat-over-matmul).
+
 ## It is a Quax type, not a materialisable array
 
 `QuantityMatrix` is a `quax` array-ish value: it flows through `quax.quaxify`-ed functions but refuses to _materialise_ into a plain array (its elements have no single dtype-plus-unit), so use `.value` / `.unit` to inspect it, and `plum.convert(..., u.Q)` only when every unit is identical (see [Quantity matrices](quantity-matrix.md)).

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -1,0 +1,56 @@
+# Sharp bits
+
+`QuantityMatrix` covers the common heterogeneous-unit vector/matrix cases, but a few restrictions follow from its design. Keep these in mind.
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import quaxed.numpy as qnp
+>>> import unxt as u
+>>> import unxts.linalg as ul
+```
+
+## Only 1-D and 2-D structures
+
+The unit structure is limited to 1-D (vector) and 2-D (matrix); there is no support for higher-rank _logical_ structures. (Leading **batch** dimensions on the value array are fine — only the trailing one or two axes are logical.)
+
+```{code-block} python
+>>> from unxts.linalg import UnitsMatrix
+>>> try:
+...     UnitsMatrix(jnp.zeros((2, 2, 2)))
+... except (TypeError, ValueError) as e:
+...     print("rejected")
+rejected
+```
+
+## `det` and `inv` assume compatible units
+
+`det` uses the product of the **main-diagonal** units, and `inv` assumes a **uniform** unit that it can reciprocate. These are exactly right for diagonal metrics and for matrices whose cofactor products share one physical dimension (the common case for coordinate metrics), but they are not general heterogeneous-unit determinants/inverses. Both require a 2-D matrix:
+
+```{code-block} python
+>>> import quax
+>>> v = ul.QuantityMatrix(jnp.array([1.0, 2.0]), unit=("m", "s"))
+>>> try:
+...     quax.quaxify(ul.det)(v)
+... except ValueError as e:
+...     print("needs a 2-D matrix")
+needs a 2-D matrix
+```
+
+## `diag` under `jax.jit` needs uniform units
+
+The `.diag()` **method** operates on the static unit structure and works for heterogeneous units, even under `jit`:
+
+```{code-block} python
+>>> M = ul.QuantityMatrix(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
+...                       unit=(("m", "s", "kg"),
+...                             ("m", "s", "kg"),
+...                             ("m", "s", "kg")))
+>>> M.diag().unit.to_string()
+'(m, s, kg)'
+```
+
+By contrast `qnp.diag` lowers to a `gather`, whose indices are traced under `jit`; there the unit of each output element cannot be resolved individually, so **all units must be equal**. Prefer the `.diag()` method for heterogeneous-unit matrices.
+
+## It is a Quax type, not a materialisable array
+
+`QuantityMatrix` is a `quax` array-ish value: it flows through `quax.quaxify`-ed functions but refuses to _materialise_ into a plain array (its elements have no single dtype-plus-unit), so use `.value` / `.unit` to inspect it, and `plum.convert(..., u.Q)` only when every unit is identical (see [Quantity matrices](quantity-matrix.md)).

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -51,9 +51,9 @@ The `.diag()` **method** operates on the static unit structure and works for het
 
 By contrast `qnp.diag` lowers to a `gather`, whose indices are traced under `jit`; there the unit of each output element cannot be resolved individually, so **all units must be equal**. Prefer the `.diag()` method for heterogeneous-unit matrices.
 
-## `matmul` can't do a _batched_ matrix-vector product
+## The `matmul` _function_ can't do a batched matrix-vector product
 
-A batched vector's value `(B, K)` is shape-indistinguishable from a matrix, so `matmul` (`@`) can only do batched matrix-vector when the shapes happen to coincide, and otherwise raises. Use `unxts.linalg.matvec` (and `vecmat`) for matrix-vector / vector-matrix products — they name the operand ranks explicitly and broadcast the batch axis correctly. See [Linear algebra](linear-algebra.md#batches-prefer-matvecvecmat-over-matmul).
+A batched vector's value `(B, K)` is shape-indistinguishable from a matrix. The **`@` operator is fine** — `QuantityMatrix.__matmul__` dispatches on the logical rank, so `A @ v` correctly does a (batched) matrix-vector product. But the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` infer their contraction from the value shapes and so cannot; they silently succeed only when the sizes coincide and otherwise raise. `unxts.linalg.matmul` refuses a batched vector operand outright, pointing you at `matvec`. Prefer `@`, `ul.matvec`, or `ul.vecmat`. See [Linear algebra](linear-algebra.md#batches).
 
 ## It is a Quax type, not a materialisable array
 

--- a/packages/unxts.linalg/docs/tutorial-metric.md
+++ b/packages/unxts.linalg/docs/tutorial-metric.md
@@ -1,0 +1,68 @@
+# Tutorial: a heterogeneous metric
+
+This tutorial walks through a small end-to-end example: representing a diagonal _metric_ whose entries have mixed physical dimensions, then computing its determinant, inverse, and diagonal — all while `unxts.linalg` keeps the units straight. A single-unit `unxt.Quantity` could not represent such an object.
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import quax
+>>> import quaxed.numpy as qnp
+>>> import unxt as u
+>>> import unxts.linalg as ul
+```
+
+## The setup
+
+Consider a 2-D configuration space with a radial coordinate (metres) and an angular coordinate (radians). A diagonal metric `g` that turns coordinate differences into a squared length has diagonal entries with _different_ units: the radial part is `m2` (length²) while the angular part carries `m2 / rad2` so that `g · dθ²` still has units of length².
+
+We build `g` as a 2×2 `QuantityMatrix` with per-element units:
+
+```{code-block} python
+>>> g = ul.QuantityMatrix(
+...     jnp.array([[1.0, 0.0], [0.0, 4.0]]),
+...     unit=(("m2", "m2"), ("m2", "m2 / rad2")),
+... )
+>>> g.unit.to_string()
+'((m2, m2), (m2, m2 / rad2))'
+```
+
+## Reading off the diagonal
+
+`.diag()` extracts the diagonal as a 1-D `QuantityMatrix`, preserving each entry's (heterogeneous) unit — this is the part of the metric that actually scales each coordinate:
+
+```{code-block} python
+>>> d = g.diag()
+>>> d.unit.to_string()
+'(m2, m2 / rad2)'
+>>> d.value
+Array([1., 4.], dtype=float32)
+```
+
+## Determinant
+
+The determinant of a diagonal metric is the product of its diagonal units — here `m2 · m2/rad2`:
+
+```{code-block} python
+>>> quax.quaxify(ul.det)(g).unit.to_string()
+'m4 / rad2'
+```
+
+## Inverse
+
+The inverse metric carries the reciprocal of each unit, ready to _raise_ an index again:
+
+```{code-block} python
+>>> ginv = quax.quaxify(ul.inv)(g)
+>>> ginv.value
+Array([[1.  , 0.  ],
+       [0.  , 0.25]], dtype=float32)
+>>> ginv.unit.to_string()
+'((1 / m2, 1 / m2), (1 / m2, rad2 / m2))'
+```
+
+## Recap
+
+- A `QuantityMatrix` let us attach a distinct unit to every entry of the metric — impossible with a single-unit `unxt.Quantity`.
+- `.diag()`, `det`, and `inv` all propagated those per-element units automatically.
+- Everything is plain JAX underneath, so the same objects flow through `jax.jit`, `jax.grad`, and `jax.vmap`.
+
+See [Sharp bits](sharp-bits.md) for the current restrictions (1-D/2-D only, and the uniform-unit requirements of some operations under `jax.jit`).

--- a/packages/unxts.linalg/docs/tutorial-metric.md
+++ b/packages/unxts.linalg/docs/tutorial-metric.md
@@ -48,21 +48,29 @@ The determinant of a diagonal metric is the product of its diagonal units — he
 
 ## Inverse
 
-The inverse metric carries the reciprocal of each unit, ready to _raise_ an index again:
+`inv` mixes the matrix entries, so it is only unit-correct when the units are **uniform** (the reciprocal then applies throughout). Our metric is heterogeneous, so `inv` refuses it rather than return a misleading per-element reciprocal:
 
 ```{code-block} python
->>> ginv = quax.quaxify(ul.inv)(g)
->>> ginv.value
-Array([[1.  , 0.  ],
-       [0.  , 0.25]], dtype=float32)
->>> ginv.unit.to_string()
-'((1 / m2, 1 / m2), (1 / m2, rad2 / m2))'
+>>> try:
+...     quax.quaxify(ul.inv)(g)
+... except ValueError as e:
+...     print(str(e).split(";")[0])
+inv on a QuantityMatrix requires uniform units (all entries equal)
+```
+
+For a uniform-unit metric the inverse carries the single reciprocal unit:
+
+```{code-block} python
+>>> h = ul.QuantityMatrix(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
+...                       unit=(("m2", "m2"), ("m2", "m2")))
+>>> quax.quaxify(ul.inv)(h).unit.to_string()
+'((1 / m2, 1 / m2), (1 / m2, 1 / m2))'
 ```
 
 ## Recap
 
 - A `QuantityMatrix` let us attach a distinct unit to every entry of the metric — impossible with a single-unit `unxt.Quantity`.
-- `.diag()`, `det`, and `inv` all propagated those per-element units automatically.
+- `.diag()` and `det` propagated those per-element units automatically; `inv` is defined for uniform units (see [Sharp bits](sharp-bits.md)).
 - Everything is plain JAX underneath, so the same objects flow through `jax.jit`, `jax.grad`, and `jax.vmap`.
 
-See [Sharp bits](sharp-bits.md) for the current restrictions (1-D/2-D only, and the uniform-unit requirements of some operations under `jax.jit`).
+See [Sharp bits](sharp-bits.md) for the current restrictions (1-D/2-D only, and the uniform-unit requirements of `inv` and of `diag` under `jax.jit`).

--- a/packages/unxts.linalg/docs/units-matrix.md
+++ b/packages/unxts.linalg/docs/units-matrix.md
@@ -1,0 +1,72 @@
+# Units matrices
+
+`UnitsMatrix` is the immutable, hashable unit structure carried by a [`QuantityMatrix`](quantity-matrix.md). It wraps a 1-D or 2-D structure of `unxt.AbstractUnit` objects and provides tuple-style indexing, transposition, and serialization. Because it is hashable and static, it lives in a `QuantityMatrix`'s pytree _aux data_, so it is available concretely even under `jax.jit`.
+
+```{code-block} python
+>>> import unxt as u
+>>> from unxts.linalg import UnitsMatrix
+```
+
+## Construction
+
+1-D from a tuple of units (or unit strings), 2-D from a nested tuple:
+
+```{code-block} python
+>>> units_1d = UnitsMatrix(("m", "s", "kg"))
+>>> units_1d.shape
+(3,)
+>>> units_2d = UnitsMatrix((("m", "s"), ("kg", "rad")))
+>>> units_2d.shape
+(2, 2)
+```
+
+`unxt.unit` is overloaded to build a `UnitsMatrix` from a (nested) tuple, so you rarely construct one directly — passing a tuple as the `unit=` of a `QuantityMatrix` is enough:
+
+```{code-block} python
+>>> u.unit(("m", "s", "kg"))
+UnitsMatrix("(m, s, kg)")
+```
+
+## Indexing and iteration
+
+Indexing a single element returns the underlying unit; indexing a row of a 2-D structure returns a `UnitsMatrix`:
+
+```{code-block} python
+>>> units_2d[0, 1]
+Unit("s")
+>>> units_2d[0]
+UnitsMatrix("(m, s)")
+```
+
+## Serialization
+
+`to_string` gives a compact human-readable form; `to_tuple` gives a nested tuple of units:
+
+```{code-block} python
+>>> units_2d.to_string()
+'((m, s), (kg, rad))'
+>>> UnitsMatrix(("m", "s")).to_tuple()
+(Unit("m"), Unit("s"))
+```
+
+## Transpose and inverse
+
+`.T` transposes the (2-D) unit structure, and `.inverse()` raises each unit to the power −1 — the operations underpinning `QuantityMatrix.T` and matrix inversion:
+
+```{code-block} python
+>>> UnitsMatrix((("m", "s"), ("kg", "rad"))).T
+UnitsMatrix("((m, kg), (s, rad))")
+>>> UnitsMatrix(("m2", "s2")).inverse()
+UnitsMatrix("(1 / m2, 1 / s2)")
+```
+
+## Equality and hashing
+
+Two `UnitsMatrix` objects compare equal when their shapes and units match; a `UnitsMatrix` also compares equal to an equivalent (nested) tuple. Hashing is by value, so a `UnitsMatrix` is a valid static field / dict key:
+
+```{code-block} python
+>>> UnitsMatrix(("m", "s")) == ("m", "s")
+True
+>>> hash(UnitsMatrix(("m", "s"))) == hash(UnitsMatrix(("m", "s")))
+True
+```

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -1,0 +1,90 @@
+[project]
+authors = [
+  { name = "GalacticDynamics", email = "nstarman@users.noreply.github.com" },
+  { name = "Nathaniel Starkman", email = "nstarman@users.noreply.github.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python",
+  "Topic :: Scientific/Engineering",
+  "Typing :: Typed",
+]
+dependencies = [
+  "unxt",
+  "equinox>=0.11.8",
+  "jaxtyping>=0.2.34",
+  "plum-dispatch>=2.5.7",
+  "quax>=0.2.0",
+]
+description = "Heterogeneous-unit matrices and vectors for unxt (canonical: unxts.linalg)"
+dynamic = ["version"]
+license.text = "BSD-3-Clause"
+name = "unxts.linalg"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.urls]
+"Bug Tracker" = "https://github.com/GalacticDynamics/unxt/issues"
+Homepage      = "https://github.com/GalacticDynamics/unxt"
+
+[build-system]
+build-backend = "hatchling.build"
+requires      = ["hatch-vcs", "hatchling"]
+
+[dependency-groups]
+test = [
+  "optional-dependencies>=0.3.2",
+  "pytest>=8.4.2",
+  "pytest-arraydiff>=0.6.1",
+  "pytest-cov>=6.2.1",
+  "pytest-env>=1.1.5",
+  "pytest-github-actions-annotate-failures>=0.3.0",
+  "sybil[pytest]>=9.2.0",
+]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme              = "no-local-version"
+root                      = "../.."
+search_parent_directories = true
+
+[tool.hatch.version.raw-options.scm.git]
+# Git tags use hyphens; PyPI name uses dots.
+describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--tags",
+  "--long",
+  "--match",
+  "unxts-linalg-v*",
+]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/unxts/linalg/_version.py"
+version-file-template = """\
+version: str = {version!r}
+version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]
+version_tuple = {version_tuple!r}
+"""
+
+[tool.hatch.build.targets.wheel]
+# Point at namespace root, not sub-package. Hatchling traverses src/unxts/
+# and includes unxts/linalg/ in the wheel. Without src/unxts/__init__.py,
+# Python treats unxts as a namespace package. Matches coordinax pattern.
+packages = ["src/unxts"]
+
+[tool.uv.sources]
+unxt = { workspace = true }

--- a/packages/unxts.linalg/src/unxts/linalg/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/__init__.py
@@ -3,8 +3,10 @@
 `QuantityMatrix` (alias `QM`) is a quantity container whose elements may each
 carry a different unit, backed by a single JAX array plus a static
 `UnitsMatrix`. It supports 1-D (vector) and 2-D (matrix) structures, with
-Quax-registered arithmetic (add/sub/matmul/transpose/diag) plus ``det`` and
-``inv`` primitives that track per-element units through the linear algebra.
+Quax-registered arithmetic (add/sub, mul/div, matmul, transpose, diag,
+reduce-sum) plus the ``matmul``/``matvec``/``vecmat``/``vecdot`` products and
+``det``/``inv`` primitives that track per-element units through the linear
+algebra.
 """
 
 __all__ = (

--- a/packages/unxts.linalg/src/unxts/linalg/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/__init__.py
@@ -1,0 +1,32 @@
+"""Heterogeneous-unit matrices and vectors for unxt (canonical: unxts.linalg).
+
+`QuantityMatrix` (alias `QM`) is a quantity container whose elements may each
+carry a different unit, backed by a single JAX array plus a static
+`UnitsMatrix`. It supports 1-D (vector) and 2-D (matrix) structures, with
+Quax-registered arithmetic (add/sub/matmul/transpose/diag) plus ``det`` and
+``inv`` primitives that track per-element units through the linear algebra.
+"""
+
+__all__ = (
+    "QM",
+    "QuantityMatrix",
+    "UnitsMatrix",
+    "cdict_units",
+    "det",
+    "det_p",
+    "inv",
+    "inv_p",
+)
+
+# Importing from ``._src`` triggers the Quax primitive registrations and the
+# plum conversion/dispatch side effects (see ``._src.__init__``).
+from ._src import (
+    QM,
+    QuantityMatrix,
+    UnitsMatrix,
+    cdict_units,
+    det,
+    det_p,
+    inv,
+    inv_p,
+)

--- a/packages/unxts.linalg/src/unxts/linalg/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/__init__.py
@@ -16,6 +16,10 @@ __all__ = (
     "det_p",
     "inv",
     "inv_p",
+    "matmul",
+    "matvec",
+    "vecdot",
+    "vecmat",
 )
 
 # Importing from ``._src`` triggers the Quax primitive registrations and the
@@ -29,4 +33,8 @@ from ._src import (
     det_p,
     inv,
     inv_p,
+    matmul,
+    matvec,
+    vecdot,
+    vecmat,
 )

--- a/packages/unxts.linalg/src/unxts/linalg/_src/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/__init__.py
@@ -1,0 +1,47 @@
+"""Heterogeneous unit containers for vectors and matrices.
+
+This package provides two closely related building blocks:
+
+- `UnitsMatrix`, an immutable nested tuple of units with indexing support
+- `QuantityMatrix`, a quantity-like wrapper around one array plus a matching
+    static `UnitsMatrix`
+
+The numeric payload is a single JAX array of shape ``(..., *shape)`` where the
+trailing dimensions are the logical vector or matrix dimensions and any leading
+dimensions are batch dimensions. Units are stored separately as a static nested
+tuple structure with the same logical shape, allowing every element to carry
+its own physical unit.
+
+Currently the public surface supports only 1-D and 2-D structures:
+
+- 1-D: ``(..., N)`` with units ``(u0, u1, ..., uN-1)``
+- 2-D: ``(..., N, M)`` with units ``((u00, u01, ...), (u10, u11, ...), ...)``
+
+Quax primitive dispatches (``add_p``, ``dot_general_p``) perform the
+necessary per-element unit conversions via `unxt.uconvert_value` — which
+correctly handles affine conversions (e.g. °F → °C), not just
+multiplicative scale factors.
+"""
+
+__all__ = (
+    "QM",
+    "QuantityMatrix",
+    "UnitsMatrix",
+    "cdict_units",
+    "det",
+    "det_p",
+    "inv",
+    "inv_p",
+)
+
+from . import _register_primitives  # noqa: F401
+from ._det import det, det_p
+from ._inv import inv, inv_p
+from ._quantity_matrix import (  # noqa: F401
+    QM,
+    QuantityMatrix,
+    _convert_value_matrix,
+    _convert_value_vector,
+)
+from ._units_matrix import UnitsMatrix
+from ._utils import cdict_units

--- a/packages/unxts.linalg/src/unxts/linalg/_src/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/__init__.py
@@ -32,11 +32,16 @@ __all__ = (
     "det_p",
     "inv",
     "inv_p",
+    "matmul",
+    "matvec",
+    "vecdot",
+    "vecmat",
 )
 
 from . import _register_primitives  # noqa: F401
 from ._det import det, det_p
 from ._inv import inv, inv_p
+from ._products import matmul, matvec, vecdot, vecmat
 from ._quantity_matrix import (  # noqa: F401
     QM,
     QuantityMatrix,

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
@@ -156,8 +156,12 @@ def _det_jvp(primals: tuple, tangents: tuple) -> tuple:
     if type(dx) is jax_ad.Zero:
         tangent_out = lax.full_like(primal_out, 0.0)
     else:
-        # tr(A⁻¹ dA) via solve — avoids explicit matrix inversion
-        tangent_out = primal_out * jnp.trace(jnp.linalg.solve(x, dx))
+        # tr(A⁻¹ dA) via solve — avoids explicit matrix inversion.
+        # Trace the two *matrix* axes (last two), not the default (0, 1),
+        # so batched operands (*batch, n, n) differentiate correctly.
+        tangent_out = primal_out * jnp.trace(
+            jnp.linalg.solve(x, dx), axis1=-2, axis2=-1
+        )
     return primal_out, tangent_out
 
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
@@ -1,0 +1,221 @@
+"""Custom ``det_p`` JAX primitive with full JAX transform support.
+
+JAX has no built-in ``det`` primitive.  ``jnp.linalg.det`` decomposes into
+arithmetic (2x2 / 3x3) or ``lu_p`` + log/exp (larger matrices).  We define
+``det_p`` here so that Quax can intercept determinant calls on ``QuantityMatrix``
+objects.
+
+Supported transforms:
+  - JIT via MLIR lowering that delegates to ``jnp.linalg.det``
+  - Forward-mode autodiff (JVP): d(det A)(dA) = det(A) · tr(A⁻¹ dA)
+  - Reverse-mode autodiff (VJP): derived automatically from JVP via
+    transposition — no explicit transpose rule needed because the JVP tangent
+    only uses existing primitives (linalg.solve, trace, mul) that already
+    carry transpose rules.
+  - Batching (vmap): move the batch axis to the front and call det_p; the MLIR
+    lowering handles any (*batch, n, n) shape natively.
+"""
+
+import functools as ft
+import operator
+
+import jax
+import jax.core
+import jax.dtypes
+import jax.numpy as jnp
+import quax
+from jax import lax
+from jax.extend import core as jexc
+from jax.interpreters import ad as jax_ad, batching as jax_batching, mlir as jax_mlir
+from jaxtyping import Array
+
+import unxt as u
+from ._quantity_matrix import QuantityMatrix
+
+det_p = jexc.Primitive("det")
+det_p.multiple_results = False
+
+
+def to_inexact_dtype(dtype: jnp.dtype) -> jnp.dtype:
+    return (
+        dtype
+        if jnp.issubdtype(dtype, jnp.inexact)
+        else jnp.result_type(dtype, jnp.float32)
+    )
+
+
+def det(x: Array, /) -> Array:
+    """Compute the determinant of a square matrix via the ``det_p`` primitive.
+
+    Delegates to ``det_p``, a custom JAX primitive that supports JIT,
+    forward and reverse differentiation, and batching (vmap).
+
+    For plain arrays the result is a bare :class:`~jaxtyping.Array`.
+    For :class:`~unxts.linalg.QuantityMatrix` inputs the Quax
+    dispatch intercepts the call (see ``_det_p_QuantityMatrix``) and
+    returns a :class:`~unxt.AbstractQuantity`.
+
+    Parameters
+    ----------
+    x : Array, shape ``(*batch, n, n)``
+        Square matrix or batch of square matrices.
+
+    Returns
+    -------
+    Array, shape ``(*batch,)``
+        Determinant of each matrix.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from unxts.linalg import det
+
+    Plain 2x2 diagonal matrix:
+
+    >>> det(jnp.array([[2.0, 0.0], [0.0, 3.0]]))
+    Array(6., dtype=float32)
+
+    Under JIT:
+
+    >>> import jax
+    >>> jax.jit(det)(jnp.array([[2.0, 0.0], [0.0, 3.0]]))
+    Array(6., dtype=float32)
+
+    Gradient (via reverse-mode autodiff):
+
+    >>> jax.grad(det)(jnp.array([[2.0, 0.0], [0.0, 3.0]]))
+    Array([[3., 0.],
+           [0., 2.]], dtype=float32)
+
+    Batched (vmap):
+
+    >>> A = jnp.stack(
+    ...     [jnp.diag(jnp.array([2.0, 3.0])), jnp.diag(jnp.array([4.0, 5.0]))]
+    ... )
+    >>> jax.vmap(det)(A)
+    Array([ 6., 20.], dtype=float32)
+
+    """
+    return det_p.bind(x)
+
+
+# ── 1. Primal evaluation rule (eager / concrete values) ──────────────────
+
+
+def _det_impl(x: Array, /) -> Array:
+    return jnp.linalg.det(x)
+
+
+det_p.def_impl(_det_impl)
+
+
+# ── 2. Abstract evaluation rule (shape / dtype inference for JIT) ────────
+
+
+def _det_abstract_eval(x: jax.core.ShapedArray, /) -> jax.core.ShapedArray:
+    if x.ndim < 2:
+        raise ValueError(f"det_p requires at least 2-D input, got ndim={x.ndim}")
+    if x.shape[-1] != x.shape[-2]:
+        raise ValueError(
+            f"det_p requires a square matrix "
+            f"(shape[-2] == shape[-1]), got shape={x.shape}"
+        )
+    # (*batch, n, n) → (*batch,)
+    # jnp.linalg.det always returns a floating-point result (like numpy),
+    # so promote integer dtypes to their inexact equivalent.
+    out_dtype = to_inexact_dtype(x.dtype)
+    return x.update(shape=x.shape[:-2], dtype=out_dtype)
+
+
+det_p.def_abstract_eval(_det_abstract_eval)
+
+
+# ── 3. MLIR / XLA lowering (JIT compilation) ─────────────────────────────
+
+jax_mlir.register_lowering(
+    det_p,
+    jax_mlir.lower_fun(_det_impl, multiple_results=False),
+)
+
+
+# ── 4. Forward-mode differentiation (JVP) ────────────────────────────────
+#
+# Jacobi's formula: d(det A)(dA) = det(A) · tr(A⁻¹ dA)
+#
+# We use `jnp.linalg.solve(A, dA)` to compute A⁻¹ dA without explicitly
+# forming the inverse — more numerically stable.  The tangent uses only
+# existing JAX primitives (solve, trace, scalar mul), so JAX derives the
+# reverse-mode (VJP) rule automatically via transposition; no explicit
+# `ad.primitive_transposes` registration is needed.
+
+
+def _det_jvp(primals: tuple, tangents: tuple) -> tuple:
+    (x,) = primals
+    (dx,) = tangents
+    primal_out = det_p.bind(x)
+    if type(dx) is jax_ad.Zero:
+        tangent_out = lax.full_like(primal_out, 0.0)
+    else:
+        # tr(A⁻¹ dA) via solve — avoids explicit matrix inversion
+        tangent_out = primal_out * jnp.trace(jnp.linalg.solve(x, dx))
+    return primal_out, tangent_out
+
+
+jax_ad.primitive_jvps[det_p] = _det_jvp
+
+
+# ── 5. Batching rule (vmap) ───────────────────────────────────────────────
+#
+# `jnp.linalg.det` (used in the MLIR lowering) already operates correctly
+# on batched (*batch, n, n) arrays.  The batching rule moves the vmap batch
+# axis to the front (just before the matrix dims) and calls det_p; the
+# result carries the batch axis at position 0.
+
+
+def _det_batch(args: tuple, batch_axes: tuple) -> tuple:
+    (x,) = args
+    (ax,) = batch_axes
+    x = jnp.moveaxis(x, ax, 0)
+    return det_p.bind(x), 0
+
+
+jax_batching.primitive_batchers[det_p] = _det_batch
+
+
+# ── 6. Quax dispatch for QuantityMatrix ──────────────────────────────────
+
+
+@quax.register(det_p)
+def _det_p_QuantityMatrix(x: QuantityMatrix, /) -> "u.AbstractQuantity":
+    """Compute the determinant of a 2-D :class:`~unxts.linalg.QuantityMatrix`.
+
+    The numeric value is computed via ``det_p.bind(x.value)``.  The unit
+    is the product of the main-diagonal units — valid for diagonal metrics
+    and any matrix where all cofactor products share the same physical
+    dimension (e.g. coordinate metric tensors).
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> import quax
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+    >>> from unxts.linalg import det
+
+    >>> A = QuantityMatrix(
+    ...     jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+    ...     unit=(("m2", "m2"), ("m2", "m2")),
+    ... )
+    >>> quax.quaxify(det)(A)
+    Quantity(Array(6., dtype=float32), unit='m4')
+
+    """
+    if x.ndim != 2:
+        raise ValueError(
+            f"det_p QuantityMatrix dispatch requires a 2-D unit structure, got ndim={x.ndim}"
+        )
+    det_val = det_p.bind(x.value)
+    n = x.unit.shape[0]
+    det_unit = ft.reduce(operator.mul, (x.unit[i, i] for i in range(n)))
+    return u.Q(det_val, det_unit)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -1,0 +1,195 @@
+"""Custom ``inv_p`` JAX primitive with full JAX transform support.
+
+JAX has no standalone ``inv`` primitive.  ``jnp.linalg.inv`` decomposes into
+``lu_p`` + ``triangular_solve_p``, and Quax has no dispatch for those on
+``QuantityMatrix`` (which raises on materialise).  We define ``inv_p`` to give
+Quax a single interception point with full unit tracking.
+
+Supported transforms:
+  - JIT via MLIR lowering that delegates to ``jnp.linalg.inv``
+  - Forward-mode autodiff (JVP): d(A^{-1}) = -A^{-1} dA A^{-1}
+  - Reverse-mode autodiff (VJP): derived automatically from JVP
+  - Batching (vmap): move batch axis to front, call inv_p
+"""
+
+import jax
+import jax.numpy as jnp
+import quax
+from jax.extend import core as jexc
+from jax.interpreters import ad as jax_ad, batching as jax_batching, mlir as jax_mlir
+from jaxtyping import Array
+
+from ._quantity_matrix import QuantityMatrix
+
+inv_p = jexc.Primitive("inv")
+inv_p.multiple_results = False
+
+
+def inv(x: Array, /) -> Array:
+    """Compute the matrix inverse of a square matrix via the ``inv_p`` primitive.
+
+    Delegates to ``inv_p``, a custom JAX primitive that supports JIT,
+    forward and reverse differentiation, and batching (vmap).
+
+    For plain arrays the result is a bare :class:`~jaxtyping.Array`.
+    For :class:`~unxts.linalg.QuantityMatrix` inputs the Quax
+    dispatch intercepts the call (see ``_inv_p_QuantityMatrix``) and
+    returns a :class:`~unxts.linalg.QuantityMatrix` with
+    reciprocal units.
+
+    Parameters
+    ----------
+    x : Array, shape ``(*batch, n, n)``
+        Square matrix or batch of square matrices.
+
+    Returns
+    -------
+    Array, shape ``(*batch, n, n)``
+        Matrix inverse of each square matrix.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from unxts.linalg import inv
+
+    Plain 2x2 diagonal matrix:
+
+    >>> inv(jnp.array([[2.0, 0.0], [0.0, 4.0]]))
+    Array([[0.5 , 0.  ],
+           [0.  , 0.25]], dtype=float32)
+
+    Under JIT:
+
+    >>> import jax
+    >>> jax.jit(inv)(jnp.array([[2.0, 0.0], [0.0, 4.0]]))
+    Array([[0.5 , 0.  ],
+           [0.  , 0.25]], dtype=float32)
+
+    Gradient (via reverse-mode autodiff) — returns a rank-4 Jacobian:
+
+    >>> jac = jax.jacobian(inv)(jnp.array([[2.0, 0.0], [0.0, 4.0]]))
+    >>> jac.shape
+    (2, 2, 2, 2)
+
+    Batched (vmap):
+
+    >>> A = jnp.stack(
+    ...     [jnp.diag(jnp.array([2.0, 4.0])), jnp.diag(jnp.array([1.0, 2.0]))]
+    ... )
+    >>> jax.vmap(inv)(A)
+    Array([[[0.5 , 0.  ],
+            [0.  , 0.25]],
+    <BLANKLINE>
+           [[1.  , 0.  ],
+            [0.  , 0.5 ]]], dtype=float32)
+
+    """
+    return inv_p.bind(x)
+
+
+# ── 1. Primal evaluation rule ─────────────────────────────────────────────
+
+
+def _inv_impl(x: Array, /) -> Array:
+    return jnp.linalg.inv(x)
+
+
+inv_p.def_impl(_inv_impl)
+
+
+# ── 2. Abstract evaluation rule ───────────────────────────────────────────
+
+
+def _inv_abstract_eval(x: "jax.core.ShapedArray", /) -> "jax.core.ShapedArray":  # ty: ignore[possibly-missing-submodule]
+    if x.ndim < 2:
+        raise ValueError(f"inv_p requires at least 2-D input, got ndim={x.ndim}")
+    if x.shape[-1] != x.shape[-2]:
+        raise ValueError(
+            f"inv_p requires a square matrix "
+            f"(shape[-2] == shape[-1]), got shape={x.shape}"
+        )
+    return x.update(shape=x.shape)  # same shape as input
+
+
+inv_p.def_abstract_eval(_inv_abstract_eval)
+
+
+# ── 3. MLIR / XLA lowering ────────────────────────────────────────────────
+
+jax_mlir.register_lowering(
+    inv_p,
+    jax_mlir.lower_fun(_inv_impl, multiple_results=False),
+)
+
+
+# ── 4. Forward-mode differentiation (JVP) ────────────────────────────────
+#
+# d(A^{-1})(dA) = -A^{-1} dA A^{-1}
+
+
+def _inv_jvp(primals: tuple, tangents: tuple) -> tuple[Array, Array]:
+    (x,) = primals
+    (dx,) = tangents
+    primal_out = inv_p.bind(x)
+    if type(dx) is jax_ad.Zero:
+        tangent_out = jax_ad.Zero.from_primal_value(primal_out)  # ty: ignore[unresolved-attribute]
+    else:
+        tangent_out = -primal_out @ dx @ primal_out
+    return primal_out, tangent_out
+
+
+jax_ad.primitive_jvps[inv_p] = _inv_jvp
+
+
+# ── 5. Batching rule (vmap) ───────────────────────────────────────────────
+
+
+def _inv_batch(args: tuple, batch_axes: tuple) -> tuple:
+    (x,) = args
+    (ax,) = batch_axes
+    x = jnp.moveaxis(x, ax, 0)
+    return inv_p.bind(x), 0
+
+
+jax_batching.primitive_batchers[inv_p] = _inv_batch
+
+
+# ── 6. Quax dispatch for QuantityMatrix ──────────────────────────────────
+
+
+@quax.register(inv_p)
+def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
+    """Compute the inverse of a 2-D :class:`~unxts.linalg.QuantityMatrix`.
+
+    The numeric value is computed via ``inv_p.bind(x.value)``.
+    Units are assumed uniform (all entries share the same physical unit,
+    as is the case for metrics produced by the Cartesian-Jacobian pullback);
+    the inverse carries the reciprocal unit throughout.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> import quax
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+    >>> from unxts.linalg import inv
+
+    >>> A = QuantityMatrix(
+    ...     jnp.array([[4.0, 0.0], [0.0, 1.0]]),
+    ...     unit=UnitsMatrix((("m2", "m2"), ("m2", "m2"))),
+    ... )
+    >>> quax.quaxify(inv)(A)
+    QuantityMatrix(
+        Array([[0.25, 0.  ],
+               [0.  , 1.  ]], dtype=float32), unit='((1 / m2, 1 / m2), (1 / m2, 1 / m2))'
+    )
+
+    """
+    if x.ndim != 2:
+        raise ValueError(
+            f"inv_p QuantityMatrix dispatch requires a 2-D unit structure, got ndim={x.ndim}"
+        )
+
+    inv_val = inv_p.bind(x.value)
+    return QuantityMatrix(inv_val, unit=x.unit.inverse())

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -162,9 +162,11 @@ def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
     """Compute the inverse of a 2-D :class:`~unxts.linalg.QuantityMatrix`.
 
     The numeric value is computed via ``inv_p.bind(x.value)``.
-    Units are assumed uniform (all entries share the same physical unit,
-    as is the case for metrics produced by the Cartesian-Jacobian pullback);
-    the inverse carries the reciprocal unit throughout.
+    Units must be uniform (all entries share the same physical unit, as is the
+    case for metrics produced by the Cartesian-Jacobian pullback); the inverse
+    then carries the reciprocal unit throughout. A matrix inverse mixes the
+    entries, so for heterogeneous units the per-element reciprocal is not the
+    correct unit structure — that case raises ``ValueError``.
 
     Examples
     --------
@@ -190,6 +192,18 @@ def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
         raise ValueError(
             f"inv_p QuantityMatrix dispatch requires a 2-D unit structure, got ndim={x.ndim}"
         )
+
+    # The reciprocal-unit result is only correct when the units are uniform;
+    # a matrix inverse mixes entries, so heterogeneous units are not simply
+    # reciprocated element-by-element.
+    flat = x.unit._units.ravel()
+    if any(unit_i != flat[0] for unit_i in flat[1:]):
+        msg = (
+            "inv on a QuantityMatrix requires uniform units (all entries equal); "
+            "the inverse of a heterogeneous-unit matrix is not an element-wise "
+            f"reciprocal. Got units: {x.unit.to_string()}."
+        )
+        raise ValueError(msg)
 
     inv_val = inv_p.bind(x.value)
     return QuantityMatrix(inv_val, unit=x.unit.inverse())

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -19,6 +19,7 @@ from jax.extend import core as jexc
 from jax.interpreters import ad as jax_ad, batching as jax_batching, mlir as jax_mlir
 from jaxtyping import Array
 
+from ._det import to_inexact_dtype
 from ._quantity_matrix import QuantityMatrix
 
 inv_p = jexc.Primitive("inv")
@@ -108,7 +109,9 @@ def _inv_abstract_eval(x: "jax.core.ShapedArray", /) -> "jax.core.ShapedArray": 
             f"inv_p requires a square matrix "
             f"(shape[-2] == shape[-1]), got shape={x.shape}"
         )
-    return x.update(shape=x.shape)  # same shape as input
+    # `jnp.linalg.inv` promotes non-inexact inputs (int/bool) to floating point,
+    # so the abstract output dtype must match or JIT lowering fails.
+    return x.update(shape=x.shape, dtype=to_inexact_dtype(x.dtype))
 
 
 inv_p.def_abstract_eval(_inv_abstract_eval)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
@@ -42,7 +42,8 @@ def _reject_batched_vector(a: Any, b: Any, /) -> None:
             msg = (
                 "matmul cannot express a batched matrix-vector product: a "
                 "batched vector's value shape (*batch, K) is ambiguous with a "
-                "matrix. Use unxts.linalg.matvec / vecmat / vecdot instead."
+                "matrix. Use the `@` operator, or unxts.linalg.matvec / vecmat "
+                "/ vecdot, which dispatch on logical rank instead."
             )
             raise ValueError(msg)
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
@@ -1,0 +1,112 @@
+"""Batch-safe matrix/vector products for `QuantityMatrix`.
+
+These mirror the NumPy / Array-API family of contraction functions —
+``matmul`` (matrix @ matrix), ``matvec`` (matrix @ vector), ``vecmat``
+(vector @ matrix), and ``vecdot`` (vector · vector) — each dispatching to the
+`QuantityMatrix` Quax rules registered in ``_register_primitives``.
+
+Why four functions instead of just ``matmul``: a `QuantityMatrix` carries its
+logical 1-D/2-D unit structure in the *trailing* axes and treats any *leading*
+axes of the value array as batch dimensions. ``matmul`` uses NumPy's
+shape-broadcasting, under which a batched vector value ``(B, K)`` is
+indistinguishable from a matrix ``(B, K)`` — so batched matrix-vector products
+cannot be expressed with ``matmul``. ``matvec``/``vecmat`` name the operand
+ranks explicitly and therefore broadcast the batch axis correctly.
+
+Each wrapper accepts `QuantityMatrix`, `unxt.Quantity`, or plain arrays (via
+``quax``) and returns a `QuantityMatrix` (or a scalar `unxt.Quantity` for
+``vecdot``).
+"""
+
+from typing import Any
+
+import jax.numpy as jnp
+import quax
+
+__all__ = ("matmul", "matvec", "vecdot", "vecmat")
+
+
+def matmul(a: Any, b: Any, /) -> Any:
+    """Matrix-matrix product ``a @ b`` (batch dims broadcast over leading axes).
+
+    >>> import jax.numpy as jnp
+    >>> import unxts.linalg as ul
+
+    >>> A = ul.QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "m"), ("m", "m"))
+    ... )
+    >>> B = ul.QuantityMatrix(
+    ...     jnp.array([[1.0, 0.0], [0.0, 1.0]]), unit=(("s", "s"), ("s", "s"))
+    ... )
+    >>> ul.matmul(A, B).unit.to_string()
+    '((m s, m s), (m s, m s))'
+
+    """
+    return quax.quaxify(jnp.matmul)(a, b)
+
+
+def matvec(a: Any, b: Any, /) -> Any:
+    """Matrix-vector product: ``(..., N, K) @ (..., K) -> (..., N)``.
+
+    Unlike :func:`matmul`, this broadcasts a leading batch axis on **both**
+    operands, so a batch of matrices can be applied to a batch of vectors.
+
+    >>> import jax.numpy as jnp
+    >>> import unxts.linalg as ul
+
+    >>> A = ul.QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "m"), ("m", "m"))
+    ... )
+    >>> v = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+    >>> ul.matvec(A, v).value
+    Array([3., 7.], dtype=float32)
+
+    Batched — a stack of matrices times a stack of vectors:
+
+    >>> Ab = ul.QuantityMatrix(
+    ...     jnp.broadcast_to(A.value, (2, 2, 2)), unit=(("m", "m"), ("m", "m"))
+    ... )
+    >>> vb = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
+    >>> ul.matvec(Ab, vb).value
+    Array([[3., 7.],
+           [3., 7.]], dtype=float32)
+
+    """
+    return quax.quaxify(jnp.matvec)(a, b)
+
+
+def vecmat(a: Any, b: Any, /) -> Any:
+    """Vector-matrix product: ``(..., K) @ (..., K, M) -> (..., M)``.
+
+    The transpose of :func:`matvec`; also broadcasts a leading batch axis on
+    both operands.
+
+    >>> import jax.numpy as jnp
+    >>> import unxts.linalg as ul
+
+    >>> v = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+    >>> A = ul.QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "km"), ("m", "km"))
+    ... )
+    >>> ul.vecmat(v, A).value
+    Array([4., 6.], dtype=float32)
+
+    """
+    return quax.quaxify(jnp.vecmat)(a, b)
+
+
+def vecdot(a: Any, b: Any, /) -> Any:
+    """Vector dot product: ``(..., K) · (..., K) -> (...)`` (a scalar quantity).
+
+    Broadcasts a leading batch axis on both operands.
+
+    >>> import jax.numpy as jnp
+    >>> import unxts.linalg as ul
+
+    >>> a = ul.QuantityMatrix(jnp.array([1.0, 2.0]), unit=("m", "km"))
+    >>> b = ul.QuantityMatrix(jnp.array([3.0, 4.0]), unit=("s", "s"))
+    >>> ul.vecdot(a, b).value
+    Array(8003., dtype=float32)
+
+    """
+    return quax.quaxify(jnp.vecdot)(a, b)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
@@ -23,11 +23,36 @@ from typing import Any
 import jax.numpy as jnp
 import quax
 
+from ._quantity_matrix import QuantityMatrix
+
 __all__ = ("matmul", "matvec", "vecdot", "vecmat")
+
+
+def _reject_batched_vector(a: Any, b: Any, /) -> None:
+    """Raise if a `QuantityMatrix` operand is a *batched* (logically 1-D) vector.
+
+    ``matmul`` infers its contraction from NumPy shape-broadcasting, under which
+    a batched vector's value ``(*batch, K)`` is indistinguishable from a matrix.
+    So a batched matrix-vector product either contracts the wrong axes (raising
+    only when the sizes happen not to line up) or silently succeeds — a trap.
+    We reject it up front and point at the rank-explicit products instead.
+    """
+    for x in (a, b):
+        if isinstance(x, QuantityMatrix) and x.unit.ndim == 1 and x.value.ndim > 1:
+            msg = (
+                "matmul cannot express a batched matrix-vector product: a "
+                "batched vector's value shape (*batch, K) is ambiguous with a "
+                "matrix. Use unxts.linalg.matvec / vecmat / vecdot instead."
+            )
+            raise ValueError(msg)
 
 
 def matmul(a: Any, b: Any, /) -> Any:
     """Matrix-matrix product ``a @ b`` (batch dims broadcast over leading axes).
+
+    Only matrix operands may carry leading batch axes. A *batched* vector
+    operand is rejected (see :func:`matvec` / :func:`vecmat` / :func:`vecdot`),
+    because ``matmul`` cannot disambiguate its shape from a matrix.
 
     >>> import jax.numpy as jnp
     >>> import unxts.linalg as ul
@@ -41,7 +66,17 @@ def matmul(a: Any, b: Any, /) -> Any:
     >>> ul.matmul(A, B).unit.to_string()
     '((m s, m s), (m s, m s))'
 
+    A batched matrix-vector product is rejected with a helpful pointer:
+
+    >>> Ab = ul.QuantityMatrix(jnp.ones((2, 2, 2)), unit=(("m", "m"), ("m", "m")))
+    >>> vb = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
+    >>> ul.matmul(Ab, vb)
+    Traceback (most recent call last):
+    ...
+    ValueError: matmul cannot express a batched matrix-vector product: ...
+
     """
+    _reject_batched_vector(a, b)
     return quax.quaxify(jnp.matmul)(a, b)
 
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -252,8 +252,10 @@ class QuantityMatrix(u.AbstractQuantity):
             raise ValueError(
                 f"QuantityMatrix.diag() requires a 2D matrix, got ndim={self.ndim}"
             )
-        n = min(self.shape[-2], self.shape[-1])
-        diag_value = jnp.stack([self.value[..., i, i] for i in range(n)], axis=-1)
+        # `jnp.diagonal` extracts the main diagonal of the last two axes in a
+        # single primitive (result diagonal is the trailing axis), avoiding an
+        # n-op Python loop; units come from the static `UnitsMatrix`.
+        diag_value = jnp.diagonal(self.value, axis1=-2, axis2=-1)
         diag_unit = UnitsMatrix(self.unit._units.diagonal())
         return QuantityMatrix(value=diag_value, unit=diag_unit)
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -1,0 +1,437 @@
+"""QuantityMatrix class and unit-conversion helpers."""
+
+from typing import Any, NoReturn
+
+import equinox as eqx
+import jax
+import jax.core
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import plum
+from jaxtyping import Array, Shaped
+
+import unxt as u
+from ._units_matrix import UnitsMatrix
+from ._utils import _DMLS, CDict, strict_zip
+from unxt.quantity import AllowValue
+
+
+class QuantityMatrix(u.AbstractQuantity):
+    """Quantity container whose elements may each carry different units.
+
+    `QuantityMatrix` stores one numeric array together with a static
+    `UnitsMatrix` describing the unit of each logical element. The shape of the
+    unit structure determines whether the object behaves as a heterogeneous
+    vector or matrix.
+
+    Only 1-D and 2-D logical structures are supported.
+
+    Parameters
+    ----------
+    value : Array, shape ``(..., *shape)``
+        Numeric payload. For 1D: ``(..., N)``. For 2D: ``(..., N, M)``.
+        The value of element ``[i]`` (1D) or ``[i, j]`` (2D) is expressed
+        in the corresponding unit.
+    unit : UnitsMatrix
+        Per-element units. For 1D: ``(u0, u1, ...)``.
+        For 2D: ``((u00, u01, ...), (u10, u11, ...), ...)``.
+        Must be a static (hashable) nested tuple structure whose shape
+        matches the trailing dimensions of ``value``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    1D case (vector):
+
+    >>> qv = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+    >>> qv.value
+    Array([1., 2., 3.], dtype=float32)
+    >>> qv.unit.shape
+    (3,)
+
+    >>> 2 * qv
+    QuantityMatrix(Array([2., 4., 6.], dtype=float32), unit='(m, s, kg)')
+
+    >>> qv2 = QuantityMatrix(jnp.array([0.1, 200.0, 300.0]), unit=("km", "ms", "g"))
+    >>> qv + qv2
+    QuantityMatrix(Array([101. ,   2.2,   3.3], dtype=float32), unit='(m, s, kg)')
+
+    2D case (matrix):
+
+    >>> qm = QuantityMatrix(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
+    >>> qm.value.shape
+    (2, 2)
+    >>> qm.unit.shape
+    (2, 2)
+
+    >>> 2 * qm
+    QuantityMatrix(Array([[2., 2.],
+                          [2., 2.]], dtype=float32), unit='((m, s), (kg, rad))')
+
+    >>> qm2 = QuantityMatrix(
+    ...     jnp.array([[0.1, 200.0], [300.0, 0.5]]), unit=(("km", "ms"), ("g", "deg"))
+    ... )
+    >>> qm + qm2
+    QuantityMatrix(
+        Array([[101.       ,   1.2      ],
+               [  1.3      ,   1.0087266]], dtype=float32), unit='((m, s), (kg, rad))'
+    )
+
+    Indexing:
+
+    >>> qv[0]
+    Quantity(Array(1., dtype=float32), unit='m')
+    >>> qm[0]
+    QuantityMatrix(Array([1., 1.], dtype=float32), unit='(m, s)')
+    >>> qm[1, 0]
+    Quantity(Array(1., dtype=float32), unit='kg')
+
+    """
+
+    value: Shaped[Array, "..."] = eqx.field()
+    unit: UnitsMatrix = eqx.field(static=True, converter=u.unit)  # ty: ignore[invalid-assignment]
+
+    @property
+    def ndim(self) -> int:
+        """Number of real dimensions (1 for vector, 2 for matrix)."""
+        return self.unit.ndim
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Shape, including batch dimensions."""
+        return self.value.shape
+
+    @classmethod
+    def from_cdict(
+        cls, v: CDict, /, keys: tuple[str, ...] | None = None
+    ) -> "QuantityMatrix":
+        """Pack a component dictionary into a 1-D ``QuantityMatrix``.
+
+        Each value in *v* is stripped to its numeric value and stacked into a
+        single JAX array.  Values that carry units (``unxt.Quantity``) retain
+        those units in the resulting ``UnitsMatrix``; plain arrays are treated
+        as dimensionless.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> from unxts.linalg import QuantityMatrix
+
+        From a dictionary of quantities:
+
+        >>> v = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "s"), "z": u.Q(3.0, "kg")}
+        >>> qv = QuantityMatrix.from_cdict(v)
+        >>> qv.unit.to_string()
+        '(m, s, kg)'
+        >>> qv.value
+        Array([1., 2., 3.], dtype=float32)
+
+        Selecting and reordering a subset of keys:
+
+        >>> qv2 = QuantityMatrix.from_cdict(v, keys=("z", "x"))
+        >>> qv2.unit.to_string()
+        '(kg, m)'
+        >>> qv2.value
+        Array([3., 1.], dtype=float32)
+
+        Dimensionless entries (bare arrays) are accepted:
+
+        >>> import jax.numpy as jnp
+        >>> v2 = {"a": jnp.array(4.0), "b": u.Q(5.0, "m")}
+        >>> qv3 = QuantityMatrix.from_cdict(v2)
+        >>> qv3.unit.to_string()
+        '(, m)'
+
+        """
+        keys = tuple(v) if keys is None else keys
+        vs = [v[k] for k in keys]
+        us = [u.unit_of(x) or _DMLS for x in vs]
+        svs = jnp.stack([u.ustrip(AllowValue, unt, x) for x, unt in strict_zip(vs, us)])
+        return cls(svs, unit=UnitsMatrix(us))
+
+    def __getitem__(self, index: Any, /) -> "u.Q | QuantityMatrix":  # ty: ignore[invalid-method-override]
+        """Index into the QuantityMatrix to retrieve a specific element.
+
+        Indexing a logical dimension returns a ``Quantity`` when the result is
+        a scalar unit, or a ``QuantityMatrix`` when the result still has
+        structure.
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import unxt as u
+        >>> from unxts.linalg import QuantityMatrix
+
+        **1-D vector** — indexing a single element returns a ``Quantity``:
+
+        >>> qv = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+        >>> qv[0]
+        Quantity(Array(1., dtype=float32), unit='m')
+        >>> qv[2]
+        Quantity(Array(3., dtype=float32), unit='kg')
+
+        **2-D matrix** — indexing a row returns a ``QuantityMatrix``:
+
+        >>> qm = QuantityMatrix(
+        ...     jnp.ones((2, 3)), unit=(("m", "s", "kg"), ("rad", "deg", "m"))
+        ... )
+        >>> qm[0]
+        QuantityMatrix(Array([1., 1., 1.], dtype=float32), unit='(m, s, kg)')
+
+        Indexing a specific element returns a ``Quantity``:
+
+        >>> qm[1, 2]
+        Quantity(Array(1., dtype=float32), unit='m')
+
+        """
+        value_item = self.value[index]
+        unit_item = self.unit[index]
+        if isinstance(unit_item, UnitsMatrix):
+            return QuantityMatrix(value=value_item, unit=unit_item)
+        return u.Q(value_item, unit_item)
+
+    # ── Quax API ─────────────────────────────────────────────────────
+
+    def aval(self) -> jax.core.ShapedArray:
+        return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+
+    def materialise(self) -> NoReturn:
+        msg = "Refusing to materialise `QuantityMatrix`."
+        raise RuntimeError(msg)
+
+    def diag(self) -> "QuantityMatrix":
+        """Return a 1-D ``QuantityMatrix`` containing the diagonal of this matrix.
+
+        Unlike ``qnp.diag``, this method operates directly on the static
+        ``unit`` structure and the raw value array, so it works correctly under
+        ``jax.jit`` and with heterogeneous-unit matrices.
+
+        Only supported for 2-D ``QuantityMatrix`` objects.
+
+        Returns
+        -------
+        QuantityMatrix
+            1-D ``QuantityMatrix`` of length ``min(n_rows, n_cols)`` whose
+            ``unit[i]`` is ``self.unit[i, i]`` and whose ``value[..., i]`` is
+            ``self.value[..., i, i]``.
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> from unxts.linalg import QuantityMatrix
+
+        Uniform units:
+
+        >>> A = QuantityMatrix(
+        ...     jnp.diag(jnp.array([1.0, 4.0, 9.0])),
+        ...     unit=(("m", "m", "m"), ("m", "m", "m"), ("m", "m", "m")),
+        ... )
+        >>> d = A.diag()
+        >>> d.unit.shape
+        (3,)
+        >>> d.value
+        Array([1., 4., 9.], dtype=float32)
+
+        Heterogeneous units — works under jit:
+
+        >>> B = QuantityMatrix(
+        ...     jnp.diag(jnp.array([1.0, 2.0, 3.0])),
+        ...     unit=(("m", "s", "kg"), ("m", "s", "kg"), ("m", "s", "kg")),
+        ... )
+        >>> db = B.diag()
+        >>> db.unit.to_string()
+        '(m, s, kg)'
+        >>> db.value
+        Array([1., 2., 3.], dtype=float32)
+
+        """
+        if self.ndim != 2:
+            raise ValueError(
+                f"QuantityMatrix.diag() requires a 2D matrix, got ndim={self.ndim}"
+            )
+        n = min(self.shape[-2], self.shape[-1])
+        diag_value = jnp.stack([self.value[..., i, i] for i in range(n)], axis=-1)
+        diag_unit = UnitsMatrix(self.unit._units.diagonal())
+        return QuantityMatrix(value=diag_value, unit=diag_unit)
+
+    @property
+    def T(self) -> "QuantityMatrix":
+        """Transpose a 2-D ``QuantityMatrix`` (swap rows/columns and units).
+
+        Returns a new ``QuantityMatrix`` whose value array and unit structure
+        are both transposed.  Only 2-D matrices are supported.
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import quaxed.numpy as qnp
+        >>> from unxts.linalg import QuantityMatrix
+
+        >>> a = QuantityMatrix(
+        ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "s"), ("kg", "rad"))
+        ... )
+        >>> aT = a.T
+        >>> aT.value
+        Array([[1., 3.],
+               [2., 4.]], dtype=float32)
+        >>> aT.unit.to_string()
+        '((m, kg), (s, rad))'
+
+        Also accessible via ``jax.numpy.transpose``:
+
+        >>> aT2 = qnp.matrix_transpose(a)
+        >>> aT2.value
+        Array([[1., 3.],
+               [2., 4.]], dtype=float32)
+        >>> aT2.unit.to_string()
+        '((m, kg), (s, rad))'
+
+        """
+        if self.ndim != 2:
+            msg = f"QuantityMatrix.T requires a 2-D matrix, got ndim={self.ndim}"
+            raise ValueError(msg)
+        return QuantityMatrix(value=jnp.swapaxes(self.value, -2, -1), unit=self.unit.T)
+
+
+QM = QuantityMatrix
+"""Short alias for `QuantityMatrix` (cf. ``Q`` for ``Quantity``)."""
+
+
+##############################################################################
+# Unit-conversion helpers
+
+
+def _convert_value_vector(
+    value: Shaped[Array, "*batch N"],
+    from_units: tuple[u.AbstractUnit, ...],
+    to_units: tuple[u.AbstractUnit, ...],
+) -> Shaped[Array, "*batch N"]:
+    """Convert every element of *value* from *from_units* to *to_units* (1D case).
+
+    Each ``value[..., i]`` is converted individually via
+    `u.uconvert_value` so that **all** conversion types are handled
+    correctly.
+    """
+    n = len(to_units)
+    return jnp.stack(
+        [u.uconvert_value(to_units[i], from_units[i], value[..., i]) for i in range(n)],
+        axis=-1,
+    )
+
+
+def _convert_value_matrix(
+    value: Shaped[Array, "*batch N M"],
+    from_units: tuple[tuple[u.AbstractUnit, ...], ...],
+    to_units: tuple[tuple[u.AbstractUnit, ...], ...],
+) -> Shaped[Array, "*batch N M"]:
+    """Convert every element of *value* from *from_units* to *to_units* (2D case).
+
+    Each ``value[..., i, j]`` is converted individually via
+    `u.uconvert_value` so that **all** conversion types are handled
+    correctly — including nonlinear ones like dB, mag, and dex (which
+    are logarithmic, not affine).
+    """
+    n = len(to_units)
+    m = len(to_units[0])
+    return jnp.stack(
+        [
+            jnp.stack(
+                [
+                    u.uconvert_value(to_units[i][j], from_units[i][j], value[..., i, j])
+                    for j in range(m)
+                ],
+                axis=-1,
+            )
+            for i in range(n)
+        ],
+        axis=-2,
+    )
+
+
+@plum.conversion_method(type_from=QuantityMatrix, type_to=u.Q)
+def QuantityMatrix_to_quantity(x: QuantityMatrix, /) -> u.Q:
+    """Convert a ``QuantityMatrix`` to a regular ``Quantity``.
+
+    Conversion is only valid when all elements of ``x`` share the same unit.  If
+    units are heterogeneous, this conversion is ambiguous and raises
+    ``ValueError``.
+
+    >>> import plum
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    Uniform units convert to a plain quantity:
+
+    >>> qmat = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+    >>> plum.convert(qmat, u.Q)
+    Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
+
+    Mixed units are rejected:
+
+    >>> bad = QuantityMatrix(jnp.array([1.0, 2.0]), unit=("m", "s"))
+    >>> plum.convert(bad, u.Q)
+    Traceback (most recent call last):
+    ...
+    ValueError: Cannot convert QuantityMatrix to Quantity unless all units are
+    identical.
+
+    """
+    units = jtu.tree_leaves(x.unit.to_tuple())
+
+    if not units:
+        msg = "Cannot convert QuantityMatrix with no unit entries."
+        raise ValueError(msg)
+
+    first = units[0]
+    if any(unit != first for unit in units[1:]):
+        msg = (
+            "Cannot convert QuantityMatrix to Quantity unless all units are identical."
+        )
+        raise ValueError(msg)
+
+    return u.Q(x.value, first)
+
+
+def _convert_value(
+    value: Array,
+    from_units: UnitsMatrix,
+    to_units: UnitsMatrix,
+) -> Array:
+    """Convert value with heterogeneous units (works for both 1D and 2D)."""
+    from_tup = from_units.to_tuple()
+    to_tup = to_units.to_tuple()
+    if from_units.ndim == 1:
+        return _convert_value_vector(value, from_tup, to_tup)
+    if from_units.ndim == 2:
+        return _convert_value_matrix(value, from_tup, to_tup)
+    msg = f"Unsupported ndim={from_units.ndim}"
+    raise NotImplementedError(msg)
+
+
+@plum.dispatch
+def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
+    """Convert a ``QuantityMatrix`` to different (but compatible) units.
+
+    Unlike the generic astropy ``StructuredUnit.to()`` path, this dispatch uses
+    ``_convert_value`` directly so that the regular 2D JAX array in ``x.value``
+    is converted element-by-element without requiring a numpy structured array.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    >>> q = QuantityMatrix(x, (("m", "rad"), ("m", "rad")))
+    >>> target = u.unit((("km", "deg"), ("km", "deg")))
+    >>> q.uconvert(target).unit.to_string()
+    '((km, deg), (km, deg))'
+
+    """
+    if x.unit == to_units:
+        return x
+    value = _convert_value(x.value, x.unit, to_units)
+    return QuantityMatrix(value=value, unit=to_units)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -210,9 +210,27 @@ class QuantityMatrix(u.AbstractQuantity):
         >>> qm[1, 2]
         Quantity(Array(1., dtype=float32), unit='m')
 
+        Leading **batch** axes are indexed on the value only — the unit
+        structure is untouched:
+
+        >>> qmb = QuantityMatrix(jnp.ones((3, 2, 2)), unit=(("m", "s"), ("kg", "rad")))
+        >>> qmb[0].unit.to_string()
+        '((m, s), (kg, rad))'
+
         """
         value_item = self.value[index]
-        unit_item = self.unit[index]
+        # `value` carries `n_batch` leading batch axes that `unit` does not, so
+        # the leading portion of `index` addresses batch axes and must not be
+        # applied to the unit; only the trailing entries index the logical axes.
+        n_batch = self.value.ndim - self.unit.ndim
+        idx = index if isinstance(index, tuple) else (index,)
+        if any(i is Ellipsis or i is None for i in idx):
+            msg = (
+                "QuantityMatrix.__getitem__ does not support Ellipsis (...) or "
+                "None (newaxis); index the batch and logical axes positionally."
+            )
+            raise NotImplementedError(msg)
+        unit_item = self.unit[idx[n_batch:]]  # () -> whole unit (batch-only index)
         if isinstance(unit_item, UnitsMatrix):
             return QuantityMatrix(value=value_item, unit=unit_item)
         return u.Q(value_item, unit_item)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -95,6 +95,29 @@ class QuantityMatrix(u.AbstractQuantity):
     value: Shaped[Array, "..."] = eqx.field()
     unit: UnitsMatrix = eqx.field(static=True, converter=u.unit)  # ty: ignore[invalid-assignment]
 
+    def __check_init__(self) -> None:
+        """Check the value's trailing shape matches the unit structure.
+
+        The trailing ``unit.ndim`` axes of ``value`` are the logical (vector /
+        matrix) axes and must equal ``unit.shape``; any further *leading* axes
+        are batch dimensions.
+        """
+        un = self.unit.ndim
+        if self.value.ndim < un:
+            msg = (
+                f"QuantityMatrix value has ndim={self.value.ndim}, fewer than the "
+                f"{un}-D unit structure {self.unit.to_string()}."
+            )
+            raise ValueError(msg)
+        logical = tuple(self.value.shape[-un:])
+        if logical != self.unit.shape:
+            msg = (
+                f"QuantityMatrix value trailing shape {logical} does not match the "
+                f"unit structure shape {self.unit.shape} "
+                f"(value.shape={self.value.shape}, unit={self.unit.to_string()})."
+            )
+            raise ValueError(msg)
+
     @property
     def ndim(self) -> int:
         """Number of real dimensions (1 for vector, 2 for matrix)."""

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -8,6 +8,7 @@ import jax.core
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import plum
+import quax
 from jaxtyping import Array, Shaped
 
 import unxt as u
@@ -192,6 +193,53 @@ class QuantityMatrix(u.AbstractQuantity):
         if isinstance(unit_item, UnitsMatrix):
             return QuantityMatrix(value=value_item, unit=unit_item)
         return u.Q(value_item, unit_item)
+
+    def __matmul__(self, other: Any) -> Any:
+        """``@`` with NumPy semantics, dispatched on *logical* rank.
+
+        When *other* is a `QuantityMatrix`, the product is chosen from the pair
+        of logical (``unit``) ranks — not the value shapes, which also carry
+        batch axes — so a *batched* matrix-vector product works (``matmul``
+        cannot express one; see `unxts.linalg.matvec`). Leading batch axes are
+        broadcast over.
+
+        - 2-D @ 2-D → matrix-matrix (`~unxts.linalg.matmul`)
+        - 2-D @ 1-D → matrix-vector (`~unxts.linalg.matvec`)
+        - 1-D @ 2-D → vector-matrix (`~unxts.linalg.vecmat`)
+        - 1-D @ 1-D → vector-vector, a scalar `~unxt.Quantity` (`~unxts.linalg.vecdot`)
+
+        Non-`QuantityMatrix` operands fall back to the default handling.
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import unxts.linalg as ul
+
+        A batch of matrices applied to a batch of vectors — ``@`` just works:
+
+        >>> A = ul.QuantityMatrix(
+        ...     jnp.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+        ...     unit=(("m", "m"), ("m", "m")),
+        ... )
+        >>> v = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
+        >>> (A @ v).value
+        Array([[ 3.,  7.],
+               [11., 15.]], dtype=float32)
+        >>> (A @ v).unit.to_string()
+        '(m s, m s)'
+
+        """
+        if isinstance(other, QuantityMatrix):
+            ranks = (self.unit.ndim, other.unit.ndim)
+            if ranks == (2, 2):
+                return quax.quaxify(jnp.matmul)(self, other)
+            if ranks == (2, 1):
+                return quax.quaxify(jnp.matvec)(self, other)
+            if ranks == (1, 2):
+                return quax.quaxify(jnp.vecmat)(self, other)
+            if ranks == (1, 1):
+                return quax.quaxify(jnp.vecdot)(self, other)
+        return super().__matmul__(other)
 
     # ── Quax API ─────────────────────────────────────────────────────
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -172,6 +172,23 @@ class QuantityMatrix(u.AbstractQuantity):
         """
         keys = tuple(v) if keys is None else keys
         vs = [v[k] for k in keys]
+        # Each value must have a *scalar* unit (a plain Quantity or a
+        # dimensionless array). A QuantityMatrix/UnitsMatrix value has a
+        # UnitsMatrix unit, for which `unit_of`/`ustrip` have no scalar-unit
+        # dispatch — reject it up front with a clear message rather than the
+        # confusing downstream dispatch error.
+        bad = [
+            k
+            for k, x in strict_zip(keys, vs)
+            if isinstance(x, (QuantityMatrix, UnitsMatrix))
+        ]
+        if bad:
+            msg = (
+                f"from_cdict values must be scalar-unit quantities or plain "
+                f"arrays; key(s) {bad} are QuantityMatrix/UnitsMatrix, which are "
+                f"not supported."
+            )
+            raise TypeError(msg)
         us = [u.unit_of(x) or _DMLS for x in vs]
         svs = jnp.stack([u.ustrip(AllowValue, unt, x) for x, unt in strict_zip(vs, us)])
         return cls(svs, unit=UnitsMatrix(us))

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -3,6 +3,8 @@
 Registers handlers for the following JAX primitives:
 - ``lax.add_p`` — element-wise addition
 - ``lax.sub_p`` — element-wise subtraction
+- ``lax.mul_p`` — element-wise multiplication
+- ``lax.div_p`` — element-wise division
 - ``lax.dot_general_p`` — dot product / matrix multiply
 - ``lax.transpose_p`` — matrix transpose
 - ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
@@ -121,6 +123,90 @@ def sub_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
     """
     y_converted = _convert_value(y.value, y.unit, x.unit)
     return QuantityMatrix(value=lax.sub(x.value, y_converted), unit=x.unit)
+
+
+# ── mul / div (element-wise) ──────────────────────────────────────────────
+#
+# Element-wise (Hadamard) product / quotient. Unlike add/sub, the per-element
+# units *compose* multiplicatively (no unit conversion), so `m * s -> m s`.
+# QuantityMatrix subclasses AbstractQuantity, whose generic `mul_p` rule would
+# do `x.unit * y.unit` and build the *left operand's* type — producing a plain
+# Quantity wrapping a UnitsMatrix (a malformed object) when a Quantity is on the
+# left. These handlers keep the result a QuantityMatrix for every operand order.
+
+
+@quax.register(lax.mul_p)
+def mul_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
+    """Element-wise product of two `QuantityMatrix` objects (units multiply)."""
+    return QuantityMatrix(x.value * y.value, unit=x.unit * y.unit)
+
+
+@quax.register(lax.mul_p)
+def mul_qm_qty(
+    x: QuantityMatrix, y: u.AbstractQuantity, /, **kw: Any
+) -> QuantityMatrix:
+    """`QuantityMatrix` x uniform-unit Quantity: scale values, multiply units."""
+    y_unit = u.unit_of(y)
+    y_val = u.ustrip(AllowValue, y_unit, y)
+    return QuantityMatrix(x.value * y_val, unit=x.unit * y_unit)
+
+
+@quax.register(lax.mul_p)
+def mul_qty_qm(
+    x: u.AbstractQuantity, y: QuantityMatrix, /, **kw: Any
+) -> QuantityMatrix:
+    """Quantity x `QuantityMatrix` — multiplication commutes."""
+    return mul_qm_qty(y, x)
+
+
+@quax.register(lax.mul_p)
+def mul_qm_arr(x: QuantityMatrix, y: jax.Array, /, **kw: Any) -> QuantityMatrix:
+    """`QuantityMatrix` x dimensionless array: scale values, units unchanged."""
+    return QuantityMatrix(x.value * y, unit=x.unit)
+
+
+@quax.register(lax.mul_p)
+def mul_arr_qm(x: jax.Array, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
+    """Dimensionless array x `QuantityMatrix`."""
+    return QuantityMatrix(x * y.value, unit=y.unit)
+
+
+@quax.register(lax.div_p)
+def div_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
+    """Element-wise quotient of two `QuantityMatrix` objects (units divide)."""
+    return QuantityMatrix(x.value / y.value, unit=x.unit / y.unit)
+
+
+@quax.register(lax.div_p)
+def div_qm_qty(
+    x: QuantityMatrix, y: u.AbstractQuantity, /, **kw: Any
+) -> QuantityMatrix:
+    """`QuantityMatrix` / uniform-unit Quantity."""
+    y_unit = u.unit_of(y)
+    y_val = u.ustrip(AllowValue, y_unit, y)
+    return QuantityMatrix(x.value / y_val, unit=x.unit / y_unit)
+
+
+@quax.register(lax.div_p)
+def div_qty_qm(
+    x: u.AbstractQuantity, y: QuantityMatrix, /, **kw: Any
+) -> QuantityMatrix:
+    """Uniform-unit Quantity / `QuantityMatrix` (not commutative)."""
+    x_unit = u.unit_of(x)
+    x_val = u.ustrip(AllowValue, x_unit, x)
+    return QuantityMatrix(x_val / y.value, unit=x_unit / y.unit)
+
+
+@quax.register(lax.div_p)
+def div_qm_arr(x: QuantityMatrix, y: jax.Array, /, **kw: Any) -> QuantityMatrix:
+    """`QuantityMatrix` / dimensionless array: scale values, units unchanged."""
+    return QuantityMatrix(x.value / y, unit=x.unit)
+
+
+@quax.register(lax.div_p)
+def div_arr_qm(x: jax.Array, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
+    """Dimensionless array / `QuantityMatrix` (units invert)."""
+    return QuantityMatrix(x / y.value, unit=_DMLS / y.unit)
 
 
 # ── dot_general helpers ───────────────────────────────────────────────────

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -502,6 +502,28 @@ def dot_general_qm_qm(
     raise NotImplementedError(msg)
 
 
+def _wrap_operand(
+    value: jax.Array, element_unit: Any, batch_axes: tuple[int, ...], /
+) -> QuantityMatrix:
+    """Wrap a plain value as a `QuantityMatrix` with a uniform per-element unit.
+
+    The logical (vector vs matrix) rank is inferred from the number of *batch*
+    axes in ``dimension_numbers`` — ``value.ndim - len(batch_axes)`` — so a
+    batched vector ``(*batch, K)`` is correctly wrapped with a 1-D unit
+    structure rather than being mistaken for a matrix by its raw ``ndim``.
+    """
+    logical_ndim = value.ndim - len(batch_axes)
+    if logical_ndim == 1:
+        n = value.shape[-1]
+        unit = UnitsMatrix(tuple(element_unit for _ in range(n)))
+    else:  # matrix (logical_ndim == 2)
+        nr, nc = value.shape[-2], value.shape[-1]
+        unit = UnitsMatrix(
+            tuple(tuple(element_unit for _ in range(nc)) for _ in range(nr))
+        )
+    return QuantityMatrix(value, unit=unit)
+
+
 @quax.register(lax.dot_general_p)
 def dot_general_qm_arr(
     lhs: QuantityMatrix,
@@ -537,15 +559,7 @@ def dot_general_qm_arr(
     Array([2., 3.], dtype=float32)
 
     """
-    if rhs.ndim == 1:
-        n = rhs.shape[0]
-        rhs_qm = QuantityMatrix(rhs, unit=UnitsMatrix(tuple(_DMLS for _ in range(n))))
-    else:
-        nr, nc = rhs.shape[-2], rhs.shape[-1]
-        rhs_qm = QuantityMatrix(
-            rhs,
-            unit=UnitsMatrix(tuple(tuple(_DMLS for _ in range(nc)) for _ in range(nr))),
-        )
+    rhs_qm = _wrap_operand(rhs, _DMLS, dimension_numbers[1][1])
     return dot_general_qm_qm(
         lhs,
         rhs_qm,
@@ -598,19 +612,7 @@ def dot_general_qm_qty(
     """
     rhs_unit = u.unit_of(rhs)
     rhs_val = cast("jax.Array", u.ustrip(AllowValue, rhs_unit, rhs))
-    if rhs_val.ndim == 1:
-        n = rhs_val.shape[0]
-        rhs_qm = QuantityMatrix(
-            rhs_val, unit=UnitsMatrix(tuple(rhs_unit for _ in range(n)))
-        )
-    else:
-        nr, nc = rhs_val.shape[-2], rhs_val.shape[-1]
-        rhs_qm = QuantityMatrix(
-            rhs_val,
-            unit=UnitsMatrix(
-                tuple(tuple(rhs_unit for _ in range(nc)) for _ in range(nr))
-            ),
-        )
+    rhs_qm = _wrap_operand(rhs_val, rhs_unit, dimension_numbers[1][1])
     return dot_general_qm_qm(
         lhs,
         rhs_qm,
@@ -653,15 +655,7 @@ def dot_general_arr_qm(
     Array([2., 3.], dtype=float32)
 
     """
-    if lhs.ndim == 1:
-        n = lhs.shape[0]
-        lhs_qm = QuantityMatrix(lhs, unit=UnitsMatrix(tuple(_DMLS for _ in range(n))))
-    else:
-        nr, nc = lhs.shape[-2], lhs.shape[-1]
-        lhs_qm = QuantityMatrix(
-            lhs,
-            unit=UnitsMatrix(tuple(tuple(_DMLS for _ in range(nc)) for _ in range(nr))),
-        )
+    lhs_qm = _wrap_operand(lhs, _DMLS, dimension_numbers[1][0])
     return dot_general_qm_qm(
         lhs_qm,
         rhs,

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -228,6 +228,67 @@ def _dot_general_2d_1d(
     return QuantityMatrix(value=accum, unit=out_unit)
 
 
+def _dot_general_1d_2d(
+    lhs: QuantityMatrix,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> QuantityMatrix:
+    """Vector-matrix multiply: (K,) @ (K, M) → (M,).
+
+    For ``w = v @ A`` where ``v`` is ``(K,)`` and ``A`` is ``(K, M)``:
+
+    ``w[k] = Σ_j  v[j] * A[j, k]``
+
+    Each product ``v[j] * A[j,k]`` has unit ``v.unit[j] * A.unit[j][k]``.  All
+    ``K`` terms in the sum for output column ``k`` must be unit-compatible.  We
+    convert every term to the unit of the *first* term (``j = 0``) for each
+    output column ``k``: ``ref[k] = v.unit[0] * A.unit[0][k]``.  This is the
+    transpose of the matrix-vector case (:func:`_dot_general_2d_1d`).
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import unxts.linalg as ul
+
+    Row vector times a matrix:
+
+    >>> v = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+    >>> A = ul.QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "km"), ("m", "km"))
+    ... )
+    >>> w = ul.vecmat(v, A)
+    >>> w.value
+    Array([4., 6.], dtype=float32)
+    >>> w.unit.to_string()
+    '(m s, km s)'
+
+    """
+    assert lhs.shape[-1] == rhs.shape[-2]  # noqa: S101
+
+    # 1) Output units: ref[k] = lhs.unit[0] * rhs.unit[0][k]
+    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
+
+    # 2) Precompute scale factors: scale[j, k] converts
+    #    lhs.unit[j]*rhs.unit[j][k] → ref[k]
+    scale_2d = jnp.array(
+        vec_uconvert_value(
+            out_unit._units[None, :],  # (1, M) — broadcast over K
+            np.multiply(lhs.unit._units[:, None], rhs.unit._units),  # (K, M)
+            1.0,
+        )
+    )
+
+    # 3) Vectorised contraction:
+    #    w[..., k] = Σ_j  scale[j, k] * v[..., j] * A[..., j, k]
+    accum = jnp.einsum("jk,...j,...jk->...k", scale_2d, lhs.value, rhs.value)
+
+    return QuantityMatrix(value=accum, unit=out_unit)
+
+
 def _dot_general_2d_2d(
     lhs: QuantityMatrix,
     rhs: QuantityMatrix,
@@ -322,9 +383,17 @@ def dot_general_qm_qm(
 ) -> QuantityMatrix | u.Q:
     """Dot product / matrix multiply two `QuantityMatrix` objects.
 
-    Delegates to specialized implementations based on the dimensionality:
+    Delegates to specialized implementations based on the (logical)
+    dimensionality of each operand:
     - 1D @ 1D → scalar (vector dot product)
+    - 2D @ 1D → 1D (matrix-vector product)
+    - 1D @ 2D → 1D (vector-matrix product)
     - 2D @ 2D → 2D (matrix-matrix multiply)
+
+    Leading batch axes on the value arrays are broadcast over. The batch-aware
+    entry points are the wrappers in `unxts.linalg` (``matmul``/``matvec``/
+    ``vecmat``/``vecdot``); ``matmul`` alone cannot express batched
+    matrix-vector products (see `unxts.linalg._src._products`).
 
     For the standard matmul contraction: contracting_dims = ((-1,), (-2,)).
     Leading *batch* axes on the value arrays are supported: ``jnp.matmul`` /
@@ -397,6 +466,15 @@ def dot_general_qm_qm(
         )
     if lhs.ndim == 2 and rhs.ndim == 1:
         return _dot_general_2d_1d(
+            lhs,
+            rhs,
+            dimension_numbers=dimension_numbers,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            **kw,
+        )
+    if lhs.ndim == 1 and rhs.ndim == 2:
+        return _dot_general_1d_2d(
             lhs,
             rhs,
             dimension_numbers=dimension_numbers,

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -1,0 +1,814 @@
+"""Quax primitive registrations for QuantityMatrix arithmetic.
+
+Registers handlers for the following JAX primitives:
+- ``lax.add_p`` — element-wise addition
+- ``lax.sub_p`` — element-wise subtraction
+- ``lax.dot_general_p`` — dot product / matrix multiply
+- ``lax.transpose_p`` — matrix transpose
+- ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
+- ``lax.reduce_sum_p`` — summation reduction
+"""
+
+from typing import Any, cast
+
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import numpy as np
+import quax
+from jax import lax
+
+import unxt as u
+from ._quantity_matrix import QuantityMatrix, _convert_value
+from ._units_matrix import UnitsMatrix
+from unxt.quantity import AllowValue
+
+# Vectorised uconvert_value — used by dot-product helpers.
+vec_uconvert_value = np.vectorize(u.uconvert_value)
+
+_DMLS = u.unit("")
+
+
+# ── add / sub ────────────────────────────────────────────────────────────
+
+
+@quax.register(lax.add_p)
+def add_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
+    """Element-wise addition of two `QuantityMatrix` objects.
+
+    The result adopts the units of *x*.  Each element is converted from
+    ``y.unit`` → ``x.unit`` before the numeric add.
+
+    Works for both 1D (vector) and 2D (matrix) cases.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    2D case:
+
+    >>> a = QuantityMatrix(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
+    >>> b = QuantityMatrix(jnp.ones((2, 2)), unit=(("km", "ms"), ("g", "deg")))
+
+    >>> result = qnp.add(a, b)
+    >>> result.unit.to_string()
+    '((m, s), (kg, rad))'
+
+    >>> result.value
+    Array([[1001.       ,    1.001    ],
+           [   1.001    ,    1.0174533]], dtype=float32)
+
+    1D case:
+
+    >>> a1d = QuantityMatrix(jnp.ones(3), unit=("m", "s", "kg"))
+    >>> b1d = QuantityMatrix(jnp.ones(3), unit=("km", "ms", "g"))
+
+    >>> result1d = qnp.add(a1d, b1d)
+    >>> result1d.unit.to_string()
+    '(m, s, kg)'
+
+    >>> result1d.value
+    Array([1001.   ,    1.001,    1.001], dtype=float32)
+
+    """
+    y_converted = _convert_value(y.value, y.unit, x.unit)
+    return QuantityMatrix(value=lax.add(x.value, y_converted), unit=x.unit)
+
+
+@quax.register(lax.sub_p)
+def sub_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
+    """Element-wise subtraction of two `QuantityMatrix` objects.
+
+    The result adopts the units of *x*.  Each element is converted from
+    ``y.unit`` → ``x.unit`` before the numeric subtract.
+
+    Works for both 1D (vector) and 2D (matrix) cases.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    2D case:
+
+    >>> a = QuantityMatrix(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
+    >>> b = QuantityMatrix(
+    ...     value=jnp.ones((2, 2)),
+    ...     unit=(("km", u.unit("ms")), (u.unit("g"), u.unit("deg"))),
+    ... )
+
+    >>> result = qnp.subtract(a, b)
+    >>> result.unit.to_string()
+    '((m, s), (kg, rad))'
+
+    >>> result.value
+    Array([[-9.990000e+02,  9.990000e-01],
+           [ 9.990000e-01,  9.825467e-01]], dtype=float32)
+
+    1D case:
+
+    >>> a1d = QuantityMatrix(value=jnp.ones(3), unit=("m", "s", "kg"))
+    >>> b1d = QuantityMatrix(value=jnp.ones(3), unit=("km", u.unit("ms"), u.unit("g")))
+
+    >>> result1d = qnp.subtract(a1d, b1d)
+    >>> result1d.unit.to_string()
+    '(m, s, kg)'
+
+    >>> result1d.value
+    Array([-999.   ,    0.999,    0.999], dtype=float32)
+
+    """
+    y_converted = _convert_value(y.value, y.unit, x.unit)
+    return QuantityMatrix(value=lax.sub(x.value, y_converted), unit=x.unit)
+
+
+# ── dot_general helpers ───────────────────────────────────────────────────
+
+
+def _dot_general_1d_1d(
+    lhs: QuantityMatrix,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> u.Q:
+    """Vector dot product: (N,) @ (N,) → scalar.
+
+    Result = Σ_i  lhs[i] * rhs[i]
+
+    All terms must be unit-compatible. We convert to the unit of the first term.
+    """
+    n = lhs.shape[-1]
+    assert n == rhs.shape[-1]  # noqa: S101
+
+    # Reference unit: lhs.unit[0] * rhs.unit[0]
+    ref_unit = lhs.unit[0] * rhs.unit[0]
+
+    # Compute scale factors
+    scales = jnp.array(
+        [u.uconvert_value(ref_unit, lhs.unit[i] * rhs.unit[i], 1.0) for i in range(n)]
+    )
+
+    # Compute dot product with rescaling
+    result_value = jnp.sum(scales * lhs.value * rhs.value, axis=-1)
+
+    return u.Q(result_value, ref_unit)
+
+
+def _dot_general_2d_1d(
+    lhs: QuantityMatrix,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> QuantityMatrix:
+    """Matrix-vector multiply: (N, K) @ (K,) → (N,).
+
+    For ``w = A @ v`` where ``A`` is ``(N, K)`` and ``v`` is ``(K,)``:
+
+    ``w[i] = Σ_j  A[i, j] * v[j]``
+
+    Each product ``A[i,j] * v[j]`` has unit ``A.unit[i][j] * v.unit[j]``.  All
+    ``K`` terms in the sum for output row ``i`` must be unit-compatible.  We
+    convert every term to the unit of the *first* term (``j = 0``) for each
+    output row ``i``: ``ref[i] = A.unit[i][0] * v.unit[0]``.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    Identity matrix times a vector:
+
+    >>> A = QuantityMatrix(jnp.eye(3), unit=(("", "", ""), ("", "", ""), ("", "", "")))
+    >>> v = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+    >>> w = qnp.matmul(A, v)
+    >>> w.value
+    Array([1., 2., 3.], dtype=float32)
+
+    Mixed units on contraction axis (km column converted to m):
+
+    >>> A2 = QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "km"), ("m", "km"))
+    ... )
+    >>> v2 = QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+    >>> w2 = qnp.matmul(A2, v2)
+    >>> w2.value
+    Array([2001., 4003.], dtype=float32)
+    >>> w2.unit.to_string()
+    '(m s, m s)'
+
+    """
+    assert rhs.shape[-1] == lhs.shape[-1]  # noqa: S101
+
+    # 1) Output units: ref[i] = lhs.unit[i][0] * rhs.unit[0]
+    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
+
+    # 2) Precompute scale factors: scale[i, j] converts
+    #    lhs.unit[i][j]*rhs.unit[j] → ref[i]
+    scale_2d = jnp.array(
+        vec_uconvert_value(
+            out_unit._units[:, None],  # (N, 1) — broadcast over K
+            np.multiply(lhs.unit._units, rhs.unit._units[None, :]),  # (N, K)
+            1.0,
+        )
+    )
+
+    # 3) Vectorised contraction:
+    #    w[..., i] = Σ_j  scale[i, j] * A[..., i, j] * v[..., j]
+    accum = jnp.einsum("ij,...ij,...j->...i", scale_2d, lhs.value, rhs.value)
+
+    return QuantityMatrix(value=accum, unit=out_unit)
+
+
+def _dot_general_2d_2d(
+    lhs: QuantityMatrix,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> QuantityMatrix:
+    """Matrix multiply: (N, K) @ (K, M) → (N, M).
+
+    For ``C = A @ B`` where ``A`` is ``(N, K)`` and ``B`` is ``(K, M)``:
+
+    ``C[i, k] = Σ_j  A[i, j] * B[j, k]``
+
+    Each product ``A[i,j] * B[j,k]`` has unit ``A.unit[i][j] * B.unit[j][k]``.
+    All ``K`` terms in the sum **must** be unit-compatible.  We convert every
+    term to the unit of the *first* term (``j = 0``) using `u.uconvert_value`,
+    then sum with a plain matmul.
+
+    The strategy:
+    1. Pick a reference unit for each ``(i, k)`` output element:
+       ``ref[i][k] = A.unit[i][0] * B.unit[0][k]``.
+    2. For each contraction index ``j``, compute per-element conversion
+       factors from ``A.unit[i][j] * B.unit[j][k]`` to ``ref[i][k]``.
+       Because the products are *multiplicative* compositions, the
+       conversion from ``u_A * u_B`` to ``ref`` is multiplicative even
+       when the individual units are affine — the product of two
+       absolute quantities is always absolute.
+       So we can safely compute a scale factor:
+       ``scale[i][j][k] = uconvert_value(ref[i][k], A.unit[i][j] * B.unit[j][k], 1.0)``
+    3. Build the rescaled sum as:
+       ``C_val[i, k] = Σ_j  scale[i][j][k] * A_val[i, j] * B_val[j, k]``
+       Done via ``C_val = (A_val * S_ij) @ B_val`` per output column, or
+       equivalently with a loop + accumulate.
+    """
+    # Check contraction axis
+    assert lhs.shape[-1] == rhs.shape[-2]  # noqa: S101
+
+    # 1) Compute output units: ref[i][k] = lhs.unit[i][0] * rhs.unit[0][k]
+    out_unit = np.multiply(lhs.unit._units[:, 0:1], rhs.unit._units[0:1, :])
+
+    # 2) Precompute all scale factors as a (N, K, M) constant array.
+    #    scale[i, j, k] converts lhs.unit[i][j]*rhs.unit[j][k] → out_unit[i][k].
+    #
+    #    CORRECTNESS NOTE — why a multiplicative scale factor is exact:
+    #    Affine units (°C, °F) are the only units where a bare
+    #    multiplicative scale would be wrong (they have an additive
+    #    offset).  But astropy rejects product conversions involving
+    #    affine units — e.g. ``(deg_C * s).to(deg_F * s)`` raises
+    #    ``UnitConversionError``.  Every product unit that astropy
+    #    *does* accept (including logarithmic units like dex, mag) is
+    #    a plain ``CompositeUnit`` whose conversion is purely
+    #    multiplicative.  So ``uconvert_value(to, from, 1.0)`` yields
+    #    an exact scale factor for all valid product units.
+    #
+    #    The tests in ``TestAffineProductUnitsRejected`` assert that
+    #    astropy keeps rejecting affine product conversions.  If that
+    #    ever changes, those tests will fail, alerting us that this
+    #    assumption needs revisiting.
+    scale_3d = jnp.array(
+        vec_uconvert_value(
+            out_unit[:, None, :],  # (N, 1, M)
+            np.multiply(lhs.unit._units[:, :, None], rhs.unit._units[None, :, :]),
+            1.0,  # ꜛ (N, K, M)
+        )
+    )
+
+    # 3) Vectorised contraction — no Python loop, no accumulator.
+    #    C[..., i, k] = Σ_j  scale[i, j, k] * A[..., i, j] * B[..., j, k]
+    accum = jnp.sum(  # (N, K, M) * (..., N, K, 1) * (..., 1, K, M)
+        scale_3d * lhs.value[..., :, :, None] * rhs.value[..., None, :, :], axis=-2
+    )
+
+    return QuantityMatrix(value=accum, unit=out_unit)
+
+
+# ── dot_general dispatch ──────────────────────────────────────────────────
+
+
+@quax.register(lax.dot_general_p)
+def dot_general_qm_qm(
+    lhs: QuantityMatrix,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> QuantityMatrix | u.Q:
+    """Dot product / matrix multiply two `QuantityMatrix` objects.
+
+    Delegates to specialized implementations based on the dimensionality:
+    - 1D @ 1D → scalar (vector dot product)
+    - 2D @ 2D → 2D (matrix-matrix multiply)
+
+    For the standard matmul contraction: contracting_dims = ((-1,), (-2,)),
+    with no batch dims (batch is handled by leading dims in QuantityMatrix).
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    1D @ 1D (dot product):
+
+    >>> v1 = QuantityMatrix(jnp.array([1.0, 2.0]), unit=("m", "km"))
+    >>> v2 = QuantityMatrix(jnp.array([3.0, 4.0]), unit=("s", "s"))
+    >>> result = qnp.dot(v1, v2)
+    >>> result.value
+    Array(8003., dtype=float32)
+    >>> result.unit
+    Unit("m s")
+
+    2D @ 2D (matrix multiply):
+
+    >>> a = QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "km"), ("m", "km"))
+    ... )
+    >>> b = QuantityMatrix(
+    ...     jnp.array([[1.0, 0.0], [0.0, 1.0]]), unit=(("s", "s"), ("s", "s"))
+    ... )
+
+    >>> c = qnp.matmul(a, b)
+    >>> c.unit.to_string()
+    '((m s, m s), (m s, m s))'
+
+    >>> c.value
+    Array([[1.e+00, 2.e+03],
+           [3.e+00, 4.e+03]], dtype=float32)
+
+    """
+    # For now, we only handle the standard matmul/dot contraction
+    (contract, batch) = dimension_numbers
+    assert len(contract[0]) == 1 and len(contract[1]) == 1  # noqa: PT018, S101
+    assert len(batch[0]) == 0 and len(batch[1]) == 0  # noqa: PT018, S101
+
+    # Delegate based on dimensionality
+    if lhs.ndim == 1 and rhs.ndim == 1:
+        return _dot_general_1d_1d(
+            lhs,
+            rhs,
+            dimension_numbers=dimension_numbers,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            **kw,
+        )
+    if lhs.ndim == 2 and rhs.ndim == 2:
+        return _dot_general_2d_2d(
+            lhs,
+            rhs,
+            dimension_numbers=dimension_numbers,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            **kw,
+        )
+    if lhs.ndim == 2 and rhs.ndim == 1:
+        return _dot_general_2d_1d(
+            lhs,
+            rhs,
+            dimension_numbers=dimension_numbers,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            **kw,
+        )
+    msg = f"Unsupported dimensionality: lhs.ndim={lhs.ndim}, rhs.ndim={rhs.ndim}"
+    raise NotImplementedError(msg)
+
+
+@quax.register(lax.dot_general_p)
+def dot_general_qm_arr(
+    lhs: QuantityMatrix,
+    rhs: jax.Array,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> "QuantityMatrix | u.Q":
+    """Dot product of a :class:`QuantityMatrix` with a plain JAX array.
+
+    The plain array is treated as dimensionless.  Delegates to
+    :func:`dot_general_qm_qm` after wrapping ``rhs`` in a dimensionless
+    :class:`QuantityMatrix`.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+
+    2D metric x 1D plain vector:
+
+    >>> g = QuantityMatrix(
+    ...     jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+    ...     unit=UnitsMatrix((("m2", "m2"), ("m2", "m2"))),
+    ... )
+    >>> v = jnp.array([1.0, 1.0])
+    >>> w = qnp.matmul(g, v)
+    >>> w.unit.to_string()
+    '(m2, m2)'
+    >>> w.value
+    Array([2., 3.], dtype=float32)
+
+    """
+    if rhs.ndim == 1:
+        n = rhs.shape[0]
+        rhs_qm = QuantityMatrix(rhs, unit=UnitsMatrix(tuple(_DMLS for _ in range(n))))
+    else:
+        nr, nc = rhs.shape[-2], rhs.shape[-1]
+        rhs_qm = QuantityMatrix(
+            rhs,
+            unit=UnitsMatrix(tuple(tuple(_DMLS for _ in range(nc)) for _ in range(nr))),
+        )
+    return dot_general_qm_qm(
+        lhs,
+        rhs_qm,
+        dimension_numbers=dimension_numbers,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+        **kw,
+    )
+
+
+@quax.register(lax.dot_general_p)
+def dot_general_qm_qty(
+    lhs: QuantityMatrix,
+    rhs: u.AbstractQuantity,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> "QuantityMatrix | u.Q":
+    """Dot product of a :class:`QuantityMatrix` with a :class:`~unxt.AbstractQuantity`.
+
+    The Quantity carries a single scalar unit that applies uniformly to all
+    elements.  The ``rhs`` is wrapped as a uniform-unit
+    :class:`QuantityMatrix` and delegated to :func:`dot_general_qm_qm`.
+
+    Note that :class:`QuantityMatrix` is itself a subtype of
+    :class:`~unxt.AbstractQuantity`, so :func:`dot_general_qm_qm` takes
+    precedence when both sides are :class:`QuantityMatrix`.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import quaxed.numpy as qnp
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+
+    2D metric with units @ uniform-unit Quantity vector:
+
+    >>> g = QuantityMatrix(
+    ...     jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+    ...     unit=UnitsMatrix((("m2 / rad2", "m2 / rad2"), ("m2 / rad2", "m2 / rad2"))),
+    ... )
+    >>> v = u.Q(jnp.array([1.0, 1.0]), "rad")
+    >>> w = qnp.matmul(g, v)
+    >>> w.unit.to_string()
+    '(m2 / rad, m2 / rad)'
+    >>> w.value
+    Array([2., 3.], dtype=float32)
+
+    """
+    rhs_unit = u.unit_of(rhs)
+    rhs_val = cast("jax.Array", u.ustrip(AllowValue, rhs_unit, rhs))
+    if rhs_val.ndim == 1:
+        n = rhs_val.shape[0]
+        rhs_qm = QuantityMatrix(
+            rhs_val, unit=UnitsMatrix(tuple(rhs_unit for _ in range(n)))
+        )
+    else:
+        nr, nc = rhs_val.shape[-2], rhs_val.shape[-1]
+        rhs_qm = QuantityMatrix(
+            rhs_val,
+            unit=UnitsMatrix(
+                tuple(tuple(rhs_unit for _ in range(nc)) for _ in range(nr))
+            ),
+        )
+    return dot_general_qm_qm(
+        lhs,
+        rhs_qm,
+        dimension_numbers=dimension_numbers,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+        **kw,
+    )
+
+
+@quax.register(lax.dot_general_p)
+def dot_general_arr_qm(
+    lhs: jax.Array,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> "QuantityMatrix | u.Q":
+    """Dot product of a plain JAX array with a :class:`QuantityMatrix`.
+
+    The plain array is treated as dimensionless.  Delegates to
+    :func:`dot_general_qm_qm` after wrapping ``lhs`` in a dimensionless
+    :class:`QuantityMatrix`.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> from unxts.linalg import QuantityMatrix
+
+    Dimensionless identity @ QuantityMatrix vector:
+
+    >>> A = jnp.eye(2)
+    >>> v = QuantityMatrix(jnp.array([2.0, 3.0]), unit=("m / s", "m / s"))
+    >>> w = qnp.matmul(A, v)
+    >>> w.unit.to_string()
+    '(m / s, m / s)'
+    >>> w.value
+    Array([2., 3.], dtype=float32)
+
+    """
+    if lhs.ndim == 1:
+        n = lhs.shape[0]
+        lhs_qm = QuantityMatrix(lhs, unit=UnitsMatrix(tuple(_DMLS for _ in range(n))))
+    else:
+        nr, nc = lhs.shape[-2], lhs.shape[-1]
+        lhs_qm = QuantityMatrix(
+            lhs,
+            unit=UnitsMatrix(tuple(tuple(_DMLS for _ in range(nc)) for _ in range(nr))),
+        )
+    return dot_general_qm_qm(
+        lhs_qm,
+        rhs,
+        dimension_numbers=dimension_numbers,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+        **kw,
+    )
+
+
+# ── transpose ────────────────────────────────────────────────────────────
+
+
+@quax.register(lax.transpose_p)
+def transpose_qm(
+    x: QuantityMatrix, /, *, permutation: tuple[int, ...]
+) -> QuantityMatrix:
+    """Transpose a ``QuantityMatrix``, swapping only the last two (matrix) axes.
+
+    Leading batch dimensions must be preserved unchanged.  Only permutations
+    that swap the last two axes while keeping all batch axes in place are
+    supported, because the unit structure is purely 2-D and cannot represent
+    arbitrary axis re-orderings.
+
+    >>> import jax.numpy as jnp
+    >>> import quaxed.numpy as qnp
+    >>> from unxts.linalg import QuantityMatrix
+
+    2-D (no batch):
+
+    >>> a = QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=(("m", "s"), ("kg", "rad"))
+    ... )
+    >>> aT = qnp.matrix_transpose(a)
+    >>> aT.value
+    Array([[1., 3.],
+           [2., 4.]], dtype=float32)
+    >>> aT.unit.to_string()
+    '((m, kg), (s, rad))'
+
+    Batched ``(B, N, M)`` — batch axis is preserved:
+
+    >>> import jax
+    >>> b = QuantityMatrix(jnp.ones((3, 2, 2)), unit=(("m", "s"), ("kg", "rad")))
+    >>> bT = qnp.matrix_transpose(b)
+    >>> bT.shape
+    (3, 2, 2)
+
+    """
+    ndim_val = len(permutation)  # full ndim of the value array (includes batch dims)
+    if ndim_val < 2:
+        msg = f"transpose_qm requires ndim >= 2, got ndim={ndim_val}"
+        raise NotImplementedError(msg)
+    # Validate: batch axes must be unchanged, last two must be swapped.
+    expected = (*range(ndim_val - 2), ndim_val - 1, ndim_val - 2)
+    if tuple(permutation) != expected:
+        msg = (
+            f"transpose_qm only supports matrix transpose of the last two axes "
+            f"(expected permutation {expected}), got {tuple(permutation)}"
+        )
+        raise NotImplementedError(msg)
+    transposed_value = lax.transpose(x.value, permutation)
+    return QuantityMatrix(value=transposed_value, unit=x.unit.T)
+
+
+# ── gather ───────────────────────────────────────────────────────────────
+
+
+def _jit_fallback_uniform_unit(units: UnitsMatrix, out_size: int) -> UnitsMatrix:
+    """Return a 1-D ``UnitsMatrix`` of length *out_size* if all units are equal.
+
+    Used as a JIT-mode fallback inside ``gather_qm`` when the concrete gather
+    indices are not available.  Raises ``ValueError`` for heterogeneous inputs.
+    """
+    all_units = jtu.tree_leaves(units.to_tuple())
+    first = all_units[0]
+    if any(u_i != first for u_i in all_units[1:]):
+        msg = (
+            "QuantityMatrix gather (e.g. jnp.diag) under jit requires all units "
+            "to be equal when indices cannot be concretized. "
+            "Call eagerly (outside jit) for heterogeneous-unit QuantityMatrix."
+        )
+        raise ValueError(msg)
+    return UnitsMatrix(np.full((out_size,), first, dtype=object))
+
+
+@quax.register(lax.gather_p)
+def gather_qm(
+    x: QuantityMatrix,
+    start_indices: jax.Array,
+    /,
+    *,
+    dimension_numbers: lax.GatherDimensionNumbers,
+    slice_sizes: tuple[int, ...],
+    indices_are_sorted: bool = False,
+    mode: Any = None,
+    fill_value: Any = None,
+    unique_indices: bool = False,
+    **kwargs: Any,
+) -> QuantityMatrix:
+    """Handle element-selection gathers (e.g. ``jnp.diag``) for ``QuantityMatrix``.
+
+    Supports only *element-selection* gathers where every input dimension is
+    collapsed (``offset_dims == ()`` and all ``slice_sizes == 1``).  This
+    covers ``jnp.diag``, ``jnp.diagonal``, and integer-array fancy indexing on
+    ``QuantityMatrix`` objects.
+
+    Unit extraction:
+
+    ``QuantityMatrix.unit`` is declared ``static=True`` and is therefore always
+    a concrete Python object, even inside ``jax.jit``.  The *indices*, however,
+    are traced under JIT and cannot be read concretely.  Because JAX's
+    ``jnp.diag`` uses ``platform_dependent`` internally, quax always traces
+    both branches via ``make_jaxpr``, so the JIT fallback path is taken for
+    unit resolution.  Consequently, all units in the input must be equal;
+    heterogeneous-unit inputs raise ``ValueError``.
+
+    >>> import jax.numpy as jnp
+    >>> from unxts.linalg import QuantityMatrix
+
+    Diagonal of a 3x3 dimensionless matrix:
+
+    >>> A = QuantityMatrix(
+    ...     jnp.diag(jnp.array([1.0, 4.0, 9.0])),
+    ...     unit=(("", "", ""), ("", "", ""), ("", "", "")),
+    ... )
+    >>> d = A.diag()
+    >>> d.unit.shape
+    (3,)
+    >>> d.unit.ndim
+    1
+    >>> d.value
+    Array([1., 4., 9.], dtype=float32)
+
+    ```{note}
+    ``jnp.diag`` uses JAX's ``platform_dependent`` internally, which causes
+    quax to trace both branches via ``make_jaxpr`` even in eager mode.  This
+    means the JIT fallback path is always taken for the unit computation, so
+    **heterogeneous-unit matrices are not supported** with ``qnp.diag``.
+    All units in the input must be equal; otherwise a ``ValueError`` is raised.
+    ```
+    """
+    result_value = lax.gather(
+        x.value,
+        start_indices,
+        dimension_numbers,
+        slice_sizes,
+        indices_are_sorted=indices_are_sorted,
+        mode=mode,
+        fill_value=fill_value,
+        unique_indices=unique_indices,
+    )
+
+    # Only element-selection gathers are supported: all input dimensions must
+    # be collapsed and every slice_size must be 1.
+    n_input_dims = x.value.ndim
+    normalized_collapsed = {
+        d % n_input_dims for d in dimension_numbers.collapsed_slice_dims
+    }
+    is_element_selection = (
+        dimension_numbers.offset_dims == ()
+        and normalized_collapsed == set(range(n_input_dims))
+        and all(s == 1 for s in slice_sizes)
+    )
+    if not is_element_selection:
+        msg = (
+            "QuantityMatrix: only element-selection gathers (all input dims "
+            "collapsed, all slice_sizes == 1) are supported. "
+            f"Got offset_dims={dimension_numbers.offset_dims}, "
+            f"collapsed_slice_dims={dimension_numbers.collapsed_slice_dims}, "
+            f"slice_sizes={slice_sizes}."
+        )
+        raise NotImplementedError(msg)
+
+    # Number of output elements — start_indices.shape is always concrete in JAX.
+    out_size = start_indices.shape[0]
+
+    if isinstance(start_indices, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
+        # JIT path: indices are traced — fall back to uniform-unit check.
+        out_unit = _jit_fallback_uniform_unit(x.unit, out_size)
+    else:
+        # Eager path: indices are concrete — look up units directly.
+        idx_np = np.asarray(start_indices)
+        if x.unit.ndim == 1:
+            out_unit = UnitsMatrix(x.unit._units[idx_np[:, 0]])
+        else:  # x.unit.ndim == 2
+            out_unit = UnitsMatrix(x.unit._units[idx_np[:, 0], idx_np[:, 1]])
+
+    return QuantityMatrix(value=result_value, unit=out_unit)
+
+
+# ── reduce_sum ───────────────────────────────────────────────────────────
+
+
+@quax.register(lax.reduce_sum_p)
+def reduce_sum_p_qm(
+    operand: QuantityMatrix, /, *, axes: Any, **kwargs: Any
+) -> QuantityMatrix:
+    """Handle ``lax.reduce_sum`` for ``QuantityMatrix``.
+
+    ``jnp.diag`` on a square 2-D matrix uses ``platform_dependent`` which traces
+    *both* the default (gather-based) and Mosaic implementation.  The Mosaic
+    path computes ``reduce(mul(eye, A), axis=0)`` — JAX's JIT optimises
+    ``lax.reduce(x, 0, lax.add, (0,))`` to the simpler ``reduce_sum_p``
+    primitive.  This handler ensures the output carries the correct 1-D unit
+    structure so that both branches produce the *same* pytree — required by
+    ``platform_dependent`` / ``lax.switch``.
+
+    Unit reduction rule:
+
+    When reducing a 2-D ``QuantityMatrix`` along ``axes=(0,)`` (rows): the
+    output unit for column *j* is taken from ``operand.unit[0, j]`` (the first
+    row).  All elements being summed along a column must be unit-compatible for
+    the sum to be physically meaningful.
+
+    Analogously for ``axes=(1,)`` (column reduction), the output unit for row
+    *i* is ``operand.unit[i, 0]``.
+
+    >>> import jax.numpy as jnp
+    >>> from unxts.linalg import QuantityMatrix
+
+    ``QuantityMatrix.diag()`` on a 3x3 uniform-unit matrix:
+
+    >>> A = QuantityMatrix(
+    ...     jnp.diag(jnp.array([1.0, 4.0, 9.0])),
+    ...     unit=(("m", "m", "m"), ("m", "m", "m"), ("m", "m", "m")),
+    ... )
+    >>> d = A.diag()
+    >>> d.unit.shape
+    (3,)
+    >>> d.unit.ndim
+    1
+
+    """
+    result_value = lax.reduce_sum_p.bind(operand.value, axes=axes, **kwargs)
+
+    # Reduce the unit structure by dropping the summed axes.
+    axset = set(axes)
+    if operand.ndim == 2:
+        if axset == {0}:
+            # Row reduction → 1-D output; unit = first row's units.
+            out_unit = UnitsMatrix(operand.unit._units[0])
+        elif axset == {1}:
+            # Column reduction → 1-D output; unit = first column's units.
+            out_unit = UnitsMatrix(operand.unit._units[:, 0])
+        else:
+            msg = f"reduce_sum_p_qm: unsupported axes={axes} for 2-D QuantityMatrix."
+            raise NotImplementedError(msg)
+    else:
+        msg = f"reduce_sum_p_qm: only 2-D QuantityMatrix is supported, got ndim={operand.ndim}."
+        raise NotImplementedError(msg)
+
+    return QuantityMatrix(value=result_value, unit=out_unit)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -836,8 +836,10 @@ def transpose_qm(
 # ── gather ───────────────────────────────────────────────────────────────
 
 
-def _jit_fallback_uniform_unit(units: UnitsMatrix, out_size: int) -> UnitsMatrix:
-    """Return a 1-D ``UnitsMatrix`` of length *out_size* if all units are equal.
+def _jit_fallback_uniform_unit(
+    units: UnitsMatrix, out_shape: tuple[int, ...]
+) -> UnitsMatrix:
+    """Return a ``UnitsMatrix`` of shape *out_shape* if all units are equal.
 
     Used as a JIT-mode fallback inside ``gather_qm`` when the concrete gather
     indices are not available.  Raises ``ValueError`` for heterogeneous inputs.
@@ -851,7 +853,7 @@ def _jit_fallback_uniform_unit(units: UnitsMatrix, out_size: int) -> UnitsMatrix
             "Call eagerly (outside jit) for heterogeneous-unit QuantityMatrix."
         )
         raise ValueError(msg)
-    return UnitsMatrix(np.full((out_size,), first, dtype=object))
+    return UnitsMatrix(np.full(out_shape, first, dtype=object))
 
 
 @quax.register(lax.gather_p)
@@ -942,19 +944,24 @@ def gather_qm(
         )
         raise NotImplementedError(msg)
 
-    # Number of output elements — start_indices.shape is always concrete in JAX.
-    out_size = start_indices.shape[0]
+    # Output index-batch shape. For an element-selection gather JAX packs the
+    # indices as ``start_indices.shape == (*index_shape, index_vector_dim)``, so
+    # the output (and its unit structure) has shape ``index_shape``. This holds
+    # for 1-D index arrays (``index_shape`` 1-D, e.g. jnp.diag) *and* for
+    # multi-dimensional advanced indexing (``index_shape`` 2-D+). The last axis
+    # is the index vector, indexed via ``idx_np[..., k]``.
+    out_shape = start_indices.shape[:-1]
 
     if isinstance(start_indices, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
         # JIT path: indices are traced — fall back to uniform-unit check.
-        out_unit = _jit_fallback_uniform_unit(x.unit, out_size)
+        out_unit = _jit_fallback_uniform_unit(x.unit, out_shape)
     else:
         # Eager path: indices are concrete — look up units directly.
         idx_np = np.asarray(start_indices)
         if x.unit.ndim == 1:
-            out_unit = UnitsMatrix(x.unit._units[idx_np[:, 0]])
+            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0]])
         else:  # x.unit.ndim == 2
-            out_unit = UnitsMatrix(x.unit._units[idx_np[:, 0], idx_np[:, 1]])
+            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0], idx_np[..., 1]])
 
     return QuantityMatrix(value=result_value, unit=out_unit)
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -251,9 +251,14 @@ def _dot_general_1d_1d(
     # Reference unit: lhs.unit[0] * rhs.unit[0]
     ref_unit = lhs.unit[0] * rhs.unit[0]
 
-    # Compute scale factors
+    # Compute scale factors. ``uconvert_value`` returns Python floats, so a bare
+    # ``jnp.array`` is float64 and would silently upcast a float32 contraction
+    # under jax_enable_x64=True. Cast to ``result_type(values, 1.0)``: the weak
+    # float keeps the scale *at least* floating (so integer operands still get a
+    # correct fractional conversion) without widening float32 → float64.
     scales = jnp.array(
-        [u.uconvert_value(ref_unit, lhs.unit[i] * rhs.unit[i], 1.0) for i in range(n)]
+        [u.uconvert_value(ref_unit, lhs.unit[i] * rhs.unit[i], 1.0) for i in range(n)],
+        dtype=jnp.result_type(lhs.value, rhs.value, 1.0),
     )
 
     # Compute dot product with rescaling
@@ -316,12 +321,13 @@ def _dot_general_2d_1d(
 
     # 2) Precompute scale factors: scale[i, j] converts
     #    lhs.unit[i][j]*rhs.unit[j] → ref[i]
-    scale_2d = jnp.array(
+    scale_2d = jnp.asarray(
         vec_uconvert_value(
             out_unit._units[:, None],  # (N, 1) — broadcast over K
             np.multiply(lhs.unit._units, rhs.unit._units[None, :]),  # (N, K)
             1.0,
-        )
+        ),
+        dtype=jnp.result_type(lhs.value, rhs.value, 1.0),
     )
 
     # 3) Vectorised contraction:
@@ -377,12 +383,13 @@ def _dot_general_1d_2d(
 
     # 2) Precompute scale factors: scale[j, k] converts
     #    lhs.unit[j]*rhs.unit[j][k] → ref[k]
-    scale_2d = jnp.array(
+    scale_2d = jnp.asarray(
         vec_uconvert_value(
             out_unit._units[None, :],  # (1, M) — broadcast over K
             np.multiply(lhs.unit._units[:, None], rhs.unit._units),  # (K, M)
             1.0,
-        )
+        ),
+        dtype=jnp.result_type(lhs.value, rhs.value, 1.0),
     )
 
     # 3) Vectorised contraction:
@@ -453,12 +460,13 @@ def _dot_general_2d_2d(
     #    astropy keeps rejecting affine product conversions.  If that
     #    ever changes, those tests will fail, alerting us that this
     #    assumption needs revisiting.
-    scale_3d = jnp.array(
+    scale_3d = jnp.asarray(
         vec_uconvert_value(
             out_unit[:, None, :],  # (N, 1, M)
             np.multiply(lhs.unit._units[:, :, None], rhs.unit._units[None, :, :]),
             1.0,  # ꜛ (N, K, M)
-        )
+        ),
+        dtype=jnp.result_type(lhs.value, rhs.value, 1.0),
     )
 
     # 3) Vectorised contraction — no Python loop, no accumulator.
@@ -957,6 +965,21 @@ def gather_qm(
     # multi-dimensional advanced indexing (``index_shape`` 2-D+). The last axis
     # is the index vector, indexed via ``idx_np[..., k]``.
     out_shape = start_indices.shape[:-1]
+
+    # A scalar-output gather (``index_shape == ()``) selects a single element,
+    # which carries a single unit. ``UnitsMatrix`` only represents 1-D/2-D unit
+    # structures, so return a plain scalar ``Quantity`` instead.
+    if out_shape == ():
+        if isinstance(start_indices, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
+            scalar_unit = _jit_fallback_uniform_unit(x.unit, (1,))._units[0]
+        else:
+            idx_np = np.asarray(start_indices)
+            scalar_unit = (
+                x.unit._units[idx_np[0]]
+                if x.unit.ndim == 1
+                else x.unit._units[idx_np[0], idx_np[1]]
+            )
+        return u.Q(result_value, scalar_unit)
 
     if isinstance(start_indices, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
         # JIT path: indices are traced — fall back to uniform-unit check.

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -818,6 +818,12 @@ def transpose_qm(
 
     """
     ndim_val = len(permutation)  # full ndim of the value array (includes batch dims)
+    # An identity permutation is a no-op that preserves the unit structure — most
+    # relevant for a 1-D vector, whose only permutation is (0,). JAX normally
+    # elides such transposes before they bind ``transpose_p``, but handle them
+    # directly so correctness does not depend on that elision.
+    if tuple(permutation) == tuple(range(ndim_val)):
+        return x
     if ndim_val < 2:
         msg = f"transpose_qm requires ndim >= 2, got ndim={ndim_val}"
         raise NotImplementedError(msg)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -21,7 +21,11 @@ import quax
 from jax import lax
 
 import unxt as u
-from ._quantity_matrix import QuantityMatrix, _convert_value
+from ._quantity_matrix import (
+    QuantityMatrix,
+    _convert_value,
+    _convert_value_matrix,
+)
 from ._units_matrix import UnitsMatrix
 from unxt.quantity import AllowValue
 
@@ -976,11 +980,15 @@ def reduce_sum_p_qm(
 
     When reducing a 2-D ``QuantityMatrix`` along ``axes=(0,)`` (rows): the
     output unit for column *j* is taken from ``operand.unit[0, j]`` (the first
-    row).  All elements being summed along a column must be unit-compatible for
-    the sum to be physically meaningful.
+    row).  The other elements in each column are first *converted* to that
+    reference unit before summing, so a column of unit-compatible-but-different
+    units (e.g. ``m`` and ``km``) sums correctly rather than being silently
+    relabelled.  Summing along a column of *incompatible* units raises (via
+    ``uconvert_value``), as it must.
 
     Analogously for ``axes=(1,)`` (column reduction), the output unit for row
-    *i* is ``operand.unit[i, 0]``.
+    *i* is ``operand.unit[i, 0]`` and each row is converted to it before
+    summing.
 
     >>> import jax.numpy as jnp
     >>> from unxts.linalg import QuantityMatrix
@@ -998,8 +1006,6 @@ def reduce_sum_p_qm(
     1
 
     """
-    result_value = lax.reduce_sum_p.bind(operand.value, axes=axes, **kwargs)
-
     # `axes` index the *value* array, which carries `n_batch` leading batch
     # axes that the unit structure does not. Map them to the logical axes.
     n_batch = operand.value.ndim - operand.unit.ndim
@@ -1008,14 +1014,24 @@ def reduce_sum_p_qm(
 
     # Reducing only batch axes leaves the per-element unit structure unchanged.
     if not logical_axes:
+        result_value = lax.reduce_sum_p.bind(operand.value, axes=axes, **kwargs)
         return QuantityMatrix(value=result_value, unit=operand.unit)
 
+    units = operand.unit._units
     if operand.unit.ndim == 2 and logical_axes == {0}:
-        # Row reduction → unit = first row's units (columns must be compatible).
-        out_unit = UnitsMatrix(operand.unit._units[0])
+        # Row reduction → unit = first row's units. Convert every row to that
+        # reference row before summing so compatible-but-different units add up.
+        out_unit = UnitsMatrix(units[0])
+        target = tuple(tuple(units[0]) for _ in range(units.shape[0]))
+        value = _convert_value_matrix(operand.value, units, target)
     elif operand.unit.ndim == 2 and logical_axes == {1}:
-        # Column reduction → unit = first column's units.
-        out_unit = UnitsMatrix(operand.unit._units[:, 0])
+        # Column reduction → unit = first column's units; convert each column.
+        out_unit = UnitsMatrix(units[:, 0])
+        target = tuple(
+            tuple(units[i, 0] for _ in range(units.shape[1]))
+            for i in range(units.shape[0])
+        )
+        value = _convert_value_matrix(operand.value, units, target)
     else:
         msg = (
             f"reduce_sum_p_qm: unsupported reduction over logical axes "
@@ -1024,4 +1040,5 @@ def reduce_sum_p_qm(
         )
         raise NotImplementedError(msg)
 
+    result_value = lax.reduce_sum_p.bind(value, axes=axes, **kwargs)
     return QuantityMatrix(value=result_value, unit=out_unit)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -326,8 +326,10 @@ def dot_general_qm_qm(
     - 1D @ 1D → scalar (vector dot product)
     - 2D @ 2D → 2D (matrix-matrix multiply)
 
-    For the standard matmul contraction: contracting_dims = ((-1,), (-2,)),
-    with no batch dims (batch is handled by leading dims in QuantityMatrix).
+    For the standard matmul contraction: contracting_dims = ((-1,), (-2,)).
+    Leading *batch* axes on the value arrays are supported: ``jnp.matmul`` /
+    ``jnp.dot`` emit them as leading batch dimensions, which the
+    ``_dot_general_*`` helpers broadcast over via ``...``.
 
     >>> import jax.numpy as jnp
     >>> import quaxed.numpy as qnp
@@ -362,10 +364,17 @@ def dot_general_qm_qm(
            [3.e+00, 4.e+03]], dtype=float32)
 
     """
-    # For now, we only handle the standard matmul/dot contraction
+    # We handle the standard (optionally batched) matmul/dot contraction only.
+    # Batch dims, if present, must be the *leading* axes on both operands — this
+    # is exactly what jnp.matmul/jnp.dot emit for QuantityMatrix values that
+    # carry leading batch dimensions, and what the `_dot_general_*` helpers
+    # broadcast over via ``...``. Anything else is not a plain matmul/dot.
     (contract, batch) = dimension_numbers
+    lhs_batch, rhs_batch = batch
     assert len(contract[0]) == 1 and len(contract[1]) == 1  # noqa: PT018, S101
-    assert len(batch[0]) == 0 and len(batch[1]) == 0  # noqa: PT018, S101
+    assert lhs_batch == tuple(range(len(lhs_batch)))  # noqa: S101
+    assert rhs_batch == tuple(range(len(rhs_batch)))  # noqa: S101
+    assert len(lhs_batch) == len(rhs_batch)  # noqa: S101
 
     # Delegate based on dimensionality
     if lhs.ndim == 1 and rhs.ndim == 1:

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -516,11 +516,20 @@ def _wrap_operand(
     if logical_ndim == 1:
         n = value.shape[-1]
         unit = UnitsMatrix(tuple(element_unit for _ in range(n)))
-    else:  # matrix (logical_ndim == 2)
+    elif logical_ndim == 2:
         nr, nc = value.shape[-2], value.shape[-1]
         unit = UnitsMatrix(
             tuple(tuple(element_unit for _ in range(nc)) for _ in range(nr))
         )
+    else:
+        # Only vector/matrix operands are supported; fail here with a clear
+        # message rather than an IndexError on value.shape[-2] below.
+        msg = (
+            "QuantityMatrix dot_general only supports vector (1-D) or matrix "
+            f"(2-D) operands; got logical ndim {logical_ndim} for a value of "
+            f"shape {value.shape} with {len(batch_axes)} batch axes."
+        )
+        raise NotImplementedError(msg)
     return QuantityMatrix(value, unit=unit)
 
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -126,6 +126,19 @@ def sub_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
 # ── dot_general helpers ───────────────────────────────────────────────────
 
 
+def _check_contract(lhs_dim: int, rhs_dim: int, /) -> None:
+    """Validate that the contraction dimensions match.
+
+    An explicit check (not ``assert``, which ``python -O`` strips) so a shape
+    mismatch fails deterministically with a clear message.
+    """
+    if lhs_dim != rhs_dim:
+        msg = (
+            f"QuantityMatrix dot_general contraction mismatch: {lhs_dim} != {rhs_dim}."
+        )
+        raise ValueError(msg)
+
+
 def _dot_general_1d_1d(
     lhs: QuantityMatrix,
     rhs: QuantityMatrix,
@@ -143,7 +156,7 @@ def _dot_general_1d_1d(
     All terms must be unit-compatible. We convert to the unit of the first term.
     """
     n = lhs.shape[-1]
-    assert n == rhs.shape[-1]  # noqa: S101
+    _check_contract(n, rhs.shape[-1])
 
     # Reference unit: lhs.unit[0] * rhs.unit[0]
     ref_unit = lhs.unit[0] * rhs.unit[0]
@@ -206,7 +219,7 @@ def _dot_general_2d_1d(
     '(m s, m s)'
 
     """
-    assert rhs.shape[-1] == lhs.shape[-1]  # noqa: S101
+    _check_contract(lhs.shape[-1], rhs.shape[-1])
 
     # 1) Output units: ref[i] = lhs.unit[i][0] * rhs.unit[0]
     out_unit = UnitsMatrix(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
@@ -267,7 +280,7 @@ def _dot_general_1d_2d(
     '(m s, km s)'
 
     """
-    assert lhs.shape[-1] == rhs.shape[-2]  # noqa: S101
+    _check_contract(lhs.shape[-1], rhs.shape[-2])
 
     # 1) Output units: ref[k] = lhs.unit[0] * rhs.unit[0][k]
     out_unit = UnitsMatrix(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
@@ -327,7 +340,7 @@ def _dot_general_2d_2d(
        equivalently with a loop + accumulate.
     """
     # Check contraction axis
-    assert lhs.shape[-1] == rhs.shape[-2]  # noqa: S101
+    _check_contract(lhs.shape[-1], rhs.shape[-2])
 
     # 1) Compute output units: ref[i][k] = lhs.unit[i][0] * rhs.unit[0][k]
     out_unit = np.multiply(lhs.unit._units[:, 0:1], rhs.unit._units[0:1, :])

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -1000,20 +1000,28 @@ def reduce_sum_p_qm(
     """
     result_value = lax.reduce_sum_p.bind(operand.value, axes=axes, **kwargs)
 
-    # Reduce the unit structure by dropping the summed axes.
-    axset = set(axes)
-    if operand.ndim == 2:
-        if axset == {0}:
-            # Row reduction → 1-D output; unit = first row's units.
-            out_unit = UnitsMatrix(operand.unit._units[0])
-        elif axset == {1}:
-            # Column reduction → 1-D output; unit = first column's units.
-            out_unit = UnitsMatrix(operand.unit._units[:, 0])
-        else:
-            msg = f"reduce_sum_p_qm: unsupported axes={axes} for 2-D QuantityMatrix."
-            raise NotImplementedError(msg)
+    # `axes` index the *value* array, which carries `n_batch` leading batch
+    # axes that the unit structure does not. Map them to the logical axes.
+    n_batch = operand.value.ndim - operand.unit.ndim
+    axset = {a % operand.value.ndim for a in axes}
+    logical_axes = frozenset(a - n_batch for a in axset if a >= n_batch)
+
+    # Reducing only batch axes leaves the per-element unit structure unchanged.
+    if not logical_axes:
+        return QuantityMatrix(value=result_value, unit=operand.unit)
+
+    if operand.unit.ndim == 2 and logical_axes == {0}:
+        # Row reduction → unit = first row's units (columns must be compatible).
+        out_unit = UnitsMatrix(operand.unit._units[0])
+    elif operand.unit.ndim == 2 and logical_axes == {1}:
+        # Column reduction → unit = first column's units.
+        out_unit = UnitsMatrix(operand.unit._units[:, 0])
     else:
-        msg = f"reduce_sum_p_qm: only 2-D QuantityMatrix is supported, got ndim={operand.ndim}."
+        msg = (
+            f"reduce_sum_p_qm: unsupported reduction over logical axes "
+            f"{sorted(logical_axes)} of a {operand.unit.ndim}-D QuantityMatrix "
+            f"(axes={axes}, n_batch={n_batch})."
+        )
         raise NotImplementedError(msg)
 
     return QuantityMatrix(value=result_value, unit=out_unit)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -433,17 +433,33 @@ def dot_general_qm_qm(
            [3.e+00, 4.e+03]], dtype=float32)
 
     """
-    # We handle the standard (optionally batched) matmul/dot contraction only.
-    # Batch dims, if present, must be the *leading* axes on both operands — this
-    # is exactly what jnp.matmul/jnp.dot emit for QuantityMatrix values that
-    # carry leading batch dimensions, and what the `_dot_general_*` helpers
-    # broadcast over via ``...``. Anything else is not a plain matmul/dot.
-    (contract, batch) = dimension_numbers
-    lhs_batch, rhs_batch = batch
-    assert len(contract[0]) == 1 and len(contract[1]) == 1  # noqa: PT018, S101
-    assert lhs_batch == tuple(range(len(lhs_batch)))  # noqa: S101
-    assert rhs_batch == tuple(range(len(rhs_batch)))  # noqa: S101
-    assert len(lhs_batch) == len(rhs_batch)  # noqa: S101
+    # The `_dot_general_*` helpers ignore `dimension_numbers` and assume the
+    # standard (optionally batched) matmul/matvec/vecmat/vecdot contraction:
+    # lhs contracts its last axis; rhs its last axis for a vector or its
+    # second-last for a matrix; batch dims are the *leading* axes on both
+    # operands. Anything else (e.g. a general einsum/tensordot) would get
+    # incorrect unit propagation, so reject it explicitly. This is a user-facing
+    # precondition, so it raises rather than `assert` (which `-O` strips).
+    (lhs_c, rhs_c), (lhs_b, rhs_b) = dimension_numbers
+    rhs_contract_expected = rhs.value.ndim - (1 if rhs.unit.ndim == 1 else 2)
+    is_standard = (
+        len(lhs_c) == 1
+        and len(rhs_c) == 1
+        and lhs_c[0] == lhs.value.ndim - 1
+        and rhs_c[0] == rhs_contract_expected
+        and lhs_b == tuple(range(len(lhs_b)))
+        and rhs_b == tuple(range(len(rhs_b)))
+        and len(lhs_b) == len(rhs_b)
+    )
+    if not is_standard:
+        msg = (
+            "QuantityMatrix supports only the standard (optionally batched) "
+            "matmul/matvec/vecmat/vecdot contraction — lhs contracts its last "
+            "axis, rhs its last (vector) or second-last (matrix) axis, with "
+            "batch dims leading. Got dimension_numbers="
+            f"{dimension_numbers!r}."
+        )
+        raise NotImplementedError(msg)
 
     # Delegate based on dimensionality
     if lhs.ndim == 1 and rhs.ndim == 1:

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -1,0 +1,378 @@
+"""Immutable, hashable unit structure for QuantityMatrix."""
+
+from typing import Any, TypeAlias, TypeVar, final
+
+import numpy as np
+import plum
+
+import unxt as u
+
+T = TypeVar("T")
+
+NestedTuple: TypeAlias = T | tuple["NestedTuple[T]", ...]
+UnitTree: TypeAlias = NestedTuple[u.AbstractUnit]
+
+
+def _normalize_unit(x: Any, /) -> u.AbstractUnit:
+    """Convert *x* to an ``AbstractUnit``; accept unit strings and AbstractUnit.
+
+    Raises ``TypeError`` for unsupported types.
+    """
+    if isinstance(x, str):
+        return u.unit(x)  # ty: ignore[invalid-return-type]
+    if isinstance(x, u.AbstractUnit):
+        return x
+    msg = f"Expected an AbstractUnit or unit string; got {type(x).__name__!r}"
+    raise TypeError(msg)
+
+
+def _build_object_array(iterable: Any, /) -> np.ndarray:  # noqa: C901
+    """Build a 1-D or 2-D numpy object array of ``AbstractUnit`` from *iterable*.
+
+    Accepts:
+
+    - A numpy object array (element-normalize and validate ndim).
+    - A plain tuple/list of units or unit strings → 1-D output.
+    - A plain tuple/list of tuples of units or unit strings → 2-D output.
+
+    Raises ``TypeError`` if a non-sequence is passed, ``ValueError`` if the
+    structure is ragged or has unsupported ndim.
+    """
+    if isinstance(iterable, np.ndarray) and iterable.dtype == object:
+        if iterable.ndim not in (1, 2):
+            msg = f"UnitsMatrix only supports 1D or 2D; got ndim={iterable.ndim}"
+            raise ValueError(msg)
+        flat = [_normalize_unit(v) for v in iterable.flat]
+        data: np.ndarray = np.empty(iterable.shape, dtype=object)
+        data.flat[:] = flat
+        return data
+
+    # Sequence path: tuple, list, or any iterable
+    items = list(iterable)  # raises TypeError if not iterable
+
+    if not items:
+        raise ValueError("UnitsMatrix requires at least one element")
+
+    first = items[0]
+    if isinstance(first, (tuple, list)):
+        # 2-D: sequence of rows — validate and fill in one pass
+        n, m = len(items), len(first)
+        data = np.empty((n, m), dtype=object)
+        for i, row in enumerate(items):
+            if not isinstance(row, (tuple, list)) or len(row) != m:
+                raise ValueError("ragged structure")
+            for j, v in enumerate(row):
+                if isinstance(v, (tuple, list)):
+                    raise ValueError("ragged structure")
+                data[i, j] = _normalize_unit(v)
+        return data
+
+    # 1-D: sequence of units / unit strings
+    n = len(items)
+    data = np.empty(n, dtype=object)
+    for i, v in enumerate(items):
+        if isinstance(v, (tuple, list)):  # Mixed leaf/nested → ragged
+            raise ValueError("ragged structure")
+        data[i] = _normalize_unit(v)
+    return data
+
+
+@final
+class UnitsMatrix:
+    """Immutable, hashable unit structure for `QuantityMatrix`.
+
+    `UnitsMatrix` wraps a numpy object array (``dtype=object``) of
+    `~unxt.AbstractUnit` elements. Only 1-D and 2-D structures are accepted.
+
+    The class supports tuple-style indexing, iteration, `to_tuple()`, and
+    `to_string()`. It is **not** a subclass of `astropy.units.StructuredUnit`.
+
+    Hashability is achieved via ``hash(self.to_tuple())``, so the underlying
+    ``AbstractUnit`` objects must themselves be hashable (they are).
+
+    For 1D: ``UnitsMatrix(("m", "s", "kg"))``
+    For 2D: ``UnitsMatrix((("m", "s"), ("kg", "rad")))``
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> from unxts.linalg import UnitsMatrix
+
+    1D case:
+
+    >>> units_1d = UnitsMatrix(("m", "s", "kg"))
+    >>> units_1d.shape
+    (3,)
+    >>> units_1d[0]
+    Unit("m")
+    >>> units_1d.to_string()
+    '(m, s, kg)'
+
+    2D case:
+
+    >>> units_2d = UnitsMatrix((("m", "s"), ("kg", "rad")))
+    >>> units_2d.shape
+    (2, 2)
+    >>> units_2d[0, 1]
+    Unit("s")
+    >>> units_2d.to_string()
+    '((m, s), (kg, rad))'
+
+    """
+
+    __slots__ = ("_units",)
+
+    def __init__(self, iterable: Any, /) -> None:
+        if isinstance(iterable, UnitsMatrix):
+            # Copy from another UnitsMatrix — avoids sharing the mutable array.
+            data = iterable._units.copy()
+        else:
+            data = _build_object_array(iterable)
+        if data.ndim not in (1, 2):
+            msg = f"UnitsMatrix only supports 1D or 2D, but got ndim={data.ndim}"
+            raise ValueError(msg)
+        self._units = data
+
+    # ── Shape / structure ─────────────────────────────────────────────
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Shape of the N-D unit structure."""
+        return tuple(self._units.shape)
+
+    @property
+    def ndim(self) -> int:
+        """Number of dimensions."""
+        return int(self._units.ndim)
+
+    @property
+    def T(self) -> "UnitsMatrix":
+        """Compute the all-axis units array transpose.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+
+        >>> units = UnitsMatrix(("m", "s"))
+        >>> units.T
+        UnitsMatrix("(m, s)")
+
+        >>> units = UnitsMatrix((("m", "s"), ("kg", "rad")))
+        >>> units.T
+        UnitsMatrix("((m, kg), (s, rad))")
+
+        >>> units = UnitsMatrix((("m", "s", "kg"), ("Hz", "candela", "km")))
+        >>> units.T
+        UnitsMatrix("((m, Hz), (s, cd), (kg, km))")
+
+        """
+        return UnitsMatrix(self._units.T)
+
+    def inverse(self) -> "UnitsMatrix":
+        r"""Inverse unit structure — each unit raised to the power -1.
+
+        For a 1-D (diagonal) ``UnitsMatrix`` the inversion is done
+        entry-by-entry in *O(n)*, providing a speedup over the general 2-D
+        case.  For a 2-D ``UnitsMatrix`` with a uniform unit (all entries
+        equal) the reciprocal is computed once and broadcast in *O(1)*;
+        mixed-unit 2-D structures fall back to an element-wise *O(nm)* loop.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+
+        1-D (diagonal) case — element-wise reciprocal:
+
+        >>> UnitsMatrix(("m2", "s2")).inverse()
+        UnitsMatrix("(1 / m2, 1 / s2)")
+
+        2-D uniform-unit case:
+
+        >>> UnitsMatrix((("m2", "m2"), ("m2", "m2"))).inverse()
+        UnitsMatrix("((1 / m2, 1 / m2), (1 / m2, 1 / m2))")
+
+        2-D mixed-unit case:
+
+        >>> UnitsMatrix((("m2", "s2"), ("s2", "rad2"))).inverse()
+        UnitsMatrix("((1 / m2, 1 / s2), (1 / s2, 1 / rad2))")
+
+        """
+        inv_data = np.empty(self._units.shape, dtype=object)
+        if self._units.ndim == 1:
+            # Diagonal speedup: 1-D represents a diagonal metric's units.
+            for i in range(self._units.shape[0]):
+                inv_data[i] = self._units[i] ** (-1)
+        else:
+            # 2-D: fast path when all entries share the same unit.
+            flat = self._units.ravel()
+            first = flat[0]
+            if all(u == first for u in flat[1:]):
+                inv_unit = first ** (-1)
+                inv_data[:] = inv_unit
+            else:
+                n, m = self._units.shape
+                for i in range(n):
+                    for j in range(m):
+                        inv_data[i, j] = self._units[i, j] ** (-1)
+        return UnitsMatrix(inv_data)
+
+    # ── Serialization ─────────────────────────────────────────────────
+
+    def to_tuple(self) -> UnitTree:
+        """Convert to a nested tuple of `~unxt.AbstractUnit` objects.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+        >>> import unxt as u
+        >>> UnitsMatrix(("m", "s")).to_tuple()
+        (Unit("m"), Unit("s"))
+
+        """
+        if self._units.ndim == 1:
+            return tuple(self._units)
+        return tuple(map(tuple, self._units))
+
+    def to_string(self) -> str:
+        """Return a human-readable string representation of the unit structure.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+        >>> UnitsMatrix(("m", "s", "kg")).to_string()
+        '(m, s, kg)'
+        >>> UnitsMatrix((("m", "s"), ("kg", "rad"))).to_string()
+        '((m, s), (kg, rad))'
+
+        """
+        if self._units.ndim == 1:
+            inner = ", ".join(str(x) for x in self._units)
+            if len(self._units) == 1:
+                return f"({inner},)"
+            return f"({inner})"
+        # 2D
+        row_strs = []
+        for row in self._units:
+            inner = ", ".join(str(x) for x in row)
+            row_strs.append(f"({inner},)" if len(row) == 1 else f"({inner})")
+        if len(self._units) == 1:
+            return f"({row_strs[0]},)"
+        return f"({', '.join(row_strs)})"
+
+    # ── Python data model ─────────────────────────────────────────────
+
+    def __repr__(self) -> str:
+        return f'UnitsMatrix("{self.to_string()}")'
+
+    def __eq__(self, other: Any, /) -> bool:
+        if isinstance(other, UnitsMatrix):
+            if self._units.shape != other._units.shape:
+                return False
+            return bool(np.all(self._units == other._units))
+        if isinstance(other, (tuple, list)):
+            try:
+                return self == UnitsMatrix(other)
+            except (TypeError, ValueError):
+                return False
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self.to_tuple())
+
+    def __iter__(self) -> Any:
+        """Iterate over elements (1D) or row ``UnitsMatrix`` objects (2D).
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+        >>> list(UnitsMatrix(("m", "rad", "rad")))
+        [Unit("m"), Unit("rad"), Unit("rad")]
+
+        """
+        if self._units.ndim == 1:
+            yield from self._units
+            return
+        for row in self._units:
+            yield UnitsMatrix(row)
+
+    def __getitem__(self, index: Any, /) -> Any:
+        """Index into the UnitsMatrix to retrieve a unit or sub-structure.
+
+        >>> from unxts.linalg import UnitsMatrix
+        >>> units = UnitsMatrix((("m", "s"), ("kg", "rad")))
+
+        Indexing a single element returns a unit:
+
+        >>> units[0, 1]
+        Unit("s")
+
+        Indexing a row returns a UnitsMatrix:
+
+        >>> units[0]
+        UnitsMatrix("(m, s)")
+
+        """
+        result = self._units[index]
+        if isinstance(result, np.ndarray):
+            if result.ndim == 0:  # 0-d array -> extract the contained unit.
+                return result.item()
+            return UnitsMatrix(result)
+        return result
+
+
+@plum.dispatch
+def unit(tuple_of_units: tuple[Any, ...], /) -> UnitsMatrix:
+    """Convert a nested tuple of units into a ``UnitsMatrix``.
+
+    This allows users to specify units in a convenient nested tuple format when
+    constructing ``QuantityMatrix`` instances, and have them automatically
+    converted to the appropriate ``UnitsMatrix``.
+
+    >>> import unxt as u
+
+    1D case:
+
+    >>> u.unit(("m", "s", "kg"))
+    UnitsMatrix("(m, s, kg)")
+
+    2D case:
+
+    >>> u.unit((("m", "s"), ("kg", "rad")))
+    UnitsMatrix("((m, s), (kg, rad))")
+
+    """
+    return UnitsMatrix(tuple_of_units)
+
+
+@plum.dispatch
+def unit(arr: np.ndarray, /) -> UnitsMatrix:
+    """Convert a numpy object array of units into a ``UnitsMatrix``.
+
+    >>> import numpy as np
+    >>> import unxt as u
+    >>> from unxts.linalg import UnitsMatrix
+    >>> arr = np.array([u.unit("m"), u.unit("s")], dtype=object)
+    >>> u.unit(arr)
+    UnitsMatrix("(m, s)")
+
+    """
+    return UnitsMatrix(arr)
+
+
+@plum.dispatch
+def unit(obj: UnitsMatrix, /) -> UnitsMatrix:
+    """Identity: a UnitsMatrix is returned unchanged by the unit converter."""
+    return obj
+
+
+@plum.dispatch
+def unit_of(obj: UnitsMatrix, /) -> UnitsMatrix:
+    """Identity conversion for UnitsMatrix to itself.
+
+    >>> import unxt as u
+    >>> unit = u.unit(("m", "s", "kg"))
+    >>> u.unit_of(unit) is unit
+    True
+
+    """
+    return obj

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -47,6 +47,16 @@ def _build_object_array(iterable: Any, /) -> np.ndarray:  # noqa: C901
         data.flat[:] = flat
         return data
 
+    # A bare string is iterable but almost never intended: it would be split
+    # into per-character "units" (e.g. "ms" -> ("m", "s")). Require a single
+    # unit to be wrapped in a tuple.
+    if isinstance(iterable, str):
+        msg = (
+            f"UnitsMatrix does not accept a bare string ({iterable!r}); wrap a "
+            f"single unit in a tuple, e.g. ({iterable!r},)."
+        )
+        raise TypeError(msg)
+
     # Sequence path: tuple, list, or any iterable
     items = list(iterable)  # raises TypeError if not iterable
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -42,12 +42,18 @@ def _split_top_level(inner: str, /) -> list[str]:
             buf.append(ch)
         elif ch == ")":
             depth -= 1
+            if depth < 0:
+                msg = f"Unbalanced parentheses (unmatched ')'): {inner!r}"
+                raise ValueError(msg)
             buf.append(ch)
         elif ch == "," and depth == 0:
             parts.append("".join(buf).strip())
             buf = []
         else:
             buf.append(ch)
+    if depth != 0:
+        msg = f"Unbalanced parentheses (unmatched '('): {inner!r}"
+        raise ValueError(msg)
     tail = "".join(buf).strip()
     if tail:  # drop the empty tail from a trailing comma, e.g. "(m,)"
         parts.append(tail)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -26,6 +26,51 @@ def _normalize_unit(x: Any, /) -> u.AbstractUnit:
     raise TypeError(msg)
 
 
+def _split_top_level(inner: str, /) -> list[str]:
+    """Split *inner* on commas that are not enclosed in parentheses.
+
+    Unit strings never contain commas but may contain (balanced) parentheses
+    — e.g. ``"m / (kg s)"`` — so a depth-aware split unambiguously separates the
+    elements/rows of a structural string.
+    """
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in inner:
+        if ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth -= 1
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(ch)
+    tail = "".join(buf).strip()
+    if tail:  # drop the empty tail from a trailing comma, e.g. "(m,)"
+        parts.append(tail)
+    return parts
+
+
+def _parse_structure_string(s: str, /) -> tuple[Any, ...]:
+    """Parse a `to_string()` / `__repr__` structural string into a nested tuple.
+
+    e.g. ``"(m, s)" -> ("m", "s")`` and
+    ``"((m, s), (kg, rad))" -> (("m", "s"), ("kg", "rad"))``. A top-level part
+    that is itself parenthesized is a nested row (2-D); otherwise it is a unit
+    string (units never begin with ``"("``).
+    """
+    out: list[Any] = []
+    for part in _split_top_level(s[1:-1]):  # drop the outer parentheses
+        if part.startswith("(") and part.endswith(")"):
+            out.append(_parse_structure_string(part))
+        else:
+            out.append(part)
+    return tuple(out)
+
+
 def _build_object_array(iterable: Any, /) -> np.ndarray:  # noqa: C901
     """Build a 1-D or 2-D numpy object array of ``AbstractUnit`` from *iterable*.
 
@@ -47,13 +92,17 @@ def _build_object_array(iterable: Any, /) -> np.ndarray:  # noqa: C901
         data.flat[:] = flat
         return data
 
-    # A bare string is iterable but almost never intended: it would be split
-    # into per-character "units" (e.g. "ms" -> ("m", "s")). Require a single
-    # unit to be wrapped in a tuple.
     if isinstance(iterable, str):
+        # Accept the structural form produced by ``to_string()`` / ``__repr__``
+        # (e.g. "(m, s)"), so a repr round-trips. A *bare* unit string is
+        # rejected: it is iterable and would otherwise be split into
+        # per-character "units" (e.g. "ms" -> ("m", "s")); wrap it in a tuple.
+        stripped = iterable.strip()
+        if stripped.startswith("(") and stripped.endswith(")"):
+            return _build_object_array(_parse_structure_string(stripped))
         msg = (
-            f"UnitsMatrix does not accept a bare string ({iterable!r}); wrap a "
-            f"single unit in a tuple, e.g. ({iterable!r},)."
+            f"UnitsMatrix does not accept a bare unit string ({iterable!r}); wrap "
+            f"a single unit in a tuple, e.g. ({iterable!r},)."
         )
         raise TypeError(msg)
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -1,5 +1,6 @@
 """Immutable, hashable unit structure for QuantityMatrix."""
 
+import operator
 from typing import Any, TypeAlias, TypeVar, final
 
 import numpy as np
@@ -280,6 +281,55 @@ class UnitsMatrix:
                     for j in range(m):
                         inv_data[i, j] = self._units[i, j] ** (-1)
         return UnitsMatrix(inv_data)
+
+    # ── Element-wise arithmetic ───────────────────────────────────────
+
+    def _elementwise(self, other: Any, op: Any, /) -> "UnitsMatrix":
+        """Apply a binary unit op element-wise against a unit or a UnitsMatrix."""
+        if isinstance(other, UnitsMatrix):
+            if self.shape != other.shape:
+                msg = f"UnitsMatrix shape mismatch: {self.shape} vs {other.shape}."
+                raise ValueError(msg)
+            other_units = other._units
+        elif isinstance(other, u.AbstractUnit):
+            # Broadcast the scalar unit into an object array so the op runs
+            # element-wise on unit objects (astropy mishandles ndarray * Unit).
+            other_units = np.empty(self._units.shape, dtype=object)
+            other_units[...] = other
+        else:
+            return NotImplemented  # ty: ignore[invalid-return-type]
+        return UnitsMatrix(op(self._units, other_units))
+
+    def __mul__(self, other: Any, /) -> "UnitsMatrix":
+        """Element-wise unit product (against a unit or another UnitsMatrix).
+
+        >>> from unxts.linalg import UnitsMatrix
+        >>> import unxt as u
+        >>> UnitsMatrix(("m", "s")) * u.unit("kg")
+        UnitsMatrix("(kg m, kg s)")
+        >>> UnitsMatrix(("m", "s")) * UnitsMatrix(("s", "s"))
+        UnitsMatrix("(m s, s2)")
+
+        """
+        return self._elementwise(other, operator.mul)
+
+    def __rmul__(self, other: Any, /) -> "UnitsMatrix":
+        # Unit multiplication commutes.
+        return self._elementwise(other, operator.mul)
+
+    def __truediv__(self, other: Any, /) -> "UnitsMatrix":
+        """Element-wise unit quotient (against a unit or another UnitsMatrix).
+
+        >>> from unxts.linalg import UnitsMatrix
+        >>> import unxt as u
+        >>> UnitsMatrix(("m2", "s2")) / u.unit("s")
+        UnitsMatrix("(m2 / s, s)")
+
+        """
+        return self._elementwise(other, operator.truediv)
+
+    def __rtruediv__(self, other: Any, /) -> "UnitsMatrix":
+        return self._elementwise(other, lambda a, b: operator.truediv(b, a))
 
     # ── Serialization ─────────────────────────────────────────────────
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
@@ -1,4 +1,4 @@
-"""Shared utilities for the quantity_matrix package."""
+"""Shared utilities for the `unxts.linalg` package."""
 
 from typing import Any, TypeAlias, cast
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
@@ -1,0 +1,31 @@
+"""Shared utilities for the quantity_matrix package."""
+
+from typing import Any, TypeAlias, cast
+
+import unxt as u
+
+CDict: TypeAlias = dict[str, Any]
+_DMLS = u.unit("")
+
+PackedUnitOutput: TypeAlias = tuple[u.AbstractUnit | None, ...]
+
+
+def strict_zip(*args: Any) -> zip:
+    """Zip iterables while enforcing equal lengths."""
+    return zip(*args, strict=True)
+
+
+def cdict_units(p: CDict, keys: tuple[str, ...], /) -> PackedUnitOutput:
+    """Extract per-key units from a component dictionary.
+
+    Non-quantity entries yield `None`, so the output tuple can be used for
+    heterogeneous dictionaries containing both quantity and non-quantity data.
+
+    >>> import unxt as u
+    >>> d = {"x": u.Q(1.0, "m"), "y": 2.0, "z": u.Q(3.0, "kg")}
+    >>> cdict_units(d, ("x", "y", "z"))
+    (Unit("m"), None, Unit("kg"))
+
+    """
+    # `unit_of()` returns None for non-quantities, so this works for both cases.
+    return cast("PackedUnitOutput", tuple(u.unit_of(p[k]) for k in keys))

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
@@ -1,13 +1,19 @@
 """Shared utilities for the `unxts.linalg` package."""
 
-from typing import Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import unxt as u
+
+if TYPE_CHECKING:
+    from ._units_matrix import UnitsMatrix
 
 CDict: TypeAlias = dict[str, Any]
 _DMLS = u.unit("")
 
-PackedUnitOutput: TypeAlias = tuple[u.AbstractUnit | None, ...]
+# ``unit_of`` can return a ``UnitsMatrix`` (e.g. for a ``QuantityMatrix`` entry),
+# not just a scalar unit or ``None`` — kept as a forward reference to avoid an
+# import cycle with ``_units_matrix``.
+PackedUnitOutput: TypeAlias = tuple["u.AbstractUnit | UnitsMatrix | None", ...]
 
 
 def strict_zip(*args: Any) -> zip:

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -1,0 +1,1806 @@
+"""Tests for unxts.linalg.QuantityMatrix."""
+
+import math
+
+import astropy.units as apu
+import jax
+import jax.numpy as jnp
+import numpy as np
+import plum
+import pytest
+import quax
+from astropy.units import imperial  # registers °F
+from unxts.linalg import QuantityMatrix as QMat, UnitsMatrix
+from unxts.linalg._src import (
+    _convert_value_matrix,
+    _convert_value_vector,
+    det as qm_det,
+    inv as qm_inv,
+)
+
+import quaxed.numpy as qnp
+
+import unxt as u
+
+# ---------------------------------------------------------------------------
+# Unit shorthands (visual noise reduction)
+# ---------------------------------------------------------------------------
+
+_m = u.unit("m")
+_s = u.unit("s")
+_kg = u.unit("kg")
+_rad = u.unit("rad")
+_km = u.unit("km")
+_ms = u.unit("ms")
+_g = u.unit("g")
+_deg = u.unit("deg")
+_min = u.unit("min")
+_dimless = u.unit("")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unit_2x2():
+    """Return a simple 2x2 unit grid: m, s, kg, rad."""
+    return ((_m, _s), (_kg, _rad))
+
+
+@pytest.fixture
+def qm_2x2(unit_2x2):
+    """Return a 2x2 QuantityMatrix with values 1-4."""
+    return QMat(value=jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=unit_2x2)
+
+
+@pytest.fixture
+def unit_2x2_alt():
+    """Alternative 2x2 units convertible to unit_2x2: km, ms, g, deg."""
+    return ((_km, _ms), (_g, _deg))
+
+
+@pytest.fixture
+def unit_1d():
+    """Return a simple 1D unit tuple: m, s, kg."""
+    return (_m, _s, _kg)
+
+
+@pytest.fixture
+def qm_1d(unit_1d):
+    """Return a 1D QuantityMatrix (vector) with values 1-3."""
+    return QMat(value=jnp.array([1, 2, 3]), unit=unit_1d)
+
+
+@pytest.fixture
+def unit_1d_alt():
+    """Alternative 1D units convertible to unit_1d: km, ms, g."""
+    return (_km, _ms, _g)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """Tests for QuantityMatrix construction and basic properties."""
+
+    def test_shape(self, qm_2x2):
+        assert qm_2x2.shape == (2, 2)
+
+    def test_n_rows(self, qm_2x2):
+        assert qm_2x2.shape[-2] == 2
+
+    def test_n_cols(self, qm_2x2):
+        assert qm_2x2.shape[-1] == 2
+
+    def test_value(self, qm_2x2):
+        expected = jnp.array([[1, 2], [3, 4]])
+        assert jnp.array_equal(qm_2x2.value, expected)
+
+    def test_unit(self, qm_2x2, unit_2x2):
+        assert qm_2x2.unit == unit_2x2
+
+    def test_aval(self, qm_2x2):
+        aval = qm_2x2.aval()
+        assert aval.shape == (2, 2)
+        assert jnp.issubdtype(aval.dtype, jnp.floating)
+
+    def test_materialise_raises(self, qm_2x2):
+        with pytest.raises(RuntimeError, match="materialise"):
+            qm_2x2.materialise()
+
+    def test_batch_dims(self):
+        """Batch dimensions are supported via leading axes."""
+        qm = QMat(jnp.ones((5, 3, 2)), unit=((_m, _s), (_m, _s), (_m, _s)))
+        assert qm.shape == (5, 3, 2)
+        assert qm.shape[-2] == 3
+        assert qm.shape[-1] == 2
+
+    def test_1x1(self):
+        """Degenerate 1x1 matrix."""
+        qm = QMat(jnp.array([[42]]), unit=((_m,),))
+        assert qm.shape[-2] == 1
+        assert qm.shape[-1] == 1
+
+    def test_nonsquare(self):
+        """Non-square 2x3 matrix."""
+        qm = QMat(jnp.ones((2, 3)), unit=((_m, _s, _kg), (_m, _s, _kg)))
+        assert qm.shape[-2] == 2
+        assert qm.shape[-1] == 3
+
+    def test_unit_is_unitsmatrix(self, qm_2x2):
+        """The ``unit`` field is always a ``UnitsMatrix`` instance."""
+        assert isinstance(qm_2x2.unit, UnitsMatrix)
+
+    def test_unit_converter_from_plain_tuples(self):
+        """Plain nested tuples (of strings) are converted to ``UnitsMatrix``."""
+        qm = QMat(jnp.array([[1]]), unit=(("m",),))
+        assert isinstance(qm.unit, UnitsMatrix)
+        assert qm.unit[0, 0] == _m
+
+    def test_1d_construction(self, qm_1d, unit_1d):
+        """1D vector construction."""
+        assert qm_1d.ndim == 1
+        assert qm_1d.shape == (3,)
+        assert qm_1d.shape[-1] == 3
+        assert qm_1d.unit == unit_1d
+
+    def test_1d_value(self, qm_1d):
+        """1D vector value."""
+        expected = jnp.array([1, 2, 3])
+        assert jnp.array_equal(qm_1d.value, expected)
+
+    def test_1d_from_strings(self):
+        """1D vector from unit strings."""
+        qm = QMat(jnp.array([7, 8]), unit=("m", "s"))
+        assert isinstance(qm.unit, UnitsMatrix)
+        assert qm.unit[0] == _m
+        assert qm.unit[1] == _s
+
+    def test_1d_batch_dims(self):
+        """1D vector with batch dimensions."""
+        qm = QMat(jnp.ones((5, 3)), unit=(_m, _s, _kg))
+        assert qm.ndim == 1
+        assert qm.shape == (5, 3)
+
+    def test_ndim_property_1d(self, qm_1d):
+        """Ndim property returns 1 for vectors."""
+        assert qm_1d.ndim == 1
+
+    def test_ndim_property_2d(self, qm_2x2):
+        """Ndim property returns 2 for matrices."""
+        assert qm_2x2.ndim == 2
+
+    def test_repr(self, qm_2x2):
+        """``repr(QuantityMatrix(...))`` succeeds and contains key info."""
+        r = repr(qm_2x2)
+        assert "QuantityMatrix" in r
+        assert "((m, s), (kg, rad))" in r
+
+    def test_repr_1x1(self):
+        """Repr for a 1x1 matrix includes trailing-comma tuple syntax."""
+        qm = QMat(jnp.array([[42]]), unit=((_m,),))
+        r = repr(qm)
+        assert "QuantityMatrix" in r
+        assert "((m,),)" in r
+
+
+# ---------------------------------------------------------------------------
+# UnitsMatrix
+# ---------------------------------------------------------------------------
+
+
+class TestUnitsMatrix:
+    """Tests for the ``UnitsMatrix`` object-array-backed unit structure."""
+
+    def test_not_isinstance_structured_unit(self):
+        """UnitsMatrix is NOT a StructuredUnit — it is a standalone class."""
+        units = UnitsMatrix(((_m, _s),))
+        assert not isinstance(units, apu.StructuredUnit)
+
+    def test_repr(self):
+        """repr() identifies the type and format."""
+        units = UnitsMatrix((_m, _s, _kg))
+        assert repr(units) == 'UnitsMatrix("(m, s, kg)")'
+
+    def test_repr_2d(self):
+        """repr() for a 2D UnitsMatrix."""
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert repr(units) == 'UnitsMatrix("((m, s), (kg, rad))")'
+
+    def test_unit_from_object_array_1d(self):
+        """u.unit() accepts a 1-D numpy object array of AbstractUnit."""
+        arr = np.array([_m, _s, _kg], dtype=object)
+        result = u.unit(arr)
+        assert isinstance(result, UnitsMatrix)
+        assert result.shape == (3,)
+        assert result[0] == _m
+        assert result[2] == _kg
+
+    def test_unit_from_object_array_2d(self):
+        """u.unit() accepts a 2-D numpy object array of AbstractUnit."""
+        arr = np.array([[_m, _s], [_kg, _rad]], dtype=object)
+        result = u.unit(arr)
+        assert isinstance(result, UnitsMatrix)
+        assert result.shape == (2, 2)
+        assert result[0, 0] == _m
+        assert result[1, 1] == _rad
+
+    def test_hashable(self):
+        """UnitsMatrix is hashable (required for use as static eqx field)."""
+        units = UnitsMatrix((_m, _s, _kg))
+        h = hash(units)
+        assert isinstance(h, int)
+
+    def test_hash_stable(self):
+        """Equal UnitsMatrix objects have the same hash."""
+        a = UnitsMatrix((_m, _s, _kg))
+        b = UnitsMatrix((_m, _s, _kg))
+        assert hash(a) == hash(b)
+
+    def test_to_string_2x2(self):
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert units.to_string() == "((m, s), (kg, rad))"
+
+    def test_to_string_1x1(self):
+        units = UnitsMatrix(((_m,),))
+        assert units.to_string() == "((m,),)"
+
+    def test_to_string_1x2(self):
+        units = UnitsMatrix(((_m, _s),))
+        assert units.to_string() == "((m, s),)"
+
+    def test_to_string_2x1(self):
+        units = UnitsMatrix(((_m,), (_s,)))
+        assert units.to_string() == "((m,), (s,))"
+
+    def test_to_string_1d(self):
+        """1D units to_string."""
+        units = UnitsMatrix((_m, _s, _kg))
+        assert units.to_string() == "(m, s, kg)"
+
+    def test_to_string_1d_single(self):
+        """Single element 1D."""
+        units = UnitsMatrix((_m,))
+        assert units.to_string() == "(m,)"
+
+    def test_from_strings_2d(self):
+        """``UnitsMatrix`` accepts unit strings via the ``u.unit`` converter."""
+        units = UnitsMatrix((("m", "s"), ("kg", "rad")))
+        assert units[0, 0] == _m
+        assert units[1, 1] == _rad
+
+    def test_from_strings_1d(self):
+        """1D from strings."""
+        units = UnitsMatrix(("m", "s", "kg"))
+        assert units[0] == _m
+        assert units[2] == _kg
+
+    def test_idempotent_2d(self):
+        """Constructing from an existing ``UnitsMatrix`` returns an equal copy."""
+        orig = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        copy = UnitsMatrix(orig)
+        assert copy == orig
+        assert isinstance(copy, UnitsMatrix)
+
+    def test_idempotent_1d(self):
+        """1D idempotent."""
+        orig = UnitsMatrix((_m, _s, _kg))
+        copy = UnitsMatrix(orig)
+        assert copy == orig
+        assert isinstance(copy, UnitsMatrix)
+
+    def test_shape_1d(self):
+        """1D shape."""
+        units = UnitsMatrix((_m, _s, _kg))
+        assert units.shape == (3,)
+
+    def test_shape_2d(self):
+        """2D shape."""
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert units.shape == (2, 2)
+
+    def test_ndim_1d(self):
+        """1D ndim."""
+        units = UnitsMatrix((_m, _s))
+        assert units.ndim == 1
+
+    def test_ndim_2d(self):
+        """2D ndim."""
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert units.ndim == 2
+
+    def test_indexing_1d(self):
+        """1D indexing."""
+        units = UnitsMatrix((_m, _s, _kg))
+        assert units[0] == _m
+        assert units[1] == _s
+        assert units[2] == _kg
+
+    def test_indexing_2d_tuple(self):
+        """2D tuple indexing."""
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert units[0, 0] == _m
+        assert units[0, 1] == _s
+        assert units[1, 0] == _kg
+        assert units[1, 1] == _rad
+
+    def test_indexing_2d_single(self):
+        """2D single-index returns a row."""
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        row = units[0]
+        assert isinstance(row, UnitsMatrix)
+        assert row.shape == (2,)
+        assert row[0] == _m
+        assert row[1] == _s
+
+    def test_rejects_ragged_2d_structure(self):
+        """Nested tuples must be rectangular, not ragged."""
+        with pytest.raises(ValueError, match="ragged structure"):
+            UnitsMatrix(((_m, _s), (_kg,)))
+
+    def test_rejects_mixed_nested_and_leaf_structure(self):
+        """Mixed leaf/nested rows are rejected as ragged structures."""
+        with pytest.raises(ValueError, match="ragged structure"):
+            UnitsMatrix(((_m, _s), _kg))
+
+    def test_rejects_single_unit(self):
+        """A bare unit is not a valid matrix/vector unit structure."""
+        with pytest.raises((TypeError, ValueError)):
+            UnitsMatrix(_m)
+
+    def test_to_tuple_1d(self):
+        units = UnitsMatrix((_m, _s, _kg))
+        assert units.to_tuple() == (_m, _s, _kg)
+
+    def test_to_tuple_2d(self):
+        units = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert units.to_tuple() == ((_m, _s), (_kg, _rad))
+
+    def test_to_tuple_is_public(self):
+        """to_tuple() is the canonical round-trip — no private ._units access."""
+        units = UnitsMatrix(((_km, _deg), (_m, _rad)))
+        assert units.to_tuple() == ((_km, _deg), (_m, _rad))
+
+
+# ---------------------------------------------------------------------------
+# _convert_value_matrix / _convert_value_vector  (internal helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestConvertValueMatrix:
+    """Tests for the element-wise unit conversion helper (2D)."""
+
+    def test_noop_same_units(self, unit_2x2):
+        """If from_units == to_units no conversion happens."""
+        val = jnp.array([[7, 8], [9, 10]])
+        out = _convert_value_matrix(val, unit_2x2, unit_2x2)
+        assert jnp.array_equal(out, val)
+
+    def test_km_to_m(self):
+        """1 km → 1000 m."""
+        out = _convert_value_matrix(jnp.array([[3]]), ((_km,),), ((_m,),))
+        assert jnp.isclose(out[0, 0], 3000)
+
+    def test_mixed_conversion(self, unit_2x2, unit_2x2_alt):
+        """Convert from (km, ms, g, deg) → (m, s, kg, rad)."""
+        val = jnp.array([[1, 1000], [3000, 180]])
+        out = _convert_value_matrix(val, unit_2x2_alt, unit_2x2)
+        assert jnp.isclose(out[0, 0], 1000)  # 1 km -> 1000 m
+        assert jnp.isclose(out[0, 1], 1)  # 1000 ms -> 1 s
+        assert jnp.isclose(out[1, 0], 3)  # 3000 g -> 3 kg
+        assert jnp.isclose(out[1, 1], math.pi, atol=1e-4)  # 180 deg -> pi rad
+
+    def test_preserves_batch(self):
+        """Batch dimensions are preserved."""
+        val = jnp.array([[[2]], [[5]]])  # (2, 1, 1)
+        out = _convert_value_matrix(val, ((_km,),), ((_m,),))
+        assert out.shape == (2, 1, 1)
+        assert jnp.isclose(out[0, 0, 0], 2000)
+        assert jnp.isclose(out[1, 0, 0], 5000)
+
+
+class TestConvertValuePoint:
+    """Tests for the element-wise unit conversion helper (1D)."""
+
+    def test_noop_same_units(self, unit_1d):
+        """If from_units == to_units no conversion happens."""
+        val = jnp.array([7, 8, 9])
+        out = _convert_value_vector(val, unit_1d, unit_1d)
+        assert jnp.array_equal(out, val)
+
+    def test_km_to_m(self):
+        """1 km → 1000 m."""
+        out = _convert_value_vector(jnp.array([3]), (_km,), (_m,))
+        assert jnp.isclose(out[0], 3000)
+
+    def test_mixed_conversion(self, unit_1d, unit_1d_alt):
+        """Convert from (km, ms, g) → (m, s, kg)."""
+        val = jnp.array([1, 1000, 3000])
+        out = _convert_value_vector(val, unit_1d_alt, unit_1d)
+        assert jnp.isclose(out[0], 1000)  # 1 km -> 1000 m
+        assert jnp.isclose(out[1], 1)  # 1000 ms -> 1 s
+        assert jnp.isclose(out[2], 3)  # 3000 g -> 3 kg
+
+    def test_preserves_batch(self):
+        """Batch dimensions are preserved."""
+        val = jnp.array([[2], [5]])  # (2, 1)
+        out = _convert_value_vector(val, (_km,), (_m,))
+        assert out.shape == (2, 1)
+        assert jnp.isclose(out[0, 0], 2000)
+        assert jnp.isclose(out[1, 0], 5000)
+
+
+# ---------------------------------------------------------------------------
+# Addition  (quax lax.add_p)
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _add(a, b):
+    return a + b
+
+
+class TestAddition:
+    """Tests for QuantityMatrix + QuantityMatrix."""
+
+    def test_same_units(self, qm_2x2, unit_2x2):
+        """Simple add, same units."""
+        other = QMat(value=jnp.array([[10, 20], [30, 40]]), unit=unit_2x2)
+        result = _add(qm_2x2, other)
+        expected = jnp.array([[11, 22], [33, 44]])
+        assert jnp.allclose(result.value, expected)
+        assert result.unit == unit_2x2
+
+    def test_result_keeps_lhs_units(self, qm_2x2, unit_2x2, unit_2x2_alt):
+        """Result units come from the LHS."""
+        other = QMat(value=jnp.array([[1, 1000], [3000, 180]]), unit=unit_2x2_alt)
+        result = _add(qm_2x2, other)
+        assert result.unit == unit_2x2
+
+    def test_mixed_unit_values(self, qm_2x2, unit_2x2_alt):
+        """Values are correctly converted before addition."""
+        other = QMat(value=jnp.array([[1, 1000], [3000, 180]]), unit=unit_2x2_alt)
+        res_val = _add(qm_2x2, other).value
+        assert jnp.isclose(res_val[0, 0], 1001)  # 1 + 1000 m = 1001
+        assert jnp.isclose(res_val[0, 1], 3)  # 2 + 1.0 s = 3
+        assert jnp.isclose(res_val[1, 0], 6)  # 3 + 3.0 kg = 6
+        assert jnp.isclose(res_val[1, 1], 4 + math.pi, atol=1e-4)  # 4+pi rad≈7.14159
+
+    def test_add_zeros(self, qm_2x2, unit_2x2):
+        """Adding zeros gives original values."""
+        zeros = QMat(jnp.zeros((2, 2)), unit=unit_2x2)
+        result = _add(qm_2x2, zeros)
+        assert jnp.allclose(result.value, qm_2x2.value)
+
+    def test_commutativity_same_units(self, unit_2x2):
+        """A + b == b + a when units are the same."""
+        a = QMat(jnp.array([[1, 2], [3, 4]]), unit=unit_2x2)
+        b = QMat(jnp.array([[5, 6], [7, 8]]), unit=unit_2x2)
+        r1 = _add(a, b)
+        r2 = _add(b, a)
+        assert jnp.allclose(r1.value, r2.value)
+
+    def test_batch_addition(self, unit_2x2):
+        """Batch dimensions are supported."""
+        a = QMat(jnp.ones((3, 2, 2)), unit=unit_2x2)
+        b = QMat(2 * jnp.ones((3, 2, 2)), unit=unit_2x2)
+        result = _add(a, b)
+        assert result.shape == (3, 2, 2)
+        assert jnp.allclose(result.value, 3 * jnp.ones((3, 2, 2)))
+
+    def test_1x1(self):
+        """1x1 addition."""
+        a = QMat(jnp.array([[3]]), unit=((_m,),))
+        b = QMat(jnp.array([[7]]), unit=((_m,),))
+        result = _add(a, b)
+        assert jnp.isclose(result.value[0, 0], 10)
+
+    def test_1d_addition_same_units(self, qm_1d, unit_1d):
+        """1D vector addition, same units."""
+        other = QMat(jnp.array([10, 20, 30]), unit=unit_1d)
+        result = _add(qm_1d, other)
+        expected = jnp.array([11, 22, 33])
+        assert jnp.allclose(result.value, expected)
+        assert result.unit == unit_1d
+
+    def test_1d_addition_mixed_units(self, qm_1d, unit_1d_alt):
+        """1D vector addition with unit conversion."""
+        other = QMat(jnp.array([1.0, 1000.0, 3000.0]), unit=unit_1d_alt)
+        result = _add(qm_1d, other)
+        assert jnp.isclose(result.value[0], 1001)  # 1 + 1000 m
+        assert jnp.isclose(result.value[1], 3)  # 2 + 1.0 s
+        assert jnp.isclose(result.value[2], 6)  # 3 + 3.0 kg
+        assert result.unit == qm_1d.unit
+
+    def test_1d_batch_addition(self, unit_1d):
+        """1D batch addition."""
+        a = QMat(jnp.ones((3, 3)), unit=unit_1d)
+        b = QMat(2 * jnp.ones((3, 3)), unit=unit_1d)
+        result = _add(a, b)
+        assert result.shape == (3, 3)
+        assert jnp.allclose(result.value, 3 * jnp.ones((3, 3)))
+
+    def test_direct_operator_mixed_units(self):
+        """Direct ``+`` supports mixed-but-compatible units."""
+        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        q1 = QMat(x, (("km", "deg"), ("km", "deg")))
+        q2 = QMat(x, (("m", "rad"), ("m", "rad")))
+        result = q1 + q2
+
+        assert result.unit.to_string() == "((km, deg), (km, deg))"
+        assert jnp.isclose(result.value[0, 0], 1.001)
+        assert jnp.isclose(result.value[1, 0], 3.003)
+        assert jnp.isclose(result.value[0, 1], 2 + 2 * (180 / jnp.pi), atol=1e-8)
+        assert jnp.isclose(result.value[1, 1], 4 + 720 / jnp.pi, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Subtraction  (quax lax.sub_p)
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _sub(a, b):
+    return a - b
+
+
+class TestSubtraction:
+    """Tests for QuantityMatrix - QuantityMatrix."""
+
+    def test_same_units(self, qm_2x2, unit_2x2):
+        """Simple sub, same units."""
+        other = QMat(value=jnp.array([[10, 20], [30, 40]]), unit=unit_2x2)
+        result = _sub(other, qm_2x2)
+        expected = jnp.array([[9, 18], [27, 36]])
+        assert jnp.allclose(result.value, expected)
+        assert result.unit == unit_2x2
+
+    def test_result_keeps_lhs_units(self, qm_2x2, unit_2x2, unit_2x2_alt):
+        """Result units come from the LHS."""
+        other = QMat(value=jnp.array([[1, 1000], [3000, 180]]), unit=unit_2x2_alt)
+        result = _sub(qm_2x2, other)
+        assert result.unit == unit_2x2
+
+    def test_mixed_unit_values(self, qm_2x2, unit_2x2_alt):
+        """Values are correctly converted before subtraction."""
+        other = QMat(value=jnp.array([[1, 1000], [3000, 180]]), unit=unit_2x2_alt)
+        res_val = _sub(qm_2x2, other).value
+        assert jnp.isclose(res_val[0, 0], -999)  # 1 - 1000 m
+        assert jnp.isclose(res_val[0, 1], 1)  # 2 - 1.0 s
+        assert jnp.isclose(res_val[1, 0], 0, atol=1e-4)  # 3 - 3.0 kg
+        assert jnp.isclose(res_val[1, 1], 4 - math.pi, atol=1e-4)  # 4-pi rad
+
+    def test_sub_zeros(self, qm_2x2, unit_2x2):
+        """Subtracting zeros gives original values."""
+        zeros = QMat(jnp.zeros((2, 2)), unit=unit_2x2)
+        result = _sub(qm_2x2, zeros)
+        assert jnp.allclose(result.value, qm_2x2.value)
+
+    def test_self_subtraction(self, qm_2x2, unit_2x2):
+        """A - a == 0."""
+        result = _sub(qm_2x2, qm_2x2)
+        assert jnp.allclose(result.value, jnp.zeros((2, 2)))
+        assert result.unit == unit_2x2
+
+    def test_anticommutativity_same_units(self, unit_2x2):
+        """A - b == -(b - a) when units are the same."""
+        a = QMat(jnp.array([[1, 2], [3, 4]]), unit=unit_2x2)
+        b = QMat(jnp.array([[5, 6], [7, 8]]), unit=unit_2x2)
+        r1 = _sub(a, b)
+        r2 = _sub(b, a)
+        assert jnp.allclose(r1.value, -r2.value)
+
+    def test_batch_subtraction(self, unit_2x2):
+        """Batch dimensions are supported."""
+        a = QMat(3 * jnp.ones((3, 2, 2)), unit=unit_2x2)
+        b = QMat(jnp.ones((3, 2, 2)), unit=unit_2x2)
+        result = _sub(a, b)
+        assert result.shape == (3, 2, 2)
+        assert jnp.allclose(result.value, 2 * jnp.ones((3, 2, 2)))
+
+    def test_1x1(self):
+        """1x1 subtraction."""
+        a = QMat(jnp.array([[7]]), unit=((_m,),))
+        b = QMat(jnp.array([[3]]), unit=((_m,),))
+        result = _sub(a, b)
+        assert jnp.isclose(result.value[0, 0], 4)
+
+    def test_1d_subtraction_same_units(self, qm_1d, unit_1d):
+        """1D vector subtraction, same units."""
+        other = QMat(jnp.array([10, 20, 30]), unit=unit_1d)
+        result = _sub(other, qm_1d)
+        expected = jnp.array([9, 18, 27])
+        assert jnp.allclose(result.value, expected)
+        assert result.unit == unit_1d
+
+    def test_1d_subtraction_mixed_units(self, qm_1d, unit_1d_alt):
+        """1D vector subtraction with unit conversion."""
+        other = QMat(jnp.array([1.0, 1000.0, 3000.0]), unit=unit_1d_alt)
+        result = _sub(qm_1d, other)
+        assert jnp.isclose(result.value[0], -999)  # 1 - 1000 m
+        assert jnp.isclose(result.value[1], 1)  # 2 - 1.0 s
+        assert jnp.isclose(result.value[2], 0, atol=1e-4)  # 3 - 3.0 kg
+        assert result.unit == qm_1d.unit
+
+
+# ---------------------------------------------------------------------------
+# Dot product / matmul  (quax lax.dot_general_p)
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _matmul(a, b):
+    return a @ b
+
+
+class TestDotProduct:
+    """Tests for QuantityMatrix @ QuantityMatrix."""
+
+    def test_simple_matmul_uniform_units(self):
+        """2x2 @ 2x1 with uniform units along contraction axis."""
+        a = QMat(jnp.array([[2, 3], [4, 5]]), unit=((_m, _m), (_kg, _kg)))
+        b = QMat(jnp.array([[10], [20]]), unit=((_s,), (_s,)))
+        result = _matmul(a, b)
+        # C[0,0] = 2*10 + 3*20 = 80 in m*s
+        # C[1,0] = 4*10 + 5*20 = 140 in kg*s
+        assert jnp.isclose(result.value[0, 0], 80)
+        assert jnp.isclose(result.value[1, 0], 140)
+        assert result.unit == ((_m * _s,), (_kg * _s,))
+        assert result.shape[-2] == 2
+        assert result.shape[-1] == 1
+
+    def test_matmul_with_unit_conversion(self):
+        """Contraction axis has mixed units that need conversion."""
+        # A is 2x2 with units [[m, km], [kg, kg]]
+        # B is 2x1 with units [[s], [s]]
+        # C[0,0] = m*s + km*s -> converted to m*s (ref is j=0)
+        #        = 2*10 + (3 km = 3000 m)*20 s = 20 + 60000 = 60020
+        a = QMat(jnp.array([[2, 3], [4, 5]]), unit=((_m, _km), (_kg, _kg)))
+        b = QMat(jnp.array([[10], [20]]), unit=((_s,), (_s,)))
+        result = _matmul(a, b)
+        assert jnp.isclose(result.value[0, 0], 60020)
+        # C[1,0] = 4*10 + 5*20 = 140 (uniform kg*s, no conversion)
+        assert jnp.isclose(result.value[1, 0], 140)
+
+    def test_matmul_2x2_by_2x2(self):
+        """Square 2x2 @ 2x2 matmul."""
+        a = QMat(jnp.array([[1, 2], [3, 4]]), unit=((_m, _m), (_m, _m)))
+        b = QMat(jnp.array([[5, 6], [7, 8]]), unit=((_s, _s), (_s, _s)))
+        result = _matmul(a, b)
+        # Standard matmul: [[1*5+2*7, 1*6+2*8], [3*5+4*7, 3*6+4*8]]
+        #                = [[19, 22], [43, 50]]
+        expected = jnp.array([[19, 22], [43, 50]])
+        assert jnp.allclose(result.value, expected)
+        ms = _m * _s
+        assert result.unit == ((ms, ms), (ms, ms))
+
+    def test_matmul_identity(self):
+        """Multiply by identity matrix."""
+        a = QMat(jnp.array([[3, 7], [11, 13]]), unit=((_m, _m), (_m, _m)))
+        identity = QMat(jnp.eye(2), unit=((_dimless, _dimless), (_dimless, _dimless)))
+        result = _matmul(a, identity)
+        assert jnp.allclose(result.value, a.value)
+
+    def test_matmul_output_units(self):
+        """Output unit[i][k] = lhs.unit[i][0] * rhs.unit[0][k]."""
+        a = QMat(jnp.array([[1, 1]]), unit=((_m, _m),))
+        b = QMat(jnp.array([[2, 3], [4, 5]]), unit=((_s, _kg), (_s, _kg)))
+        result = _matmul(a, b)
+        # Output shape: 1x2
+        assert result.shape[-2] == 1
+        assert result.shape[-1] == 2
+        # Output units: row 0 from A.unit[0][0]=m, col 0 from B.unit[0][0]=s,
+        # col 1 from B.unit[0][1]=kg
+        assert result.unit[0][0] == _m * _s
+        assert result.unit[0][1] == _m * _kg
+
+    def test_matmul_1x1(self):
+        """1x1 @ 1x1 is scalar product."""
+        a = QMat(jnp.array([[3]]), unit=((_m,),))
+        b = QMat(jnp.array([[7]]), unit=((_s,),))
+        result = _matmul(a, b)
+        assert jnp.isclose(result.value[0, 0], 21)
+        assert result.unit == ((_m * _s,),)
+
+    def test_matmul_rhs_unit_conversion(self):
+        """Unit conversion needed on the RHS contraction axis."""
+        # A: 1x2, units [[m, m]]
+        # B: 2x1, units [[s], [min]]
+        # C[0,0] = m*s + m*min -> ref = m*s
+        #        = 1*1 + 1*1 min -> 1*1 + 1*60 s = 1 + 60 = 61 in m*s
+        a = QMat(jnp.array([[1, 1]]), ((_m, _m),))
+        b = QMat(jnp.array([[1], [1]]), ((_s,), (_min,)))
+        result = _matmul(a, b)
+        assert jnp.isclose(result.value[0, 0], 61)
+        assert result.unit == ((_m * _s,),)
+
+    def test_1d_dot_product_uniform_units(self):
+        """1D @ 1D vector dot product with uniform units."""
+        a = QMat(jnp.array([2, 3]), unit=(_m, _m))
+        b = QMat(jnp.array([4, 5]), unit=(_s, _s))
+        result = _matmul(a, b)
+        # Result should be a scalar Quantity, not a QuantityMatrix
+        # 2*4 + 3*5 = 8 + 15 = 23 in m*s
+        assert isinstance(result, u.Q)
+        assert jnp.isclose(result.value, 23)
+        assert result.unit == _m * _s
+
+    def test_1d_dot_product_mixed_units(self):
+        """1D @ 1D with mixed units requiring conversion."""
+        # a: [1 m, 1 km], b: [1 s, 1 s]
+        # Result = 1*1 + 1000*1 = 1 + 1000 = 1001 in m*s
+        a = QMat(jnp.array([1, 1]), unit=(_m, _km))
+        b = QMat(jnp.array([1, 1]), unit=(_s, _s))
+        result = _matmul(a, b)
+        assert isinstance(result, u.Q)
+        assert jnp.isclose(result.value, 1001)
+        assert result.unit == _m * _s
+
+    def test_1d_dot_product_batch(self):
+        """1D @ 1D with batch dimensions."""
+        # Batch of 3 vectors, each length 2
+        a = QMat(jnp.array([[1, 2], [3, 4], [5, 6]]), unit=(_m, _m))
+        b = QMat(jnp.array([[7, 8], [9, 10], [11, 12]]), unit=(_s, _s))
+
+        @quax.quaxify
+        def dot_batched(x, y):
+            return x @ y
+
+        result = jax.vmap(dot_batched)(a, b)
+        # [1*7 + 2*8, 3*9 + 4*10, 5*11 + 6*12] = [23, 67, 127]
+        assert jnp.isclose(result.value[0], 23)
+        assert jnp.isclose(result.value[1], 67)
+        assert jnp.isclose(result.value[2], 127)
+
+
+# ---------------------------------------------------------------------------
+# JAX integration
+# ---------------------------------------------------------------------------
+
+
+class TestJaxIntegration:
+    """QuantityMatrix works with JAX transformations."""
+
+    def test_jit_add(self, unit_2x2):
+        """jit-compiled addition."""
+        a = QMat(jnp.array([[1, 2], [3, 4]]), unit=unit_2x2)
+        b = QMat(jnp.array([[5, 6], [7, 8]]), unit=unit_2x2)
+        result = jax.jit(_add)(a, b)
+        expected = jnp.array([[6, 8], [10, 12]])
+        assert jnp.allclose(result.value, expected)
+
+    def test_jit_matmul(self):
+        """jit-compiled matmul."""
+        a = QMat(jnp.array([[2, 3]]), unit=((_m, _m),))
+        b = QMat(jnp.array([[4], [5]]), unit=((_s,), (_s,)))
+        result = jax.jit(_matmul)(a, b)
+        assert jnp.isclose(result.value[0, 0], 23)
+
+    def test_pytree_flatten_unflatten(self, qm_2x2, unit_2x2):
+        """QuantityMatrix is a proper PyTree."""
+        leaves, treedef = jax.tree.flatten(qm_2x2)
+        restored = jax.tree.unflatten(treedef, leaves)
+        assert jnp.array_equal(restored.value, qm_2x2.value)
+        assert restored.unit == unit_2x2
+
+    def test_vmap_add(self, unit_2x2):
+        """Vmap over batch dimension for addition."""
+        a = QMat(jnp.ones((4, 2, 2)), unit=unit_2x2)
+        b = QMat(2 * jnp.ones((4, 2, 2)), unit=unit_2x2)
+
+        @quax.quaxify
+        def add_batched(x, y):
+            return x + y
+
+        result = jax.vmap(add_batched)(a, b)
+        assert result.shape == (4, 2, 2)
+        assert jnp.allclose(result.value, 3 * jnp.ones((4, 2, 2)))
+
+
+# ---------------------------------------------------------------------------
+# plum.convert registration
+# ---------------------------------------------------------------------------
+
+
+class TestPlumConversion:
+    """Tests for ``plum.convert`` registrations involving ``QuantityMatrix``."""
+
+    def test_QuantityMatrix_to_quantity_uniform_1d(self):
+        """1D uniform-unit ``QuantityMatrix`` converts to ``u.Q``."""
+        qm = QMat(value=jnp.array([1, 2, 3]), unit=(_m, _m, _m))
+
+        result = plum.convert(qm, u.Q)
+
+        assert isinstance(result, u.Q)
+        assert result.unit == _m
+        assert jnp.array_equal(result.value, qm.value)
+
+    def test_QuantityMatrix_to_quantity_uniform_2d(self):
+        """2D uniform-unit ``QuantityMatrix`` converts to ``u.Q``."""
+        qm = QMat(value=jnp.array([[1, 2], [3, 4]]), unit=((_s, _s), (_s, _s)))
+
+        result = plum.convert(qm, u.Q)
+
+        assert isinstance(result, u.Q)
+        assert result.unit == _s
+        assert result.shape == (2, 2)
+        assert jnp.array_equal(result.value, qm.value)
+
+    def test_QuantityMatrix_to_quantity_heterogeneous_units_raises(self):
+        """Mixed units cannot be converted to a single ``u.Q``."""
+        qm = QMat(value=jnp.array([1.0, 2.0]), unit=(_m, _s))
+
+        with pytest.raises(ValueError, match="all units are identical"):
+            plum.convert(qm, u.Q)
+
+
+# ---------------------------------------------------------------------------
+# Affine / logarithmic product-unit guards
+# ---------------------------------------------------------------------------
+
+
+class TestAffineProductUnitsRejected:
+    """Verify that astropy rejects product conversions for affine units.
+
+    The ``dot_general_qm_qm`` implementation uses a multiplicative scale
+    factor (``scale_3d``).  This is correct because affine units (°C, °F)
+    are the only units where a multiplicative scale would be wrong (they
+    have an additive offset), and astropy rejects product conversions
+    involving them.  Logarithmic units (dex, mag) in products become
+    plain ``CompositeUnit`` objects whose conversion IS multiplicative.
+
+    If astropy ever starts accepting affine product conversions, these
+    tests will *fail* — that's intentional: it means the assumption
+    behind ``scale_3d`` must be revisited.
+    """
+
+    def test_degC_times_s_not_convertible(self):
+        """°C·s → °F·s must fail (affine offset is undefined for products)."""
+        with pytest.raises(apu.UnitConversionError, match="not convertible"):
+            (apu.deg_C * apu.s).to(imperial.deg_F * apu.s, 1.0)
+
+    def test_degF_times_s_not_convertible(self):
+        """°F·s → °C·s must fail (symmetric check)."""
+        with pytest.raises(apu.UnitConversionError, match="not convertible"):
+            (imperial.deg_F * apu.s).to(apu.deg_C * apu.s, 1.0)
+
+    def test_degC_times_m_not_convertible(self):
+        """°C·m → °F·m must fail."""
+        with pytest.raises(apu.UnitConversionError, match="not convertible"):
+            (apu.deg_C * apu.m).to(imperial.deg_F * apu.m, 1.0)
+
+    def test_dex_times_s_is_convertible(self):
+        """dex·s → dex·ms succeeds.
+
+        dex in a product is a plain CompositeUnit; only the s → ms part
+        converts, multiplicatively.
+        """
+        result = (apu.dex() * apu.s).to(apu.dex() * apu.ms, 1.0)
+        assert math.isclose(result, 1000.0, rel_tol=1e-12)
+
+    def test_mag_times_s_is_convertible(self):
+        """mag·s → mag·ms succeeds (same reasoning as dex)."""
+        result = (apu.mag() * apu.s).to(apu.mag() * apu.ms, 1.0)
+        assert math.isclose(result, 1000.0, rel_tol=1e-12)
+
+    def test_kelvin_times_s_is_convertible(self):
+        """K·s → K·ms MUST succeed (Kelvin is absolute / linear).
+
+        This is the *positive* control: linear temperature products work
+        fine and the multiplicative scale is correct.
+        """
+        result = (apu.K * apu.s).to(apu.K * apu.ms, 1.0)
+        assert math.isclose(result, 1000.0, rel_tol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Matrix-vector multiply  (_dot_general_2d_1d)
+# ---------------------------------------------------------------------------
+
+
+class TestMatVec:
+    """Tests for 2D `QuantityMatrix` @ 1D `QuantityMatrix`."""
+
+    def test_identity_uniform_units(self):
+        """Identity 3x3 @ uniform-unit vector → same vector."""
+        A = QMat(jnp.eye(3), unit=((_dimless, _dimless, _dimless),) * 3)
+        v = QMat(jnp.array([1, 2, 3]), unit=(_m, _m, _m))
+        w = _matmul(A, v)
+        assert isinstance(w, QMat)
+        assert w.ndim == 1
+        assert jnp.allclose(w.value, jnp.array([1, 2, 3]))
+
+    def test_uniform_units_values(self):
+        """2x2 @ 2: correct values with uniform units."""
+        A = QMat(jnp.array([[2, 3], [4, 5]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([10, 20]), unit=(_s, _s))
+        w = _matmul(A, v)
+        # [2*10 + 3*20, 4*10 + 5*20] = [80, 140]
+        assert jnp.isclose(w.value[0], 80)
+        assert jnp.isclose(w.value[1], 140)
+
+    def test_output_is_1d_QuantityMatrix(self):
+        """Result of 2D @ 1D is a 1D ``QuantityMatrix``, not a 2D one."""
+        A = QMat(jnp.array([[1, 0], [0, 1]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([3, 7]), unit=(_s, _s))
+        w = _matmul(A, v)
+        assert isinstance(w, QMat)
+        assert w.ndim == 1
+        assert w.shape == (2,)
+
+    def test_output_units_are_product(self):
+        """Output unit[i] == lhs.unit[i][0] * rhs.unit[0]."""
+        A = QMat(jnp.array([[1, 1], [1, 1]]), unit=((_m, _m), (_kg, _kg)))
+        v = QMat(jnp.array([1, 1]), unit=(_s, _s))
+        w = _matmul(A, v)
+        assert w.unit[0] == _m * _s
+        assert w.unit[1] == _kg * _s
+
+    def test_lhs_unit_conversion_on_contraction_axis(self):
+        """Km column in A is converted to m before summing."""
+        # A: 2x2 with top-row units [[m, km]], bottom [[m, km]]
+        # v: [1, 1] in [s, s]
+        # ref[i] = m*s, scale[i,1] = 1000 (km*s → m*s)
+        # w[0] = 1*1 + 1000*1 = 1001, w[1] = 1001
+        A = QMat(jnp.array([[1, 1], [1, 1]]), unit=((_m, _km), (_m, _km)))
+        v = QMat(jnp.array([1, 1]), unit=(_s, _s))
+        w = _matmul(A, v)
+        assert jnp.isclose(w.value[0], 1001)
+        assert jnp.isclose(w.value[1], 1001)
+        assert w.unit[0] == _m * _s
+        assert w.unit[1] == _m * _s
+
+    def test_rhs_unit_conversion_on_contraction_axis(self):
+        """Ms column in v is converted to s before summing."""
+        # A: 2x2 with units [[m, m], [m, m]]
+        # v: [1, 1] in [s, ms]
+        # ref[i] = m*s, scale[i,1] = uconvert_value(m*s, m*ms, 1.0) = 0.001
+        # w[0] = 1*1 + 0.001*1 = 1.001, w[1] = 1.001
+        A = QMat(jnp.array([[1, 1], [1, 1]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([1, 1]), unit=(_s, _ms))
+        w = _matmul(A, v)
+        assert jnp.isclose(w.value[0], 1.001)
+        assert jnp.isclose(w.value[1], 1.001)
+        assert w.unit[0] == _m * _s
+
+    def test_non_square_3x2_at_2(self):
+        """Non-square 3x2 @ 2 → 3."""
+        A = QMat(
+            jnp.array([[1, 2], [3, 4], [5, 6]]), unit=((_m, _km), (_m, _km), (_m, _km))
+        )
+        v = QMat(jnp.array([1, 1]), unit=(_s, _s))
+        w = _matmul(A, v)
+        # scale[i,1] = 1000 (km*s → m*s)
+        # w[0] = 1*1 + 1000*2*1 = 2001
+        # w[1] = 1*3 + 1000*4*1 = 4003
+        # w[2] = 1*5 + 1000*6*1 = 6005
+        assert w.shape == (3,)
+        assert jnp.isclose(w.value[0], 2001)
+        assert jnp.isclose(w.value[1], 4003)
+        assert jnp.isclose(w.value[2], 6005)
+        assert all(w.unit[i] == _m * _s for i in range(3))
+
+    def test_jit_compatible(self):
+        """jit-compiled matrix-vector multiply works."""
+        A = QMat(jnp.array([[2, 3], [4, 5]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([10, 20]), unit=(_s, _s))
+        w = jax.jit(_matmul)(A, v)
+        assert jnp.isclose(w.value[0], 80)
+        assert jnp.isclose(w.value[1], 140)
+
+    def test_batch_dimensions(self):
+        """Leading batch dimensions are preserved."""
+        # A: (3, 2, 2), v: (3, 2) — vmapped over batch dim
+        A = QMat(jnp.ones((3, 2, 2)), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.ones((3, 2)), unit=(_s, _s))
+
+        @quax.quaxify
+        def mv(a, b):
+            return a @ b
+
+        w = jax.vmap(mv)(A, v)
+        # Each 2x2 ones @ [1, 1] = [2, 2]
+        assert w.shape == (3, 2)
+        assert jnp.allclose(w.value, 2 * jnp.ones((3, 2)))
+
+    def test_different_per_row_output_units(self):
+        """Each output row can have a different unit."""
+        # A: row 0 in m, row 1 in kg; v in s
+        A = QMat(jnp.array([[1, 1], [1, 1]]), unit=((_m, _m), (_kg, _kg)))
+        v = QMat(jnp.array([1, 1]), unit=(_s, _s))
+        w = _matmul(A, v)
+        assert w.unit[0] == _m * _s
+        assert w.unit[1] == _kg * _s
+        assert jnp.isclose(w.value[0], 2)
+        assert jnp.isclose(w.value[1], 2)
+
+
+# ---------------------------------------------------------------------------
+# Gather (jnp.diag)
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _diag(a):
+    return jnp.diag(a)
+
+
+class TestDiagAndGather:
+    """Tests for gather_qm: covers jnp.diag and element-selection indexing."""
+
+    def test_diag_values(self):
+        """jnp.diag extracts the correct diagonal values."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=(("m", "m", "m"), ("m", "m", "m"), ("m", "m", "m")),
+        )
+        d = _diag(A)
+        assert isinstance(d, QMat)
+        assert jnp.allclose(d.value, jnp.array([1, 4, 9]))
+
+    def test_diag_unit_is_1d(self):
+        """jnp.diag result has a 1-D UnitsMatrix, not 2-D."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=(("m", "m", "m"), ("m", "m", "m"), ("m", "m", "m")),
+        )
+        d = _diag(A)
+        assert d.unit.ndim == 1
+        assert d.unit.shape == (3,)
+
+    def test_diag_uniform_units(self):
+        """Diagonal of uniform-unit matrix keeps that unit."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = _diag(A)
+        assert all(d.unit[i] == _m for i in range(3))
+
+    def test_diag_heterogeneous_units_picks_diagonal(self):
+        """gather_p with concrete indices extracts correct units from heterogeneous QM.
+
+        jnp.diag is internally @jit-decorated, which traces indices abstract under
+        quax.quaxify.  Direct fancy indexing (without the @jit layer) demonstrates
+        that our gather_p handler correctly extracts per-element units when indices
+        are concrete Python/NumPy values.
+        """
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _s, _kg), (_m, _s, _kg), (_m, _s, _kg)),
+        )
+
+        @quax.quaxify
+        def _fancy_diag(mat):
+            # Direct fancy indexing: indices are concrete (no @jit layer)
+            return mat[jnp.array([0, 1, 2]), jnp.array([0, 1, 2])]
+
+        d = _fancy_diag(A)
+        assert d.unit[0] == _m  # unit[0, 0]
+        assert d.unit[1] == _s  # unit[1, 1]
+        assert d.unit[2] == _kg  # unit[2, 2]
+
+    def test_diag_dimensionless_unit_string(self):
+        """Dimensionless diagonal has '(, , )'-style repr, not '((, , ), ...)'."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 4])),
+            unit=(("", "", ""), ("", "", ""), ("", "", "")),
+        )
+        d = _diag(A)
+        assert d.unit.ndim == 1
+        assert d.unit.shape == (3,)
+        assert "(" not in d.unit.to_string().replace("(", "").join([""])  # no nested (
+        # The string should be 1D style like '(, , )' not '((, , ), ...)'
+        s = d.unit.to_string()
+        assert s.count("(") == 1, f"Expected 1D unit string, got: {s!r}"
+
+    def test_diag_under_jit_uniform_units(self):
+        """jnp.diag under jit works for uniform-unit QuantityMatrix."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = jax.jit(_diag)(A)
+        assert isinstance(d, QMat)
+        assert jnp.allclose(d.value, jnp.array([1, 4, 9]))
+        assert d.unit.ndim == 1
+        assert all(d.unit[i] == _m for i in range(3))
+
+
+# ---------------------------------------------------------------------------
+# QuantityMatrix.diag() method
+# ---------------------------------------------------------------------------
+
+
+class TestDiagMethod:
+    """Tests for ``QuantityMatrix.diag()`` — the method that bypasses JAX gather."""
+
+    def test_uniform_units_values(self):
+        """Diagonal values are correct for a uniform-unit matrix."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = A.diag()
+        assert isinstance(d, QMat)
+        assert jnp.allclose(d.value, jnp.array([1, 4, 9]))
+
+    def test_uniform_units_shape(self):
+        """Result is 1-D with length equal to the diagonal."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = A.diag()
+        assert d.ndim == 1
+        assert d.shape == (3,)
+        assert d.unit.ndim == 1
+        assert d.unit.shape == (3,)
+
+    def test_uniform_units_preserved(self):
+        """Units on the diagonal are preserved unchanged."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = A.diag()
+        assert all(d.unit[i] == _m for i in range(3))
+
+    def test_heterogeneous_units_values(self):
+        """Diagonal values are correct for a heterogeneous-unit matrix."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _s, _kg), (_m, _s, _kg), (_m, _s, _kg)),
+        )
+        d = A.diag()
+        assert jnp.allclose(d.value, jnp.array([1, 2, 3]))
+
+    def test_heterogeneous_units_correct(self):
+        """Each diagonal unit is taken from ``self.unit[i, i]``."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _s, _kg), (_m, _s, _kg), (_m, _s, _kg)),
+        )
+        d = A.diag()
+        assert d.unit[0] == _m
+        assert d.unit[1] == _s
+        assert d.unit[2] == _kg
+
+    def test_heterogeneous_units_to_string(self):
+        """1-D unit string has the correct format."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _s, _kg), (_m, _s, _kg), (_m, _s, _kg)),
+        )
+        d = A.diag()
+        assert d.unit.to_string() == "(m, s, kg)"
+
+    def test_2x2_square(self):
+        """2x2 matrix diagonal."""
+        A = QMat(jnp.array([[5, 0], [0, 7]]), unit=((_m, _s), (_kg, _rad)))
+        d = A.diag()
+        assert d.shape == (2,)
+        assert jnp.isclose(d.value[0], 5)
+        assert jnp.isclose(d.value[1], 7)
+        assert d.unit[0] == _m
+        assert d.unit[1] == _rad
+
+    def test_non_square_picks_min_dim(self):
+        """For non-square matrices the diagonal length is min(rows, cols)."""
+        # 2x3 matrix → diagonal of length 2
+        A = QMat(jnp.arange(6).reshape(2, 3), unit=((_m, _s, _kg), (_rad, _km, _ms)))
+        d = A.diag()
+        assert d.shape == (2,)
+        assert jnp.isclose(d.value[0], 0)  # A[0,0]
+        assert jnp.isclose(d.value[1], 4)  # A[1,1]
+        assert d.unit[0] == _m  # unit[0,0]
+        assert d.unit[1] == _km  # unit[1,1]
+
+    def test_1d_raises(self, qm_1d):
+        """Calling .diag() on a 1-D QuantityMatrix raises ValueError."""
+        with pytest.raises(ValueError, match="2D"):
+            qm_1d.diag()
+
+    def test_jit_uniform_units(self):
+        """Works under jax.jit with uniform units."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 4, 9])),
+            unit=((_m, _m, _m), (_m, _m, _m), (_m, _m, _m)),
+        )
+        d = jax.jit(lambda x: x.diag())(A)
+        assert isinstance(d, QMat)
+        assert jnp.allclose(d.value, jnp.array([1, 4, 9]))
+        assert d.unit[0] == _m
+
+    def test_jit_heterogeneous_units(self):
+        """Works under jax.jit with heterogeneous units (the key advantage)."""
+        A = QMat(
+            jnp.diag(jnp.array([1, 2, 3])),
+            unit=((_m, _s, _kg), (_m, _s, _kg), (_m, _s, _kg)),
+        )
+        d = jax.jit(lambda x: x.diag())(A)
+        assert d.unit[0] == _m
+        assert d.unit[1] == _s
+        assert d.unit[2] == _kg
+        assert jnp.allclose(d.value, jnp.array([1, 2, 3]))
+
+    def test_batch_dimensions(self):
+        """Batch leading dimensions are preserved."""
+        # (3, 2, 2) batched matrix
+        base = jnp.diag(jnp.array([1, 4]))
+        A = QMat(
+            jnp.stack([base, 2 * base, 3 * base]),  # (3, 2, 2)
+            unit=((_m, _m), (_s, _s)),
+        )
+        d = A.diag()
+        assert d.shape == (3, 2)
+        assert jnp.isclose(d.value[0, 0], 1)
+        assert jnp.isclose(d.value[1, 0], 2)
+        assert jnp.isclose(d.value[2, 1], 12)
+
+
+# ---------------------------------------------------------------------------
+# UnitsMatrix.inverse
+# ---------------------------------------------------------------------------
+
+
+class TestUnitsMatrixInverse:
+    """Tests for ``UnitsMatrix.inverse`` — element-wise unit reciprocal."""
+
+    def test_1d_values(self):
+        """1-D: each unit is reciprocated."""
+        um = UnitsMatrix((_m, _s))
+        inv = um.inverse()
+        assert inv[0] == _m ** (-1)
+        assert inv[1] == _s ** (-1)
+
+    def test_1d_shape_preserved(self):
+        """1-D inverse has the same shape."""
+        um = UnitsMatrix((_m, _s, _kg))
+        assert um.inverse().shape == (3,)
+
+    def test_1d_returns_unitsmatrix(self):
+        """Result is a ``UnitsMatrix`` instance."""
+        um = UnitsMatrix((_m, _s))
+        assert isinstance(um.inverse(), UnitsMatrix)
+
+    def test_1d_double_inverse_is_identity(self):
+        """Two inversions return the original unit structure."""
+        um = UnitsMatrix((_m, _s, _kg))
+        assert um == um.inverse().inverse()
+
+    def test_2d_uniform_values(self):
+        """2-D uniform matrix: every entry is reciprocated."""
+        um = UnitsMatrix(((_m, _m), (_m, _m)))
+        inv = um.inverse()
+        for i in range(2):
+            for j in range(2):
+                assert inv[i, j] == _m ** (-1)
+
+    def test_2d_uniform_shape_preserved(self):
+        """2-D uniform inverse has the same shape."""
+        um = UnitsMatrix(((_m, _m), (_m, _m)))
+        assert um.inverse().shape == (2, 2)
+
+    def test_2d_mixed_values(self):
+        """2-D mixed-unit matrix: element-wise reciprocal."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        inv = um.inverse()
+        assert inv[0, 0] == _m ** (-1)
+        assert inv[0, 1] == _s ** (-1)
+        assert inv[1, 0] == _kg ** (-1)
+        assert inv[1, 1] == _rad ** (-1)
+
+    def test_2d_returns_unitsmatrix(self):
+        """Result is always a ``UnitsMatrix`` instance."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert isinstance(um.inverse(), UnitsMatrix)
+
+    def test_2d_double_inverse_is_identity(self):
+        """Two inversions return the original unit structure."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert um == um.inverse().inverse()
+
+
+# ---------------------------------------------------------------------------
+# UnitsMatrix.T
+# ---------------------------------------------------------------------------
+
+
+class TestUnitsMatrixTranspose:
+    """Tests for ``UnitsMatrix.T`` — the unit-structure transpose."""
+
+    def test_2d_square_values(self):
+        """Transposing a 2x2 UnitsMatrix swaps rows and columns."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        t = um.T
+        assert t[0, 0] == _m
+        assert t[0, 1] == _kg
+        assert t[1, 0] == _s
+        assert t[1, 1] == _rad
+
+    def test_2d_square_shape(self):
+        """Shape is preserved for a square transpose."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert um.T.shape == (2, 2)
+
+    def test_2d_nonsquare_shape(self):
+        """Transposing a 2x3 UnitsMatrix gives a 3x2."""
+        um = UnitsMatrix(((_m, _s, _kg), (_rad, _km, _ms)))
+        t = um.T
+        assert t.shape == (3, 2)
+
+    def test_2d_nonsquare_values(self):
+        """Each element [j, i] in the transpose equals [i, j] in the original."""
+        um = UnitsMatrix(((_m, _s, _kg), (_rad, _km, _ms)))
+        t = um.T
+        # Original row 0: (m, s, kg); Original row 1: (rad, km, ms)
+        # Transposed col 0 (row 0): (m, rad); col 1: (s, km); col 2: (kg, ms)
+        assert t[0, 0] == _m
+        assert t[0, 1] == _rad
+        assert t[1, 0] == _s
+        assert t[1, 1] == _km
+        assert t[2, 0] == _kg
+        assert t[2, 1] == _ms
+
+    def test_2d_double_transpose_is_identity(self):
+        """Two transposes return the original unit structure."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert um == um.T.T
+
+    def test_2d_returns_unitsmatrix(self):
+        """Result is always a ``UnitsMatrix`` instance."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert isinstance(um.T, UnitsMatrix)
+
+    def test_1d_transpose_is_identity(self):
+        """Transposing a 1-D UnitsMatrix is a no-op (numpy convention)."""
+        um = UnitsMatrix((_m, _s, _kg))
+        t = um.T
+        assert t == um
+        assert t.shape == (3,)
+        assert t.ndim == 1
+
+
+# ---------------------------------------------------------------------------
+# QuantityMatrix.T
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _transpose(x):
+    return x.T
+
+
+class TestQuantityMatrixTranspose:
+    """Tests for ``QuantityMatrix.T`` — the matrix transpose property."""
+
+    # -- Basic 2D values and units ----------------------------------------
+
+    def test_2d_square_values(self, qm_2x2):
+        """Value array is transposed correctly for a square matrix."""
+        t = qm_2x2.T
+        expected = jnp.array([[1, 3], [2, 4]])
+        assert jnp.allclose(t.value, expected)
+
+    def test_2d_square_units(self, qm_2x2):
+        """Unit structure is transposed: unit[j][i] equals original unit[i][j]."""
+        t = qm_2x2.T
+        # Original: unit[0,0]=m, unit[0,1]=s, unit[1,0]=kg, unit[1,1]=rad
+        assert t.unit[0, 0] == _m
+        assert t.unit[0, 1] == _kg
+        assert t.unit[1, 0] == _s
+        assert t.unit[1, 1] == _rad
+
+    def test_2d_square_unit_string(self, qm_2x2):
+        """Transposed unit string matches expected layout."""
+        assert qm_2x2.T.unit.to_string() == "((m, kg), (s, rad))"
+
+    def test_2d_square_shape_preserved(self, qm_2x2):
+        """Shape is unchanged for a square matrix."""
+        assert qm_2x2.T.shape == (2, 2)
+
+    def test_2d_square_returns_QuantityMatrix(self, qm_2x2):
+        """Result is a ``QuantityMatrix`` instance."""
+        assert isinstance(qm_2x2.T, QMat)
+
+    def test_2d_nonsquare_values(self):
+        """Transposing a 2x3 matrix gives a 3x2 with correct values."""
+        a = QMat(jnp.arange(6).reshape(2, 3), unit=((_m, _s, _kg), (_rad, _km, _ms)))
+        t = a.T
+        expected = jnp.arange(6).reshape(2, 3).T
+        assert jnp.allclose(t.value, expected)
+
+    def test_2d_nonsquare_shape(self):
+        """Shape is (3, 2) after transposing a (2, 3) matrix."""
+        a = QMat(jnp.ones((2, 3)), unit=((_m, _s, _kg), (_rad, _km, _ms)))
+        assert a.T.shape == (3, 2)
+
+    def test_2d_nonsquare_units(self):
+        """Unit element [j, i] of the transpose equals original [i, j]."""
+        a = QMat(jnp.ones((2, 3)), unit=((_m, _s, _kg), (_rad, _km, _ms)))
+        t = a.T
+        # Original row 0: (m, s, kg); row 1: (rad, km, ms)
+        assert t.unit[0, 0] == _m
+        assert t.unit[0, 1] == _rad
+        assert t.unit[1, 0] == _s
+        assert t.unit[1, 1] == _km
+        assert t.unit[2, 0] == _kg
+        assert t.unit[2, 1] == _ms
+
+    def test_2d_double_transpose_values(self, qm_2x2):
+        """Transposing twice recovers the original values."""
+        assert jnp.allclose(qm_2x2.T.T.value, qm_2x2.value)
+
+    def test_2d_double_transpose_units(self, qm_2x2):
+        """Transposing twice recovers the original unit structure."""
+        assert qm_2x2.T.T.unit == qm_2x2.unit
+
+    # -- Batch-dimension behavior -----------------------------------------
+
+    def test_batch_shape(self):
+        """For a batched ``(B, N, M)`` array, ``.T`` swaps only matrix axes.
+
+        Result shape is ``(B, M, N)``.
+        """
+        a = QMat(jnp.ones((3, 2, 4)), unit=((_m, _s, _kg, _rad), (_km, _ms, _g, _deg)))
+        t = a.T
+        assert t.shape == (3, 4, 2)
+
+    def test_batch_unit_structure_unchanged(self):
+        """The unit structure (which is 2-D) is transposed in the usual way.
+
+        Batch axes are preserved; only the last two (matrix) axes are swapped.
+        The unit structure only has the two logical dimensions, so it is
+        transposed as a normal 2-D matrix; the batch axis does not appear in
+        the unit structure.
+        """
+        a = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_kg, _rad)))
+        t = a.T
+        # value shape: (3,2,2) → (3,2,2);  unit shape stays (2,2) but transposed
+        assert t.shape == (3, 2, 2)
+        assert t.unit.shape == (2, 2)
+        assert t.unit[0, 0] == _m
+        assert t.unit[0, 1] == _kg
+        assert t.unit[1, 0] == _s
+        assert t.unit[1, 1] == _rad
+
+    def test_batch_matrix_transpose_via_quax(self):
+        """``matrix_transpose`` on a batched ``(B, N, M)`` preserves batch axes."""
+        a = QMat(jnp.arange(12).reshape(3, 2, 2), unit=((_m, _s), (_kg, _rad)))
+        t = qnp.matrix_transpose(a)
+        # Batch axis preserved; last two swapped: (3,2,2) → (3,2,2)
+        assert t.shape == (3, 2, 2)
+        # Check a few values: t[b, i, j] == a[b, j, i]
+        for b in range(3):
+            assert jnp.allclose(t.value[b], a.value[b].T)
+        # Unit structure is the same transposed 2-D layout
+        assert t.unit[0, 0] == _m
+        assert t.unit[0, 1] == _kg
+        assert t.unit[1, 0] == _s
+        assert t.unit[1, 1] == _rad
+
+    def test_vmap_transpose(self):
+        """``jax.vmap`` over a batch of 2-D matrices gives the per-element transpose."""
+        a = QMat(jnp.arange(12).reshape(3, 2, 2), unit=((_m, _s), (_kg, _rad)))
+
+        @quax.quaxify
+        def single_T(x):
+            return x.T
+
+        result = jax.vmap(single_T)(a)
+        # Each (2,2) slice is transposed independently
+        assert result.shape == (3, 2, 2)
+        for i in range(3):
+            expected = jnp.array(
+                [
+                    [a.value[i, 0, 0], a.value[i, 1, 0]],
+                    [a.value[i, 0, 1], a.value[i, 1, 1]],
+                ]
+            )
+            assert jnp.allclose(result.value[i], expected)
+
+    # -- JIT compatibility ------------------------------------------------
+
+    def test_jit_values(self, qm_2x2):
+        """``jax.jit`` preserves transpose values."""
+        t = jax.jit(_transpose)(qm_2x2)
+        expected = jnp.array([[1, 3], [2, 4]])
+        assert jnp.allclose(t.value, expected)
+
+    def test_jit_units(self, qm_2x2):
+        """``jax.jit`` preserves transposed unit structure."""
+        t = jax.jit(_transpose)(qm_2x2)
+        assert t.unit.to_string() == "((m, kg), (s, rad))"
+
+    # -- 1-D error --------------------------------------------------------
+
+    def test_1d_raises(self, qm_1d):
+        """Accessing ``.T`` on a 1-D ``QuantityMatrix`` raises ``ValueError``.
+
+        The ``.T`` property requires a 2-D unit structure to unpack ``(n, m)``.
+        """
+        with pytest.raises(ValueError, match="requires a 2-D matrix"):
+            _ = qm_1d.T
+
+
+# ---------------------------------------------------------------------------
+# det_p custom primitive + Quax dispatch for QuantityMatrix
+# ---------------------------------------------------------------------------
+
+
+class TestDetPrimitive:
+    """Tests for the custom ``det_p`` JAX primitive on plain arrays."""
+
+    def test_det_2x2_diagonal(self):
+        """Det on a 2×2 diagonal matrix returns the product of the diagonals."""
+        A = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        assert jnp.allclose(qm_det(A), jnp.linalg.det(A))
+
+    def test_det_3x3_identity(self):
+        """det(I_3 * 2) == 8."""
+        A = jnp.eye(3) * 2.0
+        assert jnp.allclose(qm_det(A), 8.0)
+
+    def test_det_matches_jnp_linalg_det(self):
+        """det_p gives the same result as jnp.linalg.det for a generic matrix."""
+        A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        assert jnp.allclose(qm_det(A), jnp.linalg.det(A))
+
+    def test_det_jit(self):
+        """det_p works under jax.jit."""
+        A = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        result = jax.jit(qm_det)(A)
+        assert jnp.allclose(result, 6.0)
+
+    def test_det_jvp(self):
+        """Forward-mode derivative matches Jacobi's formula.
+
+        d det(A)(dA) = det(A) * tr(A^-1 dA).
+        """
+        A = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        dA = jnp.ones((2, 2))
+        primal, tangent = jax.jvp(qm_det, (A,), (dA,))
+        # det(A) = 6
+        # tr(A⁻¹ dA) = tr([[0.5,0],[0,1/3]] @ [[1,1],[1,1]]) = 0.5 + 1/3 = 5/6
+        # tangent = 6 * 5/6 = 5
+        assert jnp.allclose(primal, 6.0)
+        assert jnp.allclose(tangent, 5.0)
+
+    def test_det_grad(self):
+        """Reverse-mode gradient matches Jacobi's formula: ∂det(A)/∂A = det(A)·A⁻ᵀ."""
+        A = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        # grad_A = det(A) * A^{-T} = 6 * diag(0.5, 1/3) = diag(3, 2)
+        grad_A = jax.grad(qm_det)(A)
+        expected = jnp.array([[3.0, 0.0], [0.0, 2.0]])
+        assert jnp.allclose(grad_A, expected)
+
+    def test_det_jit_grad(self):
+        """jit(grad(det)) works correctly."""
+        A = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        grad_A = jax.jit(jax.grad(qm_det))(A)
+        expected = jnp.array([[3.0, 0.0], [0.0, 2.0]])
+        assert jnp.allclose(grad_A, expected)
+
+    def test_det_vmap(self):
+        """det_p works under jax.vmap — maps over a batch of matrices."""
+        A = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 3.0])), jnp.diag(jnp.array([4.0, 5.0]))]
+        )
+        results = jax.vmap(qm_det)(A)
+        expected = jnp.array([6.0, 20.0])
+        assert jnp.allclose(results, expected)
+
+    def test_det_jit_vmap(self):
+        """jit(vmap(det)) works correctly."""
+        A = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 3.0])), jnp.diag(jnp.array([4.0, 5.0]))]
+        )
+        results = jax.jit(jax.vmap(qm_det))(A)
+        expected = jnp.array([6.0, 20.0])
+        assert jnp.allclose(results, expected)
+
+    def test_det_batched_shape(self):
+        """det_p on a (*batch, n, n) array returns shape (*batch,)."""
+        A = jnp.ones((3, 4, 2, 2))
+        # det of 2×2 ones matrix = 1*1 - 1*1 = 0
+        result = qm_det(A)
+        assert result.shape == (3, 4)
+
+
+class TestDetQuantityMatrix:
+    """Tests for det_p Quax dispatch on QuantityMatrix."""
+
+    def test_returns_abstract_quantity(self):
+        """Det of a 2×2 QuantityMatrix returns an AbstractQuantity."""
+        A = QMat(jnp.array([[2, 0], [0, 3]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_det)(A)
+        assert isinstance(result, u.AbstractQuantity)
+
+    def test_value_2x2_diagonal(self):
+        """Numeric value equals jnp.linalg.det of the value array."""
+        A = QMat(jnp.array([[2, 0], [0, 3]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_det)(A)
+        assert jnp.allclose(result.value, 6)
+
+    def test_unit_product_of_diagonal(self):
+        """Unit is the product of the main-diagonal units: m·m = m²."""
+        A = QMat(jnp.array([[2, 0], [0, 3]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_det)(A)
+        assert result.unit == u.unit("m2")
+
+    def test_unit_heterogeneous_diagonal(self):
+        """Unit is u00 * u11 for a 2×2 matrix with mixed diagonal units."""
+        A = QMat(jnp.eye(2), unit=((_m, _s), (_m, _s)))
+        result = quax.quaxify(qm_det)(A)
+        assert result.unit == _m * _s
+
+    def test_unit_3x3_uniform(self):
+        """Det of 3×3 identity with uniform unit m gives unit m³."""
+        A = QMat(jnp.eye(3), unit=((_m, _m, _m),) * 3)
+        result = quax.quaxify(qm_det)(A)
+        assert jnp.allclose(result.value, 1)
+        assert result.unit == u.unit("m3")
+
+    def test_jit_QuantityMatrix(self):
+        """Det of QuantityMatrix works under jax.jit."""
+        A = QMat(jnp.array([[2.0, 0.0], [0.0, 3.0]]), unit=((_m, _m), (_m, _m)))
+        result = jax.jit(quax.quaxify(qm_det))(A)
+        assert jnp.allclose(result.value, 6)
+        assert result.unit == u.unit("m2")
+
+
+# ---------------------------------------------------------------------------
+# inv_p custom primitive + Quax dispatch for QuantityMatrix
+# ---------------------------------------------------------------------------
+
+
+class TestInvPrimitive:
+    """Tests for the custom ``inv_p`` JAX primitive on plain arrays."""
+
+    def test_inv_2x2_diagonal(self):
+        """inv_p on a diagonal matrix returns the reciprocal diagonal."""
+        A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+        result = qm_inv(A)
+        expected = jnp.linalg.inv(A)
+        assert jnp.allclose(result, expected)
+
+    def test_inv_3x3_identity(self):
+        """inv(I) == I."""
+        A = jnp.eye(3)
+        assert jnp.allclose(qm_inv(A), A)
+
+    def test_inv_matches_jnp_linalg_inv(self):
+        """inv_p gives the same result as jnp.linalg.inv for a generic matrix."""
+        A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        assert jnp.allclose(qm_inv(A), jnp.linalg.inv(A))
+
+    def test_inv_jit(self):
+        """inv_p works under jax.jit."""
+        A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+        result = jax.jit(qm_inv)(A)
+        assert jnp.allclose(result, jnp.linalg.inv(A))
+
+    def test_inv_jvp(self):
+        """Forward-mode derivative of A^{-1}: d(A^{-1})(dA) = -A^{-1} dA A^{-1}."""
+        A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+        dA = jnp.ones((2, 2))
+        primal, tangent = jax.jvp(qm_inv, (A,), (dA,))
+        assert jnp.allclose(primal, jnp.linalg.inv(A))
+        # expected tangent: -A^{-1} dA A^{-1}
+        Ainv = jnp.linalg.inv(A)
+        expected_tangent = -(Ainv @ dA @ Ainv)
+        assert jnp.allclose(tangent, expected_tangent)
+
+    def test_inv_grad(self):
+        """Reverse-mode gradient via VJP derived from JVP."""
+        A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+
+        # Scalar output f(A) = sum(inv(A))
+        def f(a):
+            return jnp.sum(qm_inv(a))
+
+        grad_A = jax.grad(f)(A)
+        # Finite-difference check. Use a comparatively large step: at float32
+        # precision a tiny eps (e.g. 1e-5) makes inv(Ap) - inv(Am) dominated by
+        # rounding (catastrophic cancellation); eps=1e-2 keeps the difference
+        # well above the float32 noise floor while truncation error stays small.
+        eps = 1e-2
+        fd = jnp.zeros_like(A)
+        for i in range(2):
+            for j in range(2):
+                Ap = A.at[i, j].add(eps)
+                Am = A.at[i, j].add(-eps)
+                fd_val = (jnp.sum(jnp.linalg.inv(Ap)) - jnp.sum(jnp.linalg.inv(Am))) / (
+                    2 * eps
+                )
+                fd = fd.at[i, j].set(fd_val)
+        assert jnp.allclose(grad_A, fd, atol=1e-2)
+
+    def test_inv_jit_grad(self):
+        """jit(grad(sum(inv(A)))) works correctly."""
+        A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+
+        def f(a):
+            return jnp.sum(qm_inv(a))
+
+        grad_A = jax.jit(jax.grad(f))(A)
+
+        def g(a):
+            return jnp.sum(jnp.linalg.inv(a))
+
+        expected = jax.grad(g)(A)
+        assert jnp.allclose(grad_A, expected, atol=1e-6)
+
+    def test_inv_vmap(self):
+        """inv_p works under jax.vmap — maps over a batch of matrices."""
+        A = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 4.0])), jnp.diag(jnp.array([1.0, 2.0]))]
+        )
+        results = jax.vmap(qm_inv)(A)
+        expected = jax.vmap(jnp.linalg.inv)(A)
+        assert jnp.allclose(results, expected)
+
+    def test_inv_jit_vmap(self):
+        """jit(vmap(inv)) works correctly."""
+        A = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 4.0])), jnp.diag(jnp.array([1.0, 2.0]))]
+        )
+        results = jax.jit(jax.vmap(qm_inv))(A)
+        expected = jax.vmap(jnp.linalg.inv)(A)
+        assert jnp.allclose(results, expected)
+
+    def test_inv_batched_shape(self):
+        """inv_p on a (*batch, n, n) array returns shape (*batch, n, n)."""
+        A = jnp.stack([jnp.eye(2)] * 6).reshape(3, 2, 2, 2)
+        result = jax.vmap(jax.vmap(qm_inv))(A)
+        assert result.shape == (3, 2, 2, 2)
+
+
+class TestInvQuantityMatrix:
+    """Tests for inv_p Quax dispatch on QuantityMatrix."""
+
+    def test_returns_QuantityMatrix(self):
+        """Inv of a 2×2 QuantityMatrix returns a QuantityMatrix."""
+        A = QMat(jnp.array([[4, 0], [0, 1]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_inv)(A)
+        assert isinstance(result, QMat)
+
+    def test_value_2x2_diagonal(self):
+        """Numeric value equals jnp.linalg.inv of the value array."""
+        A = QMat(jnp.array([[4, 0], [0, 1]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_inv)(A)
+        expected_val = jnp.linalg.inv(jnp.array([[4.0, 0.0], [0.0, 1.0]]))
+        assert jnp.allclose(result.value, expected_val)
+
+    def test_unit_reciprocal(self):
+        """Unit of the inverse is the reciprocal of the original unit: 1/m."""
+        A = QMat(jnp.array([[4, 0], [0, 1]]), unit=((_m, _m), (_m, _m)))
+        result = quax.quaxify(qm_inv)(A)
+        expected_unit = u.unit("1 / m")
+        assert result.unit[0, 0] == expected_unit
+        assert result.unit[1, 1] == expected_unit
+
+    def test_unit_m2_per_rad2(self):
+        """Inv of a metric with m²/rad² entries carries rad²/m² units."""
+        m2_r2 = u.unit("m2 / rad2")
+        A = QMat(jnp.array([[4, 0], [0, 1]]), unit=((m2_r2, m2_r2), (m2_r2, m2_r2)))
+        result = quax.quaxify(qm_inv)(A)
+        assert result.unit[0, 0] == u.unit("rad2 / m2")
+
+    def test_jit_QuantityMatrix(self):
+        """Inv of QuantityMatrix works under jax.jit."""
+        A = QMat(jnp.array([[4.0, 0.0], [0.0, 1.0]]), unit=((_m, _m), (_m, _m)))
+        result = jax.jit(quax.quaxify(qm_inv))(A)
+        assert jnp.allclose(result.value, jnp.array([[0.25, 0.0], [0.0, 1.0]]))
+        assert result.unit[0, 0] == u.unit("1 / m")
+
+    def test_roundtrip_identity(self):
+        """A @ inv(A) ≈ I for a QuantityMatrix (value check)."""
+        A = QMat(jnp.array([[2, 1], [1, 3]]), unit=((_m, _m), (_m, _m)))
+        Ainv = quax.quaxify(qm_inv)(A)
+        product = A.value @ Ainv.value
+        assert jnp.allclose(product, jnp.eye(2), atol=1e-6)

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -705,6 +705,26 @@ class TestDotProduct:
         assert jnp.isclose(result.value[0, 0], 21)
         assert result.unit == ((_m * _s,),)
 
+    def test_batched_matmul_2x2(self):
+        """Leading batch axis: (B, 2, 2) @ (B, 2, 2) contracts per batch element.
+
+        ``jnp.matmul`` lowers this to a ``dot_general`` with a non-empty batch
+        dimension; the handler must accept the standard (batched) matmul pattern
+        and broadcast the per-element units over the leading batch axis.
+        """
+        a_val = jnp.array(
+            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
+        )  # (2, 2, 2)
+        b_val = jnp.broadcast_to(jnp.eye(2), (2, 2, 2))
+        a = QMat(a_val, unit=((_m, _m), (_m, _m)))
+        b = QMat(b_val, unit=((_s, _s), (_s, _s)))
+        result = _matmul(a, b)
+        assert result.shape == (2, 2, 2)
+        # Multiplying each batch element by the identity leaves values unchanged.
+        assert jnp.allclose(result.value, a_val)
+        ms = _m * _s
+        assert result.unit == ((ms, ms), (ms, ms))
+
     def test_matmul_rhs_unit_conversion(self):
         """Unit conversion needed on the RHS contraction axis."""
         # A: 1x2, units [[m, m]]
@@ -1092,8 +1112,8 @@ class TestDiagAndGather:
         d = _diag(A)
         assert d.unit.ndim == 1
         assert d.unit.shape == (3,)
-        assert "(" not in d.unit.to_string().replace("(", "").join([""])  # no nested (
-        # The string should be 1D style like '(, , )' not '((, , ), ...)'
+        # The string should be 1D style like '(, , )' not nested '((, , ), ...)',
+        # i.e. exactly one opening parenthesis.
         s = d.unit.to_string()
         assert s.count("(") == 1, f"Expected 1D unit string, got: {s!r}"
 

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -112,6 +112,24 @@ class TestConstruction:
         assert qm.shape == (5, 3, 2, 2)
         assert qm.ndim == 2  # logical
 
+    def test_batched_indexing_leaves_unit(self):
+        """Indexing a batch axis reduces the value but keeps the unit structure."""
+        qm = QMat(jnp.arange(12.0).reshape(3, 2, 2), unit=((_m, _s), (_kg, _m)))
+        # Select a batch element -> a single matrix with the full unit.
+        assert qm[0].value.shape == (2, 2)
+        assert qm[0].unit == ((_m, _s), (_kg, _m))
+        # Batch slice keeps the batch axis and the unit.
+        assert qm[0:2].value.shape == (2, 2, 2)
+        assert qm[0:2].unit == ((_m, _s), (_kg, _m))
+        # Batch index + logical row -> 1-D vector with that row's units.
+        assert qm[0, 1].value.shape == (2,)
+        assert qm[0, 1].unit == (_kg, _m)
+        # Batch index + full element -> scalar Quantity.
+        assert qm[0, 1, 0].unit == _kg
+        # Ellipsis / newaxis are not supported (deterministic error).
+        with pytest.raises(NotImplementedError, match="Ellipsis"):
+            _ = qm[..., 0]
+
     def test_shape(self, qm_2x2):
         assert qm_2x2.shape == (2, 2)
 

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -697,6 +697,63 @@ class TestSubtraction:
 
 
 # ---------------------------------------------------------------------------
+# Element-wise multiply / divide  (quax lax.mul_p / div_p)
+# ---------------------------------------------------------------------------
+
+
+@quax.quaxify
+def _mul(a, b):
+    return a * b
+
+
+@quax.quaxify
+def _div(a, b):
+    return a / b
+
+
+class TestElementwiseMulDiv:
+    """Element-wise mul/div keep the QuantityMatrix type and compose units."""
+
+    def test_qm_times_quantity_both_orders(self):
+        qm = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _s), (_kg, _rad)))
+        for r in (_mul(qm, u.Q(2.0, "s")), _mul(u.Q(2.0, "s"), qm)):  # commutes
+            assert isinstance(r, QMat)
+            assert jnp.allclose(r.value, jnp.array([[2.0, 4.0], [6.0, 8.0]]))
+            assert r.unit == ((_m * _s, _s * _s), (_kg * _s, _rad * _s))
+
+    def test_qm_times_qm_hadamard(self):
+        qm = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _s), (_kg, _rad)))
+        r = _mul(qm, qm)
+        assert isinstance(r, QMat)
+        assert jnp.allclose(r.value, jnp.array([[1.0, 4.0], [9.0, 16.0]]))
+        assert r.unit == ((_m * _m, _s * _s), (_kg * _kg, _rad * _rad))
+
+    def test_scalar_leaves_units(self):
+        qv = QMat(jnp.array([1.0, 2.0, 3.0]), unit=(_m, _s, _kg))
+        r = _mul(qv, 2.0)
+        assert isinstance(r, QMat)
+        assert r.unit == (_m, _s, _kg)
+
+    def test_division(self):
+        qm = QMat(jnp.array([[2.0, 4.0], [6.0, 8.0]]), unit=((_m, _s), (_kg, _rad)))
+        r = _div(qm, u.Q(2.0, "s"))
+        assert isinstance(r, QMat)
+        assert jnp.allclose(r.value, jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+        assert r.unit == ((_m / _s, _s / _s), (_kg / _s, _rad / _s))
+        # dimensionless / qm inverts units
+        r2 = _div(1.0, QMat(jnp.array([2.0, 4.0]), unit=(_m, _s)))
+        assert isinstance(r2, QMat)
+        assert r2.unit == (_m**-1, _s**-1)
+
+    def test_quantity_times_qm_is_usable_downstream(self):
+        """A quantity-on-left product is a real QuantityMatrix, not a Quantity."""
+        qm = QMat(jnp.ones((2, 2)), unit=((_m, _s), (_kg, _rad)))
+        r = _mul(u.Q(2.0, "s"), qm)
+        r2 = _add(r, r)  # would raise if r were a plain Quantity holding a UnitsMatrix
+        assert jnp.allclose(r2.value, 2 * r.value)
+
+
+# ---------------------------------------------------------------------------
 # Dot product / matmul  (quax lax.dot_general_p)
 # ---------------------------------------------------------------------------
 

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -10,6 +10,7 @@ import plum
 import pytest
 import quax
 from astropy.units import imperial  # registers °F
+from jax import lax
 from unxts.linalg import (
     QuantityMatrix as QMat,
     UnitsMatrix,
@@ -24,7 +25,11 @@ from unxts.linalg._src import (
     det as qm_det,
     inv as qm_inv,
 )
-from unxts.linalg._src._register_primitives import _check_contract, _wrap_operand
+from unxts.linalg._src._register_primitives import (
+    _check_contract,
+    _wrap_operand,
+    gather_qm,
+)
 
 import quaxed.numpy as qnp
 
@@ -614,6 +619,22 @@ class TestAddition:
         assert jnp.isclose(result.value[0, 1], 2 + 2 * (180 / jnp.pi), atol=1e-8)
         assert jnp.isclose(result.value[1, 1], 4 + 720 / jnp.pi, atol=1e-8)
 
+    def test_per_element_conversion_with_logarithmic_unit(self):
+        """Conversion is per-element (`uconvert_value`), not one global scale.
+
+        A logarithmic unit (``mag``) converts as identity while a neighbouring
+        length element scales by 1000 — a single shared scale factor could not
+        produce both. Guards the ``_convert_value`` per-element contract that
+        add/sub rely on for non-scale (log/affine) units.
+        """
+        mag = u.unit("mag")
+        x = QMat(jnp.array([1.0, 1.0]), unit=(mag, _m))
+        y = QMat(jnp.array([2.0, 2.0]), unit=(mag, _km))  # 2 mag, 2 km
+        result = _add(x, y)
+        # mag: 1 + 2 = 3 (identity conversion); m: 1 + 2000 = 2001 (km→m).
+        assert jnp.allclose(result.value, jnp.array([3.0, 2001.0]))
+        assert result.unit == (mag, _m)
+
 
 # ---------------------------------------------------------------------------
 # Subtraction  (quax lax.sub_p)
@@ -1116,6 +1137,63 @@ class TestProducts:
         rv = jax.vmap(matvec)(Ab, vb)
         assert jnp.allclose(rv.value, jnp.array([[3.0, 7.0], [6.0, 14.0]]))
 
+    def test_matmul_under_transforms(self):
+        """Matmul composes with jit / grad / vmap (values + units preserved)."""
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        B = QMat(jnp.array([[5.0, 6.0], [7.0, 8.0]]), unit=((_s, _s), (_s, _s)))
+
+        r = jax.jit(matmul)(A, B)
+        assert jnp.allclose(r.value, jnp.array([[19.0, 22.0], [43.0, 50.0]]))
+        assert r.unit == ((_m * _s, _m * _s), (_m * _s, _m * _s))
+
+        def loss(mat_val):
+            return jnp.sum(matmul(QMat(mat_val, unit=((_m, _m), (_m, _m))), B).value)
+
+        # d/dA_ik of sum(A @ B) is the row-sum of B over k: B row 0 = 11, row 1 = 15.
+        assert jnp.allclose(
+            jax.grad(loss)(A.value), jnp.array([[11.0, 15.0], [11.0, 15.0]])
+        )
+
+        Ab = QMat(jnp.stack([A.value, 2 * A.value]), unit=((_m, _m), (_m, _m)))
+        Bb = QMat(jnp.stack([B.value, B.value]), unit=((_s, _s), (_s, _s)))
+        assert jax.vmap(matmul)(Ab, Bb).value.shape == (2, 2, 2)
+
+    def test_vecmat_under_transforms(self):
+        """Vecmat composes with jit / grad / vmap."""
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+        a = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+
+        r = jax.jit(vecmat)(v, a)
+        assert jnp.allclose(r.value, jnp.array([4.0, 6.0]))
+        assert r.unit == (_s * _m, _s * _m)
+
+        def loss(vec_val):
+            return jnp.sum(vecmat(QMat(vec_val, unit=(_s, _s)), a).value)
+
+        # d/dv_i of sum(v @ a) is the row sums of a: [3, 7].
+        assert jnp.allclose(jax.grad(loss)(v.value), jnp.array([3.0, 7.0]))
+
+        vb = QMat(jnp.stack([v.value, v.value]), unit=(_s, _s))
+        ab = QMat(jnp.stack([a.value, a.value]), unit=((_m, _m), (_m, _m)))
+        assert jax.vmap(vecmat)(vb, ab).value.shape == (2, 2)
+
+    def test_vecdot_under_transforms(self):
+        """Vecdot composes with jit / grad / vmap (unit conversion preserved)."""
+        a = QMat(jnp.array([1.0, 2.0]), unit=(_m, _km))
+        b = QMat(jnp.array([3.0, 4.0]), unit=(_s, _s))
+
+        r = jax.jit(vecdot)(a, b)
+        assert jnp.isclose(r.value, 8003.0)
+        assert r.unit == _m * _s
+
+        # d/da_i of (a·b) carries the km→m conversion: [3, 4000] m·s.
+        grad_a = jax.grad(lambda av: vecdot(QMat(av, unit=(_m, _km)), b).value)(a.value)
+        assert jnp.allclose(grad_a, jnp.array([3.0, 4000.0]))
+
+        ab = QMat(jnp.stack([a.value, a.value]), unit=(_m, _km))
+        bb = QMat(jnp.stack([b.value, b.value]), unit=(_s, _s))
+        assert jax.vmap(vecdot)(ab, bb).value.shape == (2,)
+
     def test_batched_plain_and_quantity_operands(self):
         """A *batched* plain / Quantity vector is not mis-classified as a matrix."""
         A = QMat(jnp.ones((2, 2, 2)), unit=((_m, _m), (_m, _m)))
@@ -1274,7 +1352,24 @@ class TestAffineProductUnitsRejected:
     If astropy ever starts accepting affine product conversions, these
     tests will *fail* — that's intentional: it means the assumption
     behind ``scale_3d`` must be revisited.
+
+    The astropy-level checks below pin the *premise*; ``test_real_matmul_*``
+    pins the *conclusion* by driving a real ``QuantityMatrix @ QuantityMatrix``
+    through the actual dot-general code path.
     """
+
+    def test_real_matmul_affine_units_raises(self):
+        """A real QM @ QM whose contraction needs an affine conversion raises.
+
+        The contraction reference unit is ``°C·s`` (k=0); the ``°F·s`` term
+        (k=1) must convert to it, which astropy rejects — so the whole
+        product raises rather than silently mis-scaling.
+        """
+        degC, degF = apu.deg_C, imperial.deg_F
+        a = QMat(jnp.array([[1.0, 1.0]]), unit=((degC, degF),))
+        b = QMat(jnp.array([[1.0], [1.0]]), unit=((_s,), (_s,)))
+        with pytest.raises(apu.UnitConversionError, match="not convertible"):
+            _matmul(a, b)
 
     def test_degC_times_s_not_convertible(self):
         """°C·s → °F·s must fail (affine offset is undefined for products)."""
@@ -1527,6 +1622,27 @@ class TestDiagAndGather:
         assert jnp.allclose(d.value, jnp.array([1, 4, 9]))
         assert d.unit.ndim == 1
         assert all(d.unit[i] == _m for i in range(3))
+
+    def test_diag_under_jit_heterogeneous_units_rejected(self):
+        """qnp.diag under jit cannot resolve traced indices for mixed units."""
+        A = QMat(jnp.eye(2), unit=((_m, _s), (_m, _s)))
+        with pytest.raises(ValueError, match="units to be equal"):
+            jax.jit(_diag)(A)
+
+    def test_gather_non_element_selection_rejected(self):
+        """A window (non element-selection) gather is rejected, not mislabelled."""
+        qm = QMat(jnp.arange(8.0).reshape(4, 2), unit=(_m, _m))
+        # A slice/window gather: offset_dims is non-empty (selects full rows).
+        dnums = lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)
+        )
+        with pytest.raises(NotImplementedError, match="element-selection"):
+            gather_qm(
+                qm,
+                jnp.array([[0], [2]]),
+                dimension_numbers=dnums,
+                slice_sizes=(1, 2),
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1945,6 +2061,13 @@ class TestQuantityMatrixTranspose:
         with pytest.raises(ValueError, match="requires a 2-D matrix"):
             _ = qm_1d.T
 
+    def test_nonstandard_permutation_rejected(self):
+        """A transpose that reorders batch axes (not the last two) is rejected."""
+        a = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_kg, _rad)))
+        # swapaxes(0, 1) permutes a batch axis into the logical block.
+        with pytest.raises(NotImplementedError, match="last two axes"):
+            quax.quaxify(lambda x: jnp.swapaxes(x, 0, 1))(a)
+
 
 # ---------------------------------------------------------------------------
 # det_p custom primitive + Quax dispatch for QuantityMatrix
@@ -2084,6 +2207,30 @@ class TestDetQuantityMatrix:
         assert jnp.allclose(result.value, 6)
         assert result.unit == u.unit("m2")
 
+    def test_grad_QuantityMatrix(self):
+        """Grad flows through the QuantityMatrix det dispatch, not just plain arrays."""
+
+        def loss(mat_val):
+            A = QMat(mat_val, unit=((_m, _m), (_m, _m)))
+            return quax.quaxify(qm_det)(A).value
+
+        base = jnp.array([[2.0, 0.0], [0.0, 3.0]])
+        # ∂det/∂A = det(A)·A⁻ᵀ = diag(3, 2) for diag(2, 3).
+        assert jnp.allclose(jax.grad(loss)(base), jnp.array([[3.0, 0.0], [0.0, 2.0]]))
+
+    def test_vmap_QuantityMatrix(self):
+        """Vmap maps det over a batch of QuantityMatrix values (unit preserved)."""
+        vals = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 3.0])), jnp.diag(jnp.array([4.0, 5.0]))]
+        )
+
+        def one(mat_val):
+            return quax.quaxify(qm_det)(QMat(mat_val, unit=((_m, _m), (_m, _m))))
+
+        out = jax.vmap(one)(vals)
+        assert jnp.allclose(out.value, jnp.array([6.0, 20.0]))
+        assert out.unit == u.unit("m2")
+
 
 # ---------------------------------------------------------------------------
 # inv_p custom primitive + Quax dispatch for QuantityMatrix
@@ -2208,6 +2355,12 @@ class TestInvQuantityMatrix:
         with pytest.raises(ValueError, match="uniform units"):
             quax.quaxify(qm_inv)(A)
 
+    def test_non_2d_rejected(self):
+        """Inv of a 1-D (vector) QuantityMatrix raises: a matrix inverse needs 2-D."""
+        v = QMat(jnp.array([1.0, 2.0]), unit=(_m, _m))
+        with pytest.raises(ValueError, match="2-D unit structure"):
+            quax.quaxify(qm_inv)(v)
+
     def test_returns_QuantityMatrix(self):
         """Inv of a 2×2 QuantityMatrix returns a QuantityMatrix."""
         A = QMat(jnp.array([[4, 0], [0, 1]]), unit=((_m, _m), (_m, _m)))
@@ -2242,6 +2395,31 @@ class TestInvQuantityMatrix:
         result = jax.jit(quax.quaxify(qm_inv))(A)
         assert jnp.allclose(result.value, jnp.array([[0.25, 0.0], [0.0, 1.0]]))
         assert result.unit[0, 0] == u.unit("1 / m")
+
+    def test_grad_QuantityMatrix(self):
+        """Grad flows through the QuantityMatrix inv dispatch (value path)."""
+
+        def loss(mat_val):
+            A = QMat(mat_val, unit=((_m, _m), (_m, _m)))
+            return jnp.sum(quax.quaxify(qm_inv)(A).value)
+
+        base = jnp.array([[2.0, 0.0], [0.0, 4.0]])
+        # Compare against grad of the plain-array reference.
+        expected = jax.grad(lambda a: jnp.sum(jnp.linalg.inv(a)))(base)
+        assert jnp.allclose(jax.grad(loss)(base), expected, atol=1e-6)
+
+    def test_vmap_QuantityMatrix(self):
+        """Vmap maps inv over a batch of QuantityMatrix values (unit preserved)."""
+        vals = jnp.stack(
+            [jnp.diag(jnp.array([2.0, 4.0])), jnp.diag(jnp.array([1.0, 2.0]))]
+        )
+
+        def one(mat_val):
+            return quax.quaxify(qm_inv)(QMat(mat_val, unit=((_m, _m), (_m, _m))))
+
+        out = jax.vmap(one)(vals)
+        assert jnp.allclose(out.value, jax.vmap(jnp.linalg.inv)(vals))
+        assert out.unit[0, 0] == u.unit("1 / m")
 
     def test_roundtrip_identity(self):
         """A @ inv(A) ≈ I for a QuantityMatrix (value check)."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -221,13 +221,23 @@ class TestUnitsMatrix:
     """Tests for the ``UnitsMatrix`` object-array-backed unit structure."""
 
     def test_bare_string_rejected(self):
-        """A bare string is rejected (would otherwise split into per-char units)."""
-        with pytest.raises(TypeError, match="bare string"):
+        """A bare unit string is rejected (else it splits into per-char units)."""
+        with pytest.raises(TypeError, match="bare unit string"):
             UnitsMatrix("ms")
-        with pytest.raises(TypeError, match="bare string"):
+        with pytest.raises(TypeError, match="bare unit string"):
             UnitsMatrix("m")
         # The intended single-unit form works.
         assert UnitsMatrix(("ms",)).shape == (1,)
+
+    def test_repr_roundtrips(self):
+        """The structural repr / to_string form is accepted back as a constructor."""
+        for m in (
+            UnitsMatrix((_m, _s, _kg)),
+            UnitsMatrix(((_m, _s), (_kg, _m))),
+            UnitsMatrix((_m,)),
+        ):
+            assert UnitsMatrix(m.to_string()) == m
+            assert eval(repr(m)) == m  # noqa: S307
 
     def test_not_isinstance_structured_unit(self):
         """UnitsMatrix is NOT a StructuredUnit — it is a standalone class."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -956,6 +956,21 @@ class TestProducts:
         rv = jax.vmap(matvec)(Ab, vb)
         assert jnp.allclose(rv.value, jnp.array([[3.0, 7.0], [6.0, 14.0]]))
 
+    def test_batched_plain_and_quantity_operands(self):
+        """A *batched* plain / Quantity vector is not mis-classified as a matrix."""
+        A = QMat(jnp.ones((2, 2, 2)), unit=((_m, _m), (_m, _m)))
+        vvals = jnp.array([[0.0, 1.0], [2.0, 3.0]])  # (B=2, K=2) batched vector
+        ref = matvec(A, QMat(vvals, unit=(_dimless, _dimless))).value
+
+        # plain array on the right (dot_general_qm_arr)
+        assert jnp.allclose(matvec(A, vvals).value, ref)
+        # Quantity on the right (dot_general_qm_qty)
+        w_qty = matvec(A, u.Q(vvals, "kg"))
+        assert w_qty.value.shape == (2, 2)
+        assert w_qty.unit == (_m * _kg, _m * _kg)
+        # plain array on the left, vecmat (dot_general_arr_qm) — was silently (2,2,2)
+        assert vecmat(jnp.ones((2, 2)), A).value.shape == (2, 2)
+
 
 # ---------------------------------------------------------------------------
 # The `@` operator (QuantityMatrix.__matmul__)

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -24,6 +24,7 @@ from unxts.linalg._src import (
     det as qm_det,
     inv as qm_inv,
 )
+from unxts.linalg._src._register_primitives import _wrap_operand
 
 import quaxed.numpy as qnp
 
@@ -924,6 +925,12 @@ class TestProducts:
         d = vecdot(a, b)
         assert d.value.shape == (2,)
         assert jnp.allclose(d.value, jnp.array([8003.0, 8003.0]))
+
+    def test_wrap_operand_rejects_unsupported_rank(self):
+        """The operand-wrapper raises a clear error for non vector/matrix ranks."""
+        # logical ndim 3 (no batch axes) -> not a vector or matrix
+        with pytest.raises(NotImplementedError, match=r"vector .* or matrix"):
+            _wrap_operand(jnp.ones((2, 2, 2)), _dimless, ())
 
     def test_nonstandard_dot_general_rejected(self):
         """A non-matmul dot_general contraction is rejected, not mis-propagated."""
@@ -1952,6 +1959,13 @@ class TestInvPrimitive:
         A = jnp.array([[2.0, 0.0], [0.0, 4.0]])
         result = jax.jit(qm_inv)(A)
         assert jnp.allclose(result, jnp.linalg.inv(A))
+
+    def test_inv_jit_integer_dtype(self):
+        """Integer input promotes to inexact under jit (abstract eval must match)."""
+        A = jnp.array([[2, 0], [0, 4]], dtype=jnp.int32)
+        result = jax.jit(qm_inv)(A)  # would fail lowering if abstract dtype disagreed
+        assert jnp.issubdtype(result.dtype, jnp.inexact)
+        assert jnp.allclose(result, jnp.array([[0.5, 0.0], [0.0, 0.25]]))
 
     def test_inv_jvp(self):
         """Forward-mode derivative of A^{-1}: d(A^{-1})(dA) = -A^{-1} dA A^{-1}."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -820,19 +820,38 @@ class TestProducts:
         assert jnp.allclose(w.value, jnp.array([[3.0, 7.0], [11.0, 15.0]]))
         assert w.unit == (_m * _s, _m * _s)
 
-    def test_matmul_cannot_do_batched_matvec(self):
-        """Matmul can't express a batched matrix-vector product.
+    def test_matmul_rejects_batched_matvec(self):
+        """Matmul rejects a batched vector operand with a pointer to matvec.
 
-        A batched vector's value ``(B, K)`` is indistinguishable from a matrix,
-        so matmul tries to contract mismatched axes (here N=2 != K=3) and raises.
-        This is exactly why ``matvec`` exists.
+        A batched vector's value ``(B, K)`` is indistinguishable from a matrix.
+        Without the guard, matmul silently returns the matvec answer for square
+        batches (N==K==B) but raises for non-square shapes — an inconsistent
+        trap. The guard makes it consistently error in both cases.
         """
-        a = QMat(jnp.ones((2, 2, 3)), unit=((_m, _m, _m), (_m, _m, _m)))
-        v = QMat(jnp.ones((2, 3)), unit=(_s, _s, _s))
-        with pytest.raises(TypeError):
-            matmul(a, v)
-        # matvec handles it fine.
-        assert matvec(a, v).shape == (2, 2)
+        # Square batch (N==K==B) — this used to *silently succeed*.
+        a_sq = QMat(jnp.ones((2, 2, 2)), unit=((_m, _m), (_m, _m)))
+        v_sq = QMat(jnp.ones((2, 2)), unit=(_s, _s))
+        with pytest.raises(ValueError, match="matvec"):
+            matmul(a_sq, v_sq)
+        # Non-square batch.
+        a_ns = QMat(jnp.ones((2, 2, 3)), unit=((_m, _m, _m), (_m, _m, _m)))
+        v_ns = QMat(jnp.ones((2, 3)), unit=(_s, _s, _s))
+        with pytest.raises(ValueError, match="matvec"):
+            matmul(a_ns, v_ns)
+        # matvec handles both.
+        assert matvec(a_sq, v_sq).shape == (2, 2)
+        assert matvec(a_ns, v_ns).shape == (2, 2)
+
+    def test_matmul_guard_is_narrow(self):
+        """The guard only rejects *batched* vectors, not the valid matmul cases."""
+        # Unbatched matrix @ vector: matmul promotes the 1-D vector — allowed.
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+        assert matmul(A, v).value.shape == (2,)
+        # Batched matrix @ matrix — allowed.
+        Ab = QMat(jnp.ones((3, 2, 2)), unit=((_m, _m), (_m, _m)))
+        Bb = QMat(jnp.ones((3, 2, 2)), unit=((_s, _s), (_s, _s)))
+        assert matmul(Ab, Bb).value.shape == (3, 2, 2)
 
     def test_vecmat_unbatched(self):
         """vecmat(vector, matrix) → vector (transpose of matvec)."""
@@ -868,6 +887,38 @@ class TestProducts:
         d = vecdot(a, b)
         assert d.value.shape == (2,)
         assert jnp.allclose(d.value, jnp.array([8003.0, 8003.0]))
+
+    def test_vecmat_unit_conversion(self):
+        """Vecmat converts mixed units within each output column."""
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_kg, _kg))
+        # Column 0 mixes m (row 0) and km (row 1) -> km converted to m.
+        a = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _s), (_km, _s)))
+        w = vecmat(v, a)
+        # col 0: 1*1 kg*m + 1*3 kg*km -> 1 + 3000 = 3001 (in kg*m)
+        # col 1: 1*2 kg*s + 1*4 kg*s = 6 (in kg*s)
+        assert jnp.allclose(w.value, jnp.array([3001.0, 6.0]))
+        assert w.unit == (_kg * _m, _kg * _s)
+
+    def test_matvec_under_transforms(self):
+        """Matvec composes with jit / grad / vmap (values + units preserved)."""
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+
+        r = jax.jit(matvec)(A, v)
+        assert jnp.allclose(r.value, jnp.array([3.0, 7.0]))
+        assert r.unit == (_m * _s, _m * _s)
+
+        def loss(mat_val):
+            AA = QMat(mat_val, unit=((_m, _m), (_m, _m)))
+            return jnp.sum(matvec(AA, v).value)
+
+        # d/dA_ij of sum(A @ [1, 1]) is 1 everywhere.
+        assert jnp.allclose(jax.grad(loss)(A.value), jnp.ones((2, 2)))
+
+        Ab = QMat(jnp.stack([A.value, 2 * A.value]), unit=((_m, _m), (_m, _m)))
+        vb = QMat(jnp.stack([v.value, v.value]), unit=(_s, _s))
+        rv = jax.vmap(matvec)(Ab, vb)
+        assert jnp.allclose(rv.value, jnp.array([[3.0, 7.0], [6.0, 14.0]]))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -10,7 +10,14 @@ import plum
 import pytest
 import quax
 from astropy.units import imperial  # registers °F
-from unxts.linalg import QuantityMatrix as QMat, UnitsMatrix
+from unxts.linalg import (
+    QuantityMatrix as QMat,
+    UnitsMatrix,
+    matmul,
+    matvec,
+    vecdot,
+    vecmat,
+)
 from unxts.linalg._src import (
     _convert_value_matrix,
     _convert_value_vector,
@@ -774,6 +781,93 @@ class TestDotProduct:
         assert jnp.isclose(result.value[0], 23)
         assert jnp.isclose(result.value[1], 67)
         assert jnp.isclose(result.value[2], 127)
+
+
+# ---------------------------------------------------------------------------
+# Public products: matmul / matvec / vecmat / vecdot
+# ---------------------------------------------------------------------------
+
+
+class TestProducts:
+    """The batch-safe `unxts.linalg` matrix/vector product wrappers."""
+
+    def test_matmul_2d_2d(self):
+        """matmul(matrix, matrix) → matrix, with per-element units."""
+        a = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        b = QMat(jnp.eye(2), unit=((_s, _s), (_s, _s)))
+        r = matmul(a, b)
+        assert jnp.allclose(r.value, a.value)  # times identity
+        ms = _m * _s
+        assert r.unit == ((ms, ms), (ms, ms))
+
+    def test_matvec_unbatched(self):
+        """matvec(matrix, vector) → vector."""
+        a = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+        w = matvec(a, v)
+        assert w.ndim == 1
+        assert jnp.allclose(w.value, jnp.array([3.0, 7.0]))
+        assert w.unit == (_m * _s, _m * _s)
+
+    def test_matvec_batched(self):
+        """A batch of matrices applied to a batch of vectors (per batch element)."""
+        a_val = jnp.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+        a = QMat(a_val, unit=((_m, _m), (_m, _m)))
+        v = QMat(jnp.array([[1.0, 1.0], [1.0, 1.0]]), unit=(_s, _s))
+        w = matvec(a, v)
+        assert w.shape == (2, 2)
+        # b0: [1+2, 3+4]=[3,7]; b1: [5+6, 7+8]=[11,15]
+        assert jnp.allclose(w.value, jnp.array([[3.0, 7.0], [11.0, 15.0]]))
+        assert w.unit == (_m * _s, _m * _s)
+
+    def test_matmul_cannot_do_batched_matvec(self):
+        """Matmul can't express a batched matrix-vector product.
+
+        A batched vector's value ``(B, K)`` is indistinguishable from a matrix,
+        so matmul tries to contract mismatched axes (here N=2 != K=3) and raises.
+        This is exactly why ``matvec`` exists.
+        """
+        a = QMat(jnp.ones((2, 2, 3)), unit=((_m, _m, _m), (_m, _m, _m)))
+        v = QMat(jnp.ones((2, 3)), unit=(_s, _s, _s))
+        with pytest.raises(TypeError):
+            matmul(a, v)
+        # matvec handles it fine.
+        assert matvec(a, v).shape == (2, 2)
+
+    def test_vecmat_unbatched(self):
+        """vecmat(vector, matrix) → vector (transpose of matvec)."""
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+        a = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _km), (_m, _km)))
+        w = vecmat(v, a)
+        assert w.ndim == 1
+        assert jnp.allclose(w.value, jnp.array([4.0, 6.0]))
+        assert w.unit == (_s * _m, _s * _km)
+
+    def test_vecmat_batched(self):
+        """A batch of vectors times a batch of matrices."""
+        v = QMat(jnp.ones((2, 2)), unit=(_s, _s))
+        a_val = jnp.broadcast_to(jnp.array([[1.0, 2.0], [3.0, 4.0]]), (2, 2, 2))
+        a = QMat(a_val, unit=((_m, _km), (_m, _km)))
+        w = vecmat(v, a)
+        assert w.shape == (2, 2)
+        assert jnp.allclose(w.value, jnp.array([[4.0, 6.0], [4.0, 6.0]]))
+
+    def test_vecdot_unbatched(self):
+        """vecdot(vector, vector) → scalar Quantity."""
+        a = QMat(jnp.array([1.0, 2.0]), unit=(_m, _km))
+        b = QMat(jnp.array([3.0, 4.0]), unit=(_s, _s))
+        d = vecdot(a, b)
+        # 1*3 m*s + 2*4 km*s = 3 + 8000 = 8003 m*s
+        assert jnp.isclose(d.value, 8003.0)
+        assert d.unit == _m * _s
+
+    def test_vecdot_batched(self):
+        """Batched vector dot product."""
+        a = QMat(jnp.array([[1.0, 2.0], [1.0, 2.0]]), unit=(_m, _km))
+        b = QMat(jnp.array([[3.0, 4.0], [3.0, 4.0]]), unit=(_s, _s))
+        d = vecdot(a, b)
+        assert d.value.shape == (2,)
+        assert jnp.allclose(d.value, jnp.array([8003.0, 8003.0]))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -93,6 +93,24 @@ def unit_1d_alt():
 class TestConstruction:
     """Tests for QuantityMatrix construction and basic properties."""
 
+    def test_value_unit_shape_mismatch_rejected(self):
+        """Value's trailing shape must match the unit structure."""
+        # 1-D: value length 3 vs unit length 2
+        with pytest.raises(ValueError, match="does not match"):
+            QMat(jnp.array([1.0, 2.0, 3.0]), unit=(_m, _s))
+        # 2-D: value (2, 2) vs unit (2, 3)
+        with pytest.raises(ValueError, match="does not match"):
+            QMat(jnp.ones((2, 2)), unit=((_m, _s, _kg), (_m, _s, _kg)))
+        # value has fewer dims than the unit structure
+        with pytest.raises(ValueError, match="fewer"):
+            QMat(jnp.array([1.0, 2.0]), unit=((_m, _s),))
+
+    def test_leading_batch_dims_allowed(self):
+        """Extra *leading* axes are batch dims and are accepted."""
+        qm = QMat(jnp.ones((5, 3, 2, 2)), unit=((_m, _s), (_kg, _m)))
+        assert qm.shape == (5, 3, 2, 2)
+        assert qm.ndim == 2  # logical
+
     def test_shape(self, qm_2x2):
         assert qm_2x2.shape == (2, 2)
 
@@ -201,6 +219,15 @@ class TestConstruction:
 
 class TestUnitsMatrix:
     """Tests for the ``UnitsMatrix`` object-array-backed unit structure."""
+
+    def test_bare_string_rejected(self):
+        """A bare string is rejected (would otherwise split into per-char units)."""
+        with pytest.raises(TypeError, match="bare string"):
+            UnitsMatrix("ms")
+        with pytest.raises(TypeError, match="bare string"):
+            UnitsMatrix("m")
+        # The intended single-unit form works.
+        assert UnitsMatrix(("ms",)).shape == (1,)
 
     def test_not_isinstance_structured_unit(self):
         """UnitsMatrix is NOT a StructuredUnit — it is a standalone class."""
@@ -887,6 +914,15 @@ class TestProducts:
         d = vecdot(a, b)
         assert d.value.shape == (2,)
         assert jnp.allclose(d.value, jnp.array([8003.0, 8003.0]))
+
+    def test_nonstandard_dot_general_rejected(self):
+        """A non-matmul dot_general contraction is rejected, not mis-propagated."""
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        B = QMat(jnp.array([[1.0, 0.0], [0.0, 1.0]]), unit=((_s, _s), (_s, _s)))
+        # Contract the *first* axes (not the standard last/second-last).
+        bad = quax.quaxify(lambda a, b: jnp.tensordot(a, b, axes=([0], [0])))
+        with pytest.raises(NotImplementedError, match="standard"):
+            bad(A, B)
 
     def test_vecmat_unit_conversion(self):
         """Vecmat converts mixed units within each output column."""
@@ -1970,6 +2006,12 @@ class TestInvPrimitive:
 
 class TestInvQuantityMatrix:
     """Tests for inv_p Quax dispatch on QuantityMatrix."""
+
+    def test_heterogeneous_units_rejected(self):
+        """Inv requires uniform units; a matrix inverse isn't elementwise."""
+        A = QMat(jnp.array([[2.0, 0.0], [0.0, 3.0]]), unit=((_m, _s), (_kg, _m)))
+        with pytest.raises(ValueError, match="uniform units"):
+            quax.quaxify(qm_inv)(A)
 
     def test_returns_QuantityMatrix(self):
         """Inv of a 2×2 QuantityMatrix returns a QuantityMatrix."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -24,7 +24,7 @@ from unxts.linalg._src import (
     det as qm_det,
     inv as qm_inv,
 )
-from unxts.linalg._src._register_primitives import _wrap_operand
+from unxts.linalg._src._register_primitives import _check_contract, _wrap_operand
 
 import quaxed.numpy as qnp
 
@@ -257,6 +257,13 @@ class TestUnitsMatrix:
         ):
             assert UnitsMatrix(m.to_string()) == m
             assert eval(repr(m)) == m  # noqa: S307
+
+    def test_unbalanced_parens_rejected(self):
+        """A structural string with unbalanced parentheses raises ValueError."""
+        with pytest.raises(ValueError, match="Unbalanced"):
+            UnitsMatrix("(a, (b)")  # unmatched '('
+        with pytest.raises(ValueError, match="Unbalanced"):
+            UnitsMatrix("(), )")  # unmatched ')'
 
     def test_not_isinstance_structured_unit(self):
         """UnitsMatrix is NOT a StructuredUnit — it is a standalone class."""
@@ -943,6 +950,12 @@ class TestProducts:
         d = vecdot(a, b)
         assert d.value.shape == (2,)
         assert jnp.allclose(d.value, jnp.array([8003.0, 8003.0]))
+
+    def test_check_contract_raises_on_mismatch(self):
+        """Contraction validation raises ValueError (not a strippable assert)."""
+        _check_contract(3, 3)  # ok
+        with pytest.raises(ValueError, match="contraction mismatch"):
+            _check_contract(2, 3)
 
     def test_wrap_operand_rejects_unsupported_rank(self):
         """The operand-wrapper raises a clear error for non vector/matrix ranks."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -1597,6 +1597,36 @@ class TestDiagAndGather:
         assert d.unit[1] == _s  # unit[1, 1]
         assert d.unit[2] == _kg  # unit[2, 2]
 
+    def test_multidim_advanced_indexing_units(self):
+        """2-D index arrays give a 2-D output whose units match element-by-element.
+
+        JAX packs the indices as ``(*index_shape, index_vector_dim)``; the unit
+        lookup must index the last axis (``idx[..., k]``) and carry the full
+        ``index_shape``, not just its first entry.
+        """
+        A = QMat(jnp.arange(4.0).reshape(2, 2), unit=((_m, _s), (_kg, _rad)))
+        ii = jnp.array([[0, 1], [1, 0]])
+        jj = jnp.array([[0, 0], [1, 1]])
+
+        r = quax.quaxify(lambda a: a[ii, jj])(A)
+        # value[a,b] = A.value[ii[a,b], jj[a,b]]
+        assert jnp.allclose(r.value, jnp.array([[0.0, 2.0], [3.0, 1.0]]))
+        # unit[a,b] = A.unit[ii[a,b], jj[a,b]]
+        assert r.unit.shape == (2, 2)
+        assert r.unit[0, 0] == _m  # (0,0)
+        assert r.unit[0, 1] == _kg  # (1,0)
+        assert r.unit[1, 0] == _rad  # (1,1)
+        assert r.unit[1, 1] == _s  # (0,1)
+
+    def test_2d_index_into_1d_quantity_matrix(self):
+        """A 2-D index array on a 1-D QuantityMatrix yields a 2-D unit structure."""
+        v = QMat(jnp.arange(4.0), unit=(_m, _s, _kg, _rad))
+        r = quax.quaxify(lambda a: a[jnp.array([[0, 1], [2, 3]])])(v)
+        assert jnp.allclose(r.value, jnp.array([[0.0, 1.0], [2.0, 3.0]]))
+        assert r.unit.shape == (2, 2)
+        assert r.unit[0, 0] == _m
+        assert r.unit[1, 1] == _rad
+
     def test_diag_dimensionless_unit_string(self):
         """Dimensionless diagonal has '(, , )'-style repr, not '((, , ), ...)'."""
         A = QMat(

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -1195,6 +1195,25 @@ class TestProducts:
         bb = QMat(jnp.stack([b.value, b.value]), unit=(_s, _s))
         assert jax.vmap(vecdot)(ab, bb).value.shape == (2,)
 
+    def test_products_preserve_operand_dtype(self):
+        """Unit-conversion scale factors must not upcast the result dtype.
+
+        ``uconvert_value`` returns Python floats, so a naive ``jnp.array`` of
+        the scales is float64 under ``jax_enable_x64``; casting the scales to
+        the operand result dtype avoids surprise promotion. Tested here with
+        float16 inputs (the same upcast mechanism, but visible under x32).
+        """
+        f16 = lambda x: jnp.asarray(x, jnp.float16)
+        a = QMat(f16([1.0, 2.0]), unit=(_m, _km))
+        b = QMat(f16([3.0, 4.0]), unit=(_s, _s))
+        A = QMat(f16([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _km), (_m, _km)))
+        v = QMat(f16([1.0, 1.0]), unit=(_s, _s))
+        B = QMat(f16([[1.0, 2.0], [3.0, 4.0]]), unit=((_s, _s), (_s, _s)))
+        assert vecdot(a, b).value.dtype == jnp.float16
+        assert matvec(A, v).value.dtype == jnp.float16
+        assert vecmat(v, A).value.dtype == jnp.float16
+        assert matmul(A, B).value.dtype == jnp.float16
+
     def test_batched_plain_and_quantity_operands(self):
         """A *batched* plain / Quantity vector is not mis-classified as a matrix."""
         A = QMat(jnp.ones((2, 2, 2)), unit=((_m, _m), (_m, _m)))
@@ -1627,6 +1646,33 @@ class TestDiagAndGather:
         assert r.unit.shape == (2, 2)
         assert r.unit[0, 0] == _m
         assert r.unit[1, 1] == _rad
+
+    def test_scalar_output_gather_returns_quantity(self):
+        """A scalar-output gather (index_shape == ()) returns a scalar Quantity.
+
+        A single element has a single unit; UnitsMatrix only represents 1-D/2-D
+        structures, so the handler returns a plain Quantity for scalar output.
+        """
+        A = QMat(jnp.arange(4.0).reshape(2, 2), unit=((_m, _s), (_kg, _rad)))
+        dnums = lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0, 1), start_index_map=(0, 1)
+        )
+        # select element (1, 0) -> value 2.0, unit kg
+        r = gather_qm(A, jnp.array([1, 0]), dimension_numbers=dnums, slice_sizes=(1, 1))
+        assert isinstance(r, u.AbstractQuantity)
+        assert not isinstance(r, QMat)
+        assert jnp.allclose(r.value, 2.0)
+        assert r.unit == _kg
+        # 1-D QuantityMatrix scalar select
+        v = QMat(jnp.arange(3.0), unit=(_m, _s, _kg))
+        dn1 = lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)
+        )
+        r1 = gather_qm(v, jnp.array([2]), dimension_numbers=dn1, slice_sizes=(1,))
+        assert isinstance(r1, u.AbstractQuantity)
+        assert not isinstance(r1, QMat)
+        assert jnp.allclose(r1.value, 2.0)
+        assert r1.unit == _kg
 
     def test_diag_dimensionless_unit_string(self):
         """Dimensionless diagonal has '(, , )'-style repr, not '((, , ), ...)'."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -771,14 +771,41 @@ class TestReduceSum:
         assert r.unit == ((_m, _s), (_kg, _rad))  # unchanged
 
     def test_logical_row_and_col_reduction(self):
-        qm = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_kg, _rad)))
-        # axis 1 is the logical row axis (n_batch=1) -> first row's units
-        row = quax.quaxify(lambda a: jnp.sum(a, axis=1))(qm)
+        # Units must be dimensionally uniform along the *summed* axis. For row
+        # reduction (axis 1) each column is uniform-dimension; the output takes
+        # the first row's units.
+        qm = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_km, _s)))
+        row = quax.quaxify(lambda a: jnp.sum(a, axis=1))(qm)  # logical rows
         assert row.value.shape == (3, 2)
         assert row.unit == (_m, _s)
-        # axis 2 is the logical col axis -> first column's units
-        col = quax.quaxify(lambda a: jnp.sum(a, axis=2))(qm)
-        assert col.unit == (_m, _kg)
+        # For column reduction (axis 2) each row is uniform-dimension; the
+        # output takes the first column's units.
+        qm2 = QMat(jnp.ones((3, 2, 2)), unit=((_m, _km), (_s, _s)))
+        col = quax.quaxify(lambda a: jnp.sum(a, axis=2))(qm2)  # logical cols
+        assert col.value.shape == (3, 2)
+        assert col.unit == (_m, _s)
+
+    def test_row_reduction_converts_compatible_units(self):
+        """A column of compatible-but-different units is converted, not relabelled."""
+        # column 0 has units [m, km]; summing must give 1 m + 1 km = 1001 m.
+        qm = QMat(jnp.array([[1.0, 1.0], [1.0, 1.0]]), unit=((_m, _s), (_km, _s)))
+        row = quax.quaxify(lambda a: jnp.sum(a, axis=0))(qm)
+        assert row.unit == (_m, _s)
+        assert jnp.allclose(row.value, jnp.array([1001.0, 2.0]))
+
+    def test_col_reduction_converts_compatible_units(self):
+        """A row of compatible-but-different units is converted before summing."""
+        # row 0 has units [km, m]; summing must give 1 km + 1000 m = 2 km.
+        qm = QMat(jnp.array([[1.0, 1000.0], [1.0, 1.0]]), unit=((_km, _m), (_km, _m)))
+        col = quax.quaxify(lambda a: jnp.sum(a, axis=1))(qm)
+        assert col.unit == (_km, _km)
+        assert jnp.allclose(col.value, jnp.array([2.0, 1.001]))
+
+    def test_reduction_incompatible_units_raises(self):
+        """Summing a column of dimensionally incompatible units raises."""
+        qm = QMat(jnp.array([[1.0, 1.0], [1.0, 1.0]]), unit=((_m, _s), (_kg, _s)))
+        with pytest.raises(Exception, match=r"(?i)convert|unit"):
+            quax.quaxify(lambda a: jnp.sum(a, axis=0))(qm)
 
 
 # ---------------------------------------------------------------------------
@@ -1985,6 +2012,19 @@ class TestDetPrimitive:
         results = jax.vmap(qm_det)(A)
         expected = jnp.array([6.0, 20.0])
         assert jnp.allclose(results, expected)
+
+    def test_det_grad_batched(self):
+        """Grad over a *batched* det sums matches jnp.linalg.det.
+
+        The JVP traces the two matrix axes (not the leading batch axis); a
+        regression guard for that trace axis choice.
+        """
+        A = jnp.stack(
+            [jnp.array([[2.0, 1.0], [0.0, 3.0]]), jnp.array([[4.0, 0.0], [2.0, 5.0]])]
+        )
+        grad_custom = jax.grad(lambda mat: qm_det(mat).sum())(A)
+        grad_ref = jax.grad(lambda mat: jnp.linalg.det(mat).sum())(A)
+        assert jnp.allclose(grad_custom, grad_ref)
 
     def test_det_jit_vmap(self):
         """jit(vmap(det)) works correctly."""

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -112,6 +112,14 @@ class TestConstruction:
         assert qm.shape == (5, 3, 2, 2)
         assert qm.ndim == 2  # logical
 
+    def test_from_cdict_rejects_matrix_values(self):
+        """from_cdict rejects QuantityMatrix / UnitsMatrix values with a clear error."""
+        inner = QMat(jnp.array([1.0, 2.0]), unit=(_m, _s))
+        with pytest.raises(TypeError, match="scalar-unit"):
+            QMat.from_cdict({"a": inner})
+        with pytest.raises(TypeError, match="scalar-unit"):
+            QMat.from_cdict({"a": UnitsMatrix((_m, _s))})
+
     def test_batched_indexing_leaves_unit(self):
         """Indexing a batch axis reduces the value but keeps the unit structure."""
         qm = QMat(jnp.arange(12.0).reshape(3, 2, 2), unit=((_m, _s), (_kg, _m)))

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -922,6 +922,49 @@ class TestProducts:
 
 
 # ---------------------------------------------------------------------------
+# The `@` operator (QuantityMatrix.__matmul__)
+# ---------------------------------------------------------------------------
+
+
+class TestMatmulOperator:
+    """`@` dispatches on logical rank (NumPy semantics) and is batch-safe."""
+
+    def test_at_batched_matvec(self):
+        """A @ v with leading batch axes does matvec — matmul cannot."""
+        A = QMat(
+            jnp.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            unit=((_m, _m), (_m, _m)),
+        )
+        v = QMat(jnp.ones((2, 2)), unit=(_s, _s))
+        w = A @ v  # eager, no explicit quaxify needed
+        assert jnp.allclose(w.value, jnp.array([[3.0, 7.0], [11.0, 15.0]]))
+        assert w.unit == (_m * _s, _m * _s)
+        assert jnp.allclose(w.value, matvec(A, v).value)
+
+    def test_at_nonsquare_batched_matvec(self):
+        """The non-square batch that ``matmul`` rejects works via ``@``."""
+        A = QMat(jnp.ones((2, 2, 3)), unit=((_m, _m, _m), (_m, _m, _m)))
+        v = QMat(jnp.ones((2, 3)), unit=(_s, _s, _s))
+        assert (A @ v).shape == (2, 2)
+
+    def test_at_dispatch_by_rank(self):
+        """2D@2D→matmul, 1D@2D→vecmat, 1D@1D→vecdot (scalar)."""
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        B = QMat(jnp.eye(2), unit=((_s, _s), (_s, _s)))
+        assert (A @ B).ndim == 2  # matmul
+        v = QMat(jnp.array([1.0, 1.0]), unit=(_s, _s))
+        assert (v @ A).ndim == 1  # vecmat
+        a = QMat(jnp.array([1.0, 2.0]), unit=(_m, _km))
+        b = QMat(jnp.array([3.0, 4.0]), unit=(_s, _s))
+        assert jnp.isclose((a @ b).value, 8003.0)  # vecdot → scalar Quantity
+
+    def test_at_fallback_plain_array(self):
+        """QM @ plain array falls back to default handling (still works)."""
+        A = QMat(jnp.array([[1.0, 2.0], [3.0, 4.0]]), unit=((_m, _m), (_m, _m)))
+        assert (A @ jnp.array([1.0, 1.0])).value.shape == (2,)
+
+
+# ---------------------------------------------------------------------------
 # JAX integration
 # ---------------------------------------------------------------------------
 

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -753,6 +753,26 @@ class TestElementwiseMulDiv:
         assert jnp.allclose(r2.value, 2 * r.value)
 
 
+class TestReduceSum:
+    """lax.reduce_sum on a QuantityMatrix respects leading batch axes."""
+
+    def test_batch_axis_reduction_keeps_units(self):
+        qm = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_kg, _rad)))
+        r = quax.quaxify(lambda a: jnp.sum(a, axis=0))(qm)  # sum over batch
+        assert r.value.shape == (2, 2)
+        assert r.unit == ((_m, _s), (_kg, _rad))  # unchanged
+
+    def test_logical_row_and_col_reduction(self):
+        qm = QMat(jnp.ones((3, 2, 2)), unit=((_m, _s), (_kg, _rad)))
+        # axis 1 is the logical row axis (n_batch=1) -> first row's units
+        row = quax.quaxify(lambda a: jnp.sum(a, axis=1))(qm)
+        assert row.value.shape == (3, 2)
+        assert row.unit == (_m, _s)
+        # axis 2 is the logical col axis -> first column's units
+        col = quax.quaxify(lambda a: jnp.sum(a, axis=2))(qm)
+        assert col.unit == (_m, _kg)
+
+
 # ---------------------------------------------------------------------------
 # Dot product / matmul  (quax lax.dot_general_p)
 # ---------------------------------------------------------------------------

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -29,6 +29,7 @@ from unxts.linalg._src._register_primitives import (
     _check_contract,
     _wrap_operand,
     gather_qm,
+    transpose_qm,
 )
 
 import quaxed.numpy as qnp
@@ -2097,6 +2098,22 @@ class TestQuantityMatrixTranspose:
         # swapaxes(0, 1) permutes a batch axis into the logical block.
         with pytest.raises(NotImplementedError, match="last two axes"):
             quax.quaxify(lambda x: jnp.swapaxes(x, 0, 1))(a)
+
+    def test_identity_permutation_is_noop(self):
+        """An identity permutation is a no-op that preserves value and units.
+
+        Covers a 1-D vector (whose only permutation is ``(0,)``). ``jnp.transpose``
+        elides such no-ops before they reach the handler, so drive the handler
+        directly to confirm it does not raise on a valid identity transpose.
+        """
+        v = QMat(jnp.array([1.0, 2.0, 3.0]), unit=(_m, _s, _kg))
+        r = transpose_qm(v, permutation=(0,))
+        assert jnp.allclose(r.value, v.value)
+        assert r.unit == (_m, _s, _kg)
+        # jnp.transpose on a 1-D QuantityMatrix works end-to-end (no exception).
+        r2 = quax.quaxify(lambda a: jnp.transpose(a))(v)
+        assert jnp.allclose(r2.value, v.value)
+        assert r2.unit == (_m, _s, _kg)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,12 @@ backend-astropy = ["astropy>=6.0"]
 interop-gala = ["unxts.interop.gala"]
 interop-mpl = ["unxts.interop.matplotlib"]
 interop-xarray = ["unxts.interop.xarray"]
+linalg = ["unxts.linalg"]
 workspace = [
   "unxt[interop-gala,interop-mpl,interop-xarray]",
   "unxts.api",
   "unxts.hypothesis",
+  "unxts.linalg",
   "unxts.parametric",
 ]
 
@@ -140,6 +142,7 @@ workspace = [
   "unxts.interop.gala",
   "unxts.interop.matplotlib",
   "unxts.interop.xarray",
+  "unxts.linalg",
   "unxts.parametric",
 ]
 
@@ -338,6 +341,7 @@ namespace-packages = [
   "packages/unxts.interop.matplotlib/src/unxts/interop",
   "packages/unxts.interop.xarray/src/unxts",
   "packages/unxts.interop.xarray/src/unxts/interop",
+  "packages/unxts.linalg/src/unxts",
 ]
 
 [tool.ruff.lint]
@@ -378,6 +382,25 @@ ignore = [
   "N803",
   "N806",
   "PLC0415",
+]
+# `unxts.linalg` ports dense, doctest-heavy internal linear-algebra code. These
+# relaxations match how the module was written (private unit-array access, JAX
+# primitive registrations named `*_p_QuantityMatrix`, the `.T` transpose
+# property, and long doctest-output/error-message lines).
+"**packages/unxts.linalg/src/**" = [
+  "E501",   # Line too long (doctest output / error messages)
+  "EM101",  # Exception must not use a string literal
+  "EM102",  # Exception must not use an f-string literal
+  "N802",   # Function name should be lowercase (`.T`, `*_p_QuantityMatrix`)
+  "SLF001", # Private member access (`UnitsMatrix._units`, by design)
+  "TRY003", # Avoid specifying long messages outside the exception class
+  "TRY004", # Prefer `TypeError` (intentional `ValueError` for ragged/units)
+]
+"**packages/unxts.linalg/tests/**" = [
+  "D102",   # Missing docstring in public method
+  "N802",   # Test names embed `QuantityMatrix`/`1D`/`2D`
+  "RUF002", # Docstring contains ambiguous `×` (math notation)
+  "RUF003", # Comment contains ambiguous character
 ]
 "__init__.py" = ["F403"]
 "noxfile.py" = ["T20"]
@@ -429,6 +452,7 @@ unxt-hypothesis            = { workspace = true }
 "unxts.interop.gala"       = { workspace = true }
 "unxts.interop.matplotlib" = { workspace = true }
 "unxts.interop.xarray"     = { workspace = true }
+"unxts.linalg"             = { workspace = true }
 "unxts.parametric"         = { workspace = true }
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ members = [
     "unxts-interop-gala",
     "unxts-interop-matplotlib",
     "unxts-interop-xarray",
+    "unxts-linalg",
     "unxts-parametric",
 ]
 constraints = [{ name = "matplotlib", marker = "python_full_version >= '3.14'", specifier = ">=3.10.8" }]
@@ -4299,6 +4300,7 @@ all = [
     { name = "unxts-interop-gala" },
     { name = "unxts-interop-matplotlib" },
     { name = "unxts-interop-xarray" },
+    { name = "unxts-linalg" },
     { name = "unxts-parametric" },
 ]
 backend-astropy = [
@@ -4328,12 +4330,16 @@ interop-xarray = [
 k8s = [
     { name = "jax", extra = ["k8s"], marker = "extra == 'extra-4-unxt-k8s' or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cpu' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12') or (extra == 'extra-4-unxt-cuda' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda12' and extra == 'extra-4-unxt-cuda12-local') or (extra == 'extra-4-unxt-cuda12-local' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cpu' and extra != 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda' and extra != 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm') or (extra == 'extra-4-unxt-cuda12' and extra != 'extra-4-unxt-k8s' and extra == 'extra-4-unxt-rocm')" },
 ]
+linalg = [
+    { name = "unxts-linalg" },
+]
 workspace = [
     { name = "unxts-api" },
     { name = "unxts-hypothesis" },
     { name = "unxts-interop-gala" },
     { name = "unxts-interop-matplotlib" },
     { name = "unxts-interop-xarray" },
+    { name = "unxts-linalg" },
     { name = "unxts-parametric" },
 ]
 
@@ -4389,6 +4395,7 @@ dev = [
     { name = "unxts-interop-gala" },
     { name = "unxts-interop-matplotlib" },
     { name = "unxts-interop-xarray" },
+    { name = "unxts-linalg" },
     { name = "unxts-parametric" },
 ]
 docs = [
@@ -4462,6 +4469,7 @@ workspace = [
     { name = "unxts-interop-gala" },
     { name = "unxts-interop-matplotlib" },
     { name = "unxts-interop-xarray" },
+    { name = "unxts-linalg" },
     { name = "unxts-parametric" },
 ]
 
@@ -4503,13 +4511,16 @@ requires-dist = [
     { name = "unxts-interop-xarray", marker = "extra == 'all'", editable = "packages/unxts.interop.xarray" },
     { name = "unxts-interop-xarray", marker = "extra == 'interop-xarray'", editable = "packages/unxts.interop.xarray" },
     { name = "unxts-interop-xarray", marker = "extra == 'workspace'", editable = "packages/unxts.interop.xarray" },
+    { name = "unxts-linalg", marker = "extra == 'all'", editable = "packages/unxts.linalg" },
+    { name = "unxts-linalg", marker = "extra == 'linalg'", editable = "packages/unxts.linalg" },
+    { name = "unxts-linalg", marker = "extra == 'workspace'", editable = "packages/unxts.linalg" },
     { name = "unxts-parametric", marker = "extra == 'all'", editable = "packages/unxts.parametric" },
     { name = "unxts-parametric", marker = "extra == 'workspace'", editable = "packages/unxts.parametric" },
     { name = "wadler-lindig", specifier = ">=0.1.5" },
     { name = "xmmutablemap", specifier = ">=0.1" },
     { name = "zeroth", specifier = ">=1.0.0" },
 ]
-provides-extras = ["all", "backend-astropy", "cpu", "cuda", "cuda12", "cuda12-local", "interop-gala", "interop-mpl", "interop-xarray", "k8s", "workspace"]
+provides-extras = ["all", "backend-astropy", "cpu", "cuda", "cuda12", "cuda12-local", "interop-gala", "interop-mpl", "interop-xarray", "k8s", "linalg", "workspace"]
 
 [package.metadata.requires-dev]
 build = [{ name = "build", specifier = ">=1.3.0" }]
@@ -4559,6 +4570,7 @@ dev = [
     { name = "unxts-interop-gala", editable = "packages/unxts.interop.gala" },
     { name = "unxts-interop-matplotlib", editable = "packages/unxts.interop.matplotlib" },
     { name = "unxts-interop-xarray", editable = "packages/unxts.interop.xarray" },
+    { name = "unxts-linalg", editable = "packages/unxts.linalg" },
     { name = "unxts-parametric", editable = "packages/unxts.parametric" },
 ]
 docs = [
@@ -4628,6 +4640,7 @@ workspace = [
     { name = "unxts-interop-gala", editable = "packages/unxts.interop.gala" },
     { name = "unxts-interop-matplotlib", editable = "packages/unxts.interop.matplotlib" },
     { name = "unxts-interop-xarray", editable = "packages/unxts.interop.xarray" },
+    { name = "unxts-linalg", editable = "packages/unxts.linalg" },
     { name = "unxts-parametric", editable = "packages/unxts.parametric" },
 ]
 
@@ -4863,6 +4876,48 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-arraydiff", specifier = ">=0.6.1" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "pytest-env", specifier = ">=1.1.5" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
+]
+
+[[package]]
+name = "unxts-linalg"
+source = { editable = "packages/unxts.linalg" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jaxtyping" },
+    { name = "plum-dispatch" },
+    { name = "quax" },
+    { name = "unxt" },
+]
+
+[package.dev-dependencies]
+test = [
+    { name = "optional-dependencies" },
+    { name = "pytest" },
+    { name = "pytest-arraydiff" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-github-actions-annotate-failures" },
+    { name = "sybil", extra = ["pytest"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "equinox", specifier = ">=0.11.8" },
+    { name = "jaxtyping", specifier = ">=0.2.34" },
+    { name = "plum-dispatch", specifier = ">=2.5.7" },
+    { name = "quax", specifier = ">=0.2.0" },
+    { name = "unxt", editable = "." },
+]
+
+[package.metadata.requires-dev]
+test = [
+    { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },


### PR DESCRIPTION
## Summary

Introduces a new namespace package **`unxts.linalg`** providing `QuantityMatrix` (alias `QM`): a quantity container whose elements may each carry a **different** unit, backed by a single JAX array plus a static `UnitsMatrix`. It is the natural home for Jacobians, metric tensors, and change-of-basis matrices whose entries have mixed physical dimensions — cases a single-unit `unxt.Quantity` can't express.

The type is ported out of coordinax's internal `QMatrix` (it only ever depended on `unxt`/`equinox`/`jax`/`plum`). A follow-up coordinax PR will consume `unxts.linalg`, keeping a `QMatrix = QuantityMatrix` back-compat alias.

## What's included

**Package** (`packages/unxts.linalg/`, mirroring the `unxts.parametric` layout)
- Public API: `QuantityMatrix` (+ `QM` alias, mirroring `Q`/`PQ`), `UnitsMatrix`, `det`/`det_p`, `inv`/`inv_p`, `cdict_units`. Importing registers the Quax primitive rules (add/sub/matmul/transpose/gather/reduce-sum) and plum conversions/dispatch as side effects.
- `QMatrix` → `QuantityMatrix` rename; doctests re-pointed to `unxts.linalg` and aligned to unxt's **float32** doctest conventions.
- Workspace registration: `[tool.uv.sources]`, `workspace` group, ruff `namespace-packages` + scoped per-file-ignores, `linalg`/`workspace` extras, `conftest.py` `OptDeps` gate.

**Docs** (`packages/unxts.linalg/docs/`, hooked into the main docs index)
- Guides: quantity-matrix, units-matrix, linear-algebra, sharp-bits.
- Tutorial: a worked heterogeneous-metric example (`.diag`/`det`/`inv` with per-element units).

**CI/CD** — for **both** `unxts-linalg` and `unxts-parametric` (parametric was previously unwired)
- `ci.yml` test jobs + `CI Pass` gate wiring; `cd-pr-*`/`cd-*`/`cd-publish-*` workflows; `create-package-tags.yml` registration — mirroring the `unxts.interop.xarray` templates.

## Verification

Per-package, collected the way CI does (`src`/`tests`/`docs` separately — co-collecting `src`+`tests` triggers a namespace double-import, which CI never does):

- `pytest packages/unxts.linalg/src` → **259 passed** (doctests)
- `pytest packages/unxts.linalg/tests` → **195 passed**
- `pytest packages/unxts.linalg/docs` → **109 passed** (also via the `docs/packages/unxts.linalg` symlink)
- `ruff check` / `ruff format --check` clean; all 37 workflows pass actionlint + YAML parse.

```python
>>> import jax.numpy as jnp
>>> import unxts.linalg as ul
>>> ul.QM is ul.QuantityMatrix
True
>>> 2 * ul.QuantityMatrix(jnp.array([1., 2., 3.]), unit=("m", "s", "kg"))
QuantityMatrix(Array([2., 4., 6.], dtype=float32), unit='(m, s, kg)')
```

## Notes
- The linalg test job runs `pytest packages/unxts.linalg/tests` only (matching every sibling package), sidestepping the src+tests double-import; `.md` doctests are covered via the docs symlink.
- Per-package CI/CD uses labels `🧩 unxts-linalg` / `🧩 unxts-parametric`; those repo labels may need creating for label-triggered runs (push/`workflow_dispatch` run regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)