### PR TITLE
🐛 fix(xarray): use u.Q in interop docstrings; ParametricQuantity was removed

### DIFF
--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/accessors.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/accessors.py
@@ -182,7 +182,7 @@ class UnxtDataArrayAccessor:
         >>> import unxt as u
         >>> import unxts.interop.xarray
 
-        >>> q = u.ParametricQuantity([1.0, 2.0], "m")
+        >>> q = u.Q([1.0, 2.0], "m")
         >>> da = xr.DataArray(q, dims=["x"])
         >>> dequantified = da.unxt.dequantify()
         >>> dequantified.data
@@ -341,8 +341,8 @@ class UnxtDatasetAccessor:
         >>> import unxt as u
         >>> import unxts.interop.xarray
 
-        >>> q1 = u.ParametricQuantity([1.0, 2.0], "m")
-        >>> q2 = u.ParametricQuantity([3.0, 4.0], "s")
+        >>> q1 = u.Q([1.0, 2.0], "m")
+        >>> q2 = u.Q([3.0, 4.0], "s")
         >>> ds = xr.Dataset({"a": ("x", q1), "b": ("y", q2)})
         >>> dequantified = ds.unxt.dequantify()
         >>> dequantified["a"].attrs["units"]

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -159,7 +159,7 @@ def extract_units(obj: DataArray, /) -> dict[Hashable, u.AbstractUnit | None]:
     >>> import unxt as u
     >>> from unxts.interop.xarray._src.conversion import extract_units
 
-    >>> q = u.ParametricQuantity([1.0, 2.0], "m")
+    >>> q = u.Q([1.0, 2.0], "m")
     >>> da = xr.DataArray(q, dims=["x"])
     >>> units = extract_units(da)
     >>> units[None]
@@ -332,7 +332,7 @@ def strip_units(obj: DataArray) -> DataArray:
     >>> import unxt as u
     >>> from unxts.interop.xarray._src.conversion import strip_units
 
-    >>> q = u.ParametricQuantity([1.0, 2.0], "m")
+    >>> q = u.Q([1.0, 2.0], "m")
     >>> da = xr.DataArray(q, dims=["x"])
     >>> stripped = strip_units(da)
     >>> stripped.data


### PR DESCRIPTION
## Summary

The xarray interop package's public docstring examples for `dequantify`, `extract_units`, and `strip_units` called `u.ParametricQuantity([...], "m")`. In v2 that attribute was removed — `u.ParametricQuantity` now raises `AttributeError` ("moved to the `unxts.parametric` package") — so every worked example a user copy-pasted failed on the very first line.

Replaced with `u.Q` (the default quantity), matching the rest of the package. The examples' expected outputs are unchanged; they never depended on the quantity type. Each example was executed and verified to reproduce its documented output.

5 occurrences across 2 files:
- `_src/conversion.py` (`extract_units`, `strip_units`)
- `_src/accessors.py` (`dequantify` for `DataArray` and `Dataset`)

## Note on why CI didn't catch this
These `src` docstrings are not collected by the package's CI job (it runs only `packages/unxts.interop.xarray/tests`, not `src`). Wiring the older packages' `src` doctests into CI is a separate, larger change (their `src` doctests currently error under sybil collection) and is tracked as a follow-up.

## Audit context
From the pre-v2.0 release-readiness audit (finding **H3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)