### PR TITLE
🐛 fix(parametric): make unxts.parametric release-ready

### DIFF
--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -19,16 +19,18 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["unxt", "plum-dispatch>=2.5.7"]
+dependencies = [
+  "astropy>=7.0.0",
+  "plum-dispatch>=2.5.7",
+  "unxt",
+  "unxts.api>=2.0.0",
+]
 description = "Dimension-parametrized quantities for unxt (canonical: unxts.parametric)"
 dynamic = ["version"]
 license.text = "BSD-3-Clause"
 name = "unxts.parametric"
 readme = "README.md"
 requires-python = ">=3.11"
-
-[project.optional-dependencies]
-astropy = ["astropy"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/GalacticDynamics/unxt/issues"

--- a/packages/unxts.parametric/src/unxts/parametric/__init__.py
+++ b/packages/unxts.parametric/src/unxts/parametric/__init__.py
@@ -1,6 +1,12 @@
 """Dimension-parametrized quantities for unxt (canonical: unxts.parametric)."""
 
-__all__ = ("AbstractParametricQuantity", "ParametricQuantity", "PQ", "config")
+__all__ = (
+    "__version__",
+    "AbstractParametricQuantity",
+    "ParametricQuantity",
+    "PQ",
+    "config",
+)
 
 # Import register modules for their dispatch/promotion side effects.
 from ._src import (  # noqa: F401
@@ -13,3 +19,4 @@ from ._src import (  # noqa: F401
 from ._src.base_parametric import AbstractParametricQuantity
 from ._src.config import config
 from ._src.parametric import PQ, ParametricQuantity
+from ._version import version as __version__

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_api.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_api.py
@@ -3,6 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 import equinox as eqx
+
 from unxts.api import dimension_of
 
 from .base_parametric import AbstractParametricQuantity

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_astropy.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_astropy.py
@@ -1,36 +1,35 @@
 """Astropy interop for ``ParametricQuantity`` (registered on import).
 
-Registered only when ``astropy`` is importable; a no-op otherwise so that
-``import unxts.parametric`` never requires the optional ``astropy`` dependency.
+``astropy`` is a hard dependency of ``unxts.parametric`` (its core
+``PhysicalType`` machinery requires it), so this conversion is always
+registered.
 """
 
 __all__: tuple[str, ...] = ()
 
-try:
-    from astropy.units import Quantity as AstropyQuantity
-except ImportError:  # pragma: no cover - astropy is an optional dependency
-    pass
-else:
-    from plum import conversion_method
+from astropy.units import Quantity as AstropyQuantity
+from plum import conversion_method
 
-    import unxt_api as uapi
-    from .parametric import ParametricQuantity
+import unxts.api as uapi
 
-    @conversion_method(type_from=AstropyQuantity, type_to=ParametricQuantity)  # type: ignore[arg-type]
-    def convert_astropy_quantity_to_parametric_quantity(
-        q: AstropyQuantity, /
-    ) -> ParametricQuantity:
-        """Convert an `astropy.units.Quantity` to a `ParametricQuantity`.
+from .parametric import ParametricQuantity
 
-        Examples
-        --------
-        >>> from astropy.units import Quantity as AstropyQuantity
-        >>> from plum import convert
-        >>> from unxts.parametric import ParametricQuantity
 
-        >>> convert(AstropyQuantity(1.0, "cm"), ParametricQuantity)
-        ParametricQuantity(Array(1., dtype=float32), unit='cm')
+@conversion_method(type_from=AstropyQuantity, type_to=ParametricQuantity)  # type: ignore[arg-type]
+def convert_astropy_quantity_to_parametric_quantity(
+    q: AstropyQuantity, /
+) -> ParametricQuantity:
+    """Convert an `astropy.units.Quantity` to a `ParametricQuantity`.
 
-        """
-        u = uapi.unit_of(q)
-        return ParametricQuantity(uapi.ustrip(u, q), u)
+    Examples
+    --------
+    >>> from astropy.units import Quantity as AstropyQuantity
+    >>> from plum import convert
+    >>> from unxts.parametric import ParametricQuantity
+
+    >>> convert(AstropyQuantity(1.0, "cm"), ParametricQuantity)
+    ParametricQuantity(Array(1., dtype=float32), unit='cm')
+
+    """
+    u = uapi.unit_of(q)
+    return ParametricQuantity(uapi.ustrip(u, q), u)

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_conversions.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_conversions.py
@@ -4,9 +4,10 @@ __all__: tuple[str, ...] = ()
 
 from plum import conversion_method
 
+from unxts.api import unit_of, ustrip
+
 from .parametric import ParametricQuantity
 from unxt.quantity import AbstractQuantity
-from unxt_api import unit_of, ustrip
 
 
 @conversion_method(type_from=AbstractQuantity, type_to=ParametricQuantity)  # type: ignore[arg-type]

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
@@ -19,10 +19,11 @@ from jax import lax
 from jaxtyping import ArrayLike
 from plum import type_unparametrized as type_np
 
+from unxts.api import ustrip
+
 from .base_parametric import AbstractParametricQuantity as ABCPQ  # noqa: N814
 from .parametric import ParametricQuantity
 from unxt.quantity import AbstractQuantity as ABCQ  # noqa: N814
-from unxt_api import ustrip
 
 # ==============================================================================
 # clamp

--- a/packages/unxts.parametric/tests/test_public_api.py
+++ b/packages/unxts.parametric/tests/test_public_api.py
@@ -1,8 +1,26 @@
 """Smoke tests for the unxts.parametric public API."""
 
+import importlib.resources
+
 import unxts.parametric
 
 
 def test_all_symbols_present():
     for name in unxts.parametric.__all__:
         assert hasattr(unxts.parametric, name), f"unxts.parametric missing: {name}"
+
+
+def test_exposes_version():
+    """The package must expose a non-empty ``__version__`` string.
+
+    Every sibling ``unxts.*`` package exposes ``__version__``; this one did not.
+    """
+    assert isinstance(unxts.parametric.__version__, str)
+    assert unxts.parametric.__version__
+    assert "__version__" in unxts.parametric.__all__
+
+
+def test_ships_py_typed_marker():
+    """The package must ship a ``py.typed`` marker (it declares ``Typing :: Typed``)."""
+    marker = importlib.resources.files("unxts.parametric") / "py.typed"
+    assert marker.is_file()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ namespace-packages = [
   "packages/unxts.interop.xarray/src/unxts",
   "packages/unxts.interop.xarray/src/unxts/interop",
   "packages/unxts.linalg/src/unxts",
+  "packages/unxts.parametric/src/unxts",
 ]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -4930,13 +4930,10 @@ test = [
 name = "unxts-parametric"
 source = { editable = "packages/unxts.parametric" }
 dependencies = [
+    { name = "astropy" },
     { name = "plum-dispatch" },
     { name = "unxt" },
-]
-
-[package.optional-dependencies]
-astropy = [
-    { name = "astropy" },
+    { name = "unxts-api" },
 ]
 
 [package.dev-dependencies]
@@ -4952,11 +4949,11 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astropy", marker = "extra == 'astropy'" },
+    { name = "astropy", specifier = ">=7.0.0" },
     { name = "plum-dispatch", specifier = ">=2.5.7" },
     { name = "unxt", editable = "." },
+    { name = "unxts-api", editable = "packages/unxts.api" },
 ]
-provides-extras = ["astropy"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
## Summary

The freshly-extracted `unxts.parametric` package had several release-readiness gaps for v2.0. This PR closes the source/metadata ones (the CI/CD release-plumbing gaps are handled in a follow-up PR):

- **Ship a `py.typed` marker.** The package declares `Typing :: Typed` but shipped no marker — the only package missing one — so type checkers silently ignored its types.
- **Export `__version__`** from `__init__`. Every sibling `unxts.*` package exposes it; this one didn't (`unxts.parametric.__version__` raised `AttributeError`).
- **Declare the dependencies the source actually imports.** Added `unxts.api>=2.0.0` (previously only resolved transitively via `unxt` → `unxt-api`) and `astropy`. The core `AbstractParametricQuantity.__init_type_parameter__` uses `astropy.units.PhysicalType`, so **astropy is a hard requirement** — moved it out of `optional-dependencies` and removed the misleading "astropy is optional" `try/except` guard in `register_astropy` (dead code, since core already imports astropy unconditionally).
- **Use the canonical `unxts.api`** instead of the legacy `unxt_api` shim in `register_conversions` / `register_primitives` / `register_astropy`.
- **Register the namespace source root** in the root ruff config (was the only `unxts.*` package missing).

## Testing (TDD)
- `test_exposes_version` and `test_ships_py_typed_marker` written first; both failed before the fix, pass now.
- Full parametric suite + `src` doctests: 176 passed. Astropy→`ParametricQuantity` conversion verified. No residual `unxt_api` imports remain in the package source.

## Audit context
Third of a series of pre-v2.0 fixes from a release-readiness audit. Covers findings **H4/H5**, the missing **py.typed** and **`__version__`**, and the ruff-config gap. A follow-up PR adds the CI test job + release/CD workflows so the package actually publishes at 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)