### PR TITLE
📝 docs: fix duplicated https:// in install/clone commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ uv add unxt
   <summary>from source, using pip</summary>
 
 ```bash
-pip install git+https://https://github.com/GalacticDynamics/unxt.git
+pip install git+https://github.com/GalacticDynamics/unxt.git
 ```
 
 </details>
@@ -64,7 +64,7 @@ pip install git+https://https://github.com/GalacticDynamics/unxt.git
 
 ```bash
 cd /path/to/parent
-git clone https://https://github.com/GalacticDynamics/unxt.git
+git clone https://github.com/GalacticDynamics/unxt.git
 cd unxt
 pip install -e .  # editable mode
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ uv add unxt
 :::{tab-item} source, via pip
 
 ```bash
-pip install git+https://https://github.com/GalacticDynamics/unxt.git
+pip install git+https://github.com/GalacticDynamics/unxt.git
 ```
 
 :::
@@ -113,7 +113,7 @@ pip install git+https://https://github.com/GalacticDynamics/unxt.git
 
 ```bash
 cd /path/to/parent
-git clone https://https://github.com/GalacticDynamics/unxt.git
+git clone https://github.com/GalacticDynamics/unxt.git
 cd unxt
 pip install -e .  # editable mode
 ```


### PR DESCRIPTION
## Summary

The source-install snippets had a doubled protocol, so copy-pasting them fails immediately:

```
pip install git+https://https://github.com/GalacticDynamics/unxt.git   # before
git clone https://https://github.com/GalacticDynamics/unxt.git         # before
```

Collapsed to a single `https://` in both `README.md` (lines 58, 67) and `docs/index.md` (lines 107, 116).

## Audit context
From the pre-v2.0 release-readiness audit (finding **B2**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)