### PR TITLE
🐛 fix(unxt): relabel when converting to an equal but differently-named unit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,6 +325,11 @@ xfail_strict = true
 
 [tool.pytest_env]
 UNXT_ENABLE_RUNTIME_TYPECHECKING = "beartype.beartype"
+# Force matplotlib's non-interactive backend so the interop tests never load a
+# GUI toolkit (e.g. Tk). The Windows hosted-runner Pythons (3.13/3.14) ship a
+# broken Tcl, so an auto-selected TkAgg backend raised `_tkinter.TclError` at
+# figure creation; Agg is also what `pytest-mpl` renders with.
+MPLBACKEND = "Agg"
 
 
 [tool.repo-review]

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -236,9 +236,10 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     # Hot-path: skip the conversion only when the unit is genuinely unchanged.
     # NB: astropy treats physically-equal units as ``==`` (e.g. ``J == m2 kg /
     # s2``), so ``x.unit == u`` alone would silently return ``x`` without
-    # relabeling to the requested (equal but differently-named) unit. Compare
-    # the string form so the relabel still happens.
-    if x.unit.to_string() == u.to_string():
+    # relabeling to the requested (equal but differently-named) unit. Require
+    # the string forms to match too so the relabel still happens; the cheap
+    # ``==`` check short-circuits the common (unequal) case before formatting.
+    if x.unit == u and x.unit.to_string() == u.to_string():
         return x
 
     value = x.unit.to(u, uapi.ustrip(x))

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -233,8 +233,12 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     Quantity(Array([1., 2., 3.], dtype=float32, ...), unit='')
 
     """
-    # Hot-path: if no unit conversion is necessary
-    if x.unit == u:
+    # Hot-path: skip the conversion only when the unit is genuinely unchanged.
+    # NB: astropy treats physically-equal units as ``==`` (e.g. ``J == m2 kg /
+    # s2``), so ``x.unit == u`` alone would silently return ``x`` without
+    # relabeling to the requested (equal but differently-named) unit. Compare
+    # the string form so the relabel still happens.
+    if x.unit.to_string() == u.to_string():
         return x
 
     value = x.unit.to(u, uapi.ustrip(x))

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -99,7 +99,7 @@ Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
 Convert to standard energy units
 
 >>> u.uconvert("J", energy)
-Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
+Quantity(Array(100., dtype=float32...), unit='J')
 
 JIT compilation works seamlessly
 

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -217,6 +217,30 @@ class TestUconvertValueAstropyDistanceAngle:
         assert jnp.isclose(result, jnp.pi)
 
 
+class TestUconvertRelabelsEquivalentNamedUnit:
+    """`uconvert` to an equal-but-differently-named unit must relabel."""
+
+    def test_uconvert_to_named_energy_unit_relabels(self) -> None:
+        """`m2 kg / s2` converted to the equal named unit `J` becomes `J`.
+
+        Astropy treats ``m2 kg / s2 == J``, so a naive ``if x.unit == u``
+        hot-path would silently return the quantity unchanged (keeping the
+        composite label) instead of relabeling to the requested named unit.
+        """
+        energy = u.Q(2.0, "kg") * (u.Q(3.0, "m") / u.Q(1.0, "s")) ** 2
+        assert str(energy.unit) == "m2 kg / s2"
+
+        result = u.uconvert("J", energy)
+
+        assert str(result.unit) == "J"
+        assert jnp.isclose(result.value, 18.0)
+
+    def test_uconvert_to_identical_unit_is_noop_identity(self) -> None:
+        """Converting to the identical unit still returns the same object."""
+        q = u.Q(5.0, "J")
+        assert u.uconvert(apyu.Unit("J"), q) is q
+
+
 class TestUconvertValueAstropyErrorHandling:
     """Test error handling in uconvert_value with Astropy units."""
 


### PR DESCRIPTION
## Summary

`uconvert(named_unit, q)` silently returned `q` **unchanged** when astropy considered the units equal. For example, converting a `m2 kg / s2` quantity to the named unit `J` kept the composite label instead of relabeling to `J`:

```python
>>> energy = u.Q(2.0, "kg") * (u.Q(3.0, "m") / u.Q(1.0, "s")) ** 2
>>> u.uconvert("J", energy)   # before: unit='m2 kg / s2'  (wrong)
Quantity(Array(18., dtype=float32), unit='J')  # after
```

### Root cause
The astropy-interop conversion hot-path guarded on `x.unit == u`, but astropy treats physically-equal units as `==` (`J == m2 kg / s2`), so the relabel branch was never reached.

### Fix
Guard the hot-path on the **string form** of the unit (`x.unit.to_string() == u.to_string()`), so the conversion short-circuits only when the label is genuinely unchanged — preserving the no-op identity fast-path — and otherwise relabels to the requested unit.

Also corrects the misleading "Convert to standard energy units" doctest in `unxt.quantity`, which had documented the buggy no-op output.

## Testing (TDD)
- Added `TestUconvertRelabelsEquivalentNamedUnit` (relabel + identity no-op cases); the relabel test was written first and confirmed to fail before the fix.
- Full doctest sweep (`src/`, `docs/`, `README.md`): 2487 passed.
- `tests/unit/test_quantity.py` + astropy integration + interop doctests: 149 passed.

## Audit context
First of a series of pre-v2.0 fixes from a release-readiness audit. This is finding **H1** (silent correctness bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)