### PR TITLE
📌 pin: add v2.0 dependency floors; drop misleading unxt-api comment

### DIFF
--- a/packages/unxts.hypothesis/pyproject.toml
+++ b/packages/unxts.hypothesis/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["unxt", "hypothesis[numpy]>=6.138.14", "jax>=0.5.3"]
+dependencies = ["unxt>=2.0.0", "hypothesis[numpy]>=6.138.14", "jax>=0.5.3"]
 description = "Hypothesis strategies for unxt (canonical: unxts.hypothesis)"
 dynamic = ["version"]
 license.text = "BSD-3-Clause"

--- a/packages/unxts.interop.gala/pyproject.toml
+++ b/packages/unxts.interop.gala/pyproject.toml
@@ -21,12 +21,16 @@ classifiers = [
 # gala has no Windows wheels and its sdist needs GSL/a C compiler, so it can
 # only be required off-Windows. unxt guards the gala interop import on gala
 # actually being importable, so this package is simply inert on Windows.
-dependencies    = ["astropy>=6.0", "gala>=1.8; sys_platform != 'win32'", "unxt"]
-description     = "gala integration for unxt (canonical: unxts.interop.gala)"
-dynamic         = ["version"]
-license.text    = "BSD-3-Clause"
-name            = "unxts.interop.gala"
-readme          = "README.md"
+dependencies = [
+  "astropy>=6.0",
+  "gala>=1.8; sys_platform != 'win32'",
+  "unxt>=2.0.0",
+]
+description = "gala integration for unxt (canonical: unxts.interop.gala)"
+dynamic = ["version"]
+license.text = "BSD-3-Clause"
+name = "unxts.interop.gala"
+readme = "README.md"
 requires-python = ">=3.11"
 
 [project.urls]

--- a/packages/unxts.interop.matplotlib/pyproject.toml
+++ b/packages/unxts.interop.matplotlib/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["matplotlib>=3.8", "unxt", "zeroth>=1.0.0"]
+dependencies = ["matplotlib>=3.8", "unxt>=2.0.0", "zeroth>=1.0.0"]
 description = "matplotlib integration for unxt (canonical: unxts.interop.matplotlib)"
 dynamic = ["version"]
 license.text = "BSD-3-Clause"

--- a/packages/unxts.interop.xarray/pyproject.toml
+++ b/packages/unxts.interop.xarray/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["unxt", "xarray>=2024.1.0"]
+dependencies = ["unxt>=2.0.0", "xarray>=2024.1.0"]
 description = "xarray integration for unxt (canonical: unxts.interop.xarray)"
 dynamic = ["version"]
 license.text = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",
-  "unxt-api>=1.10.0",                             # change to "unxts.api>=2.0.0" after release
+  "unxt-api>=2.0.0",
   "wadler-lindig>=0.1.5",
   "xmmutablemap>=0.1",
   "zeroth>=1.0.0",


### PR DESCRIPTION
## Summary

Two dependency-pinning corrections for v2.0:

**Root `unxt` (H7).** It depended on `unxt-api>=1.10.0` with an inline comment suggesting a post-release swap to `unxts.api>=2.0.0`. That swap would **break at runtime** — core `unxt` imports the `unxt_api` *module* in 9 files (`src/unxt/_src/units.py`, `dims.py`, `quantity/base.py`, …), and that module is provided by the `unxt-api` shim, not by `unxts.api`. Keep the `unxt-api` dependency, bump its floor to `>=2.0.0`, and remove the misleading comment.

**`unxts.*` namespace packages (M2).** `unxts.hypothesis` and `unxts.interop.{gala,matplotlib,xarray}` depended on a bare, unpinned `unxt`, so a resolver could pair a v2 package with an incompatible `unxt` 1.x that lacks the v2 API. Added `unxt>=2.0.0` floors. (`unxts.parametric` was pinned in its own PR.)

Lockfile regenerated; all packages still import.

## Audit context
Pre-v2.0 release-readiness audit, findings **H7** and **M2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)