### PR TITLE
🐛 fix(unxt): align v2 quantity public surface (BareQuantity shim + docstrings)

### DIFF
--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -22,6 +22,9 @@ documentation.
 # The ``_MOVED_TO_PARAMETRIC`` shim in ``__getattr__`` mirrors the one in the
 # quantity subpackage on purpose; silence the duplicate-code check.
 # pylint: disable=duplicate-code
+# The ``BareQuantity`` deprecation shim in ``__getattr__`` imports ``warnings``
+# lazily on purpose; silence the module-level lint for that intentional pattern.
+# pylint: disable=import-outside-toplevel
 
 __all__ = (
     "__version__",

--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -98,5 +98,17 @@ def __getattr__(name: str) -> object:
             f"`from unxts.parametric import {name}`."
         )
         raise AttributeError(msg)
+    if name == "BareQuantity":
+        import warnings  # noqa: PLC0415
+
+        warnings.warn(
+            "`BareQuantity` has been renamed to `Quantity` and is now the "
+            "default quantity class (unxt v2). The parametric class formerly "
+            "named `Quantity` is now `ParametricQuantity`. `BareQuantity` "
+            "will be removed in a future release.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return Quantity
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -19,7 +19,7 @@ class Quantity(AbstractQuantity):
     This class is not parametrized by its dimensionality, making it a single
     class (and a single JAX pytree type) regardless of dimension. For runtime
     dimension checking and dimension-specific dispatch, see
-    `unxt.ParametricQuantity`.
+    `unxts.parametric.ParametricQuantity`.
 
     Examples
     --------
@@ -43,7 +43,7 @@ class Quantity(AbstractQuantity):
         """No-op support for ``Quantity[...]`` syntax.
 
         The dimension parameter is accepted for interchangeability with
-        `unxt.ParametricQuantity` but is NOT checked.
+        `unxts.parametric.ParametricQuantity` but is NOT checked.
 
         >>> from unxt.quantity import Quantity
         >>> Quantity["length"]

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -8,12 +8,13 @@ correctness.
 
 - **`Quantity`**: The default quantity class, no dimension parametrization,
   aliased as `Q`.
-- **`ParametricQuantity`**: Dimension-parametrized with runtime checking,
-  aliased as `PQ`.
-- **`StaticQuantity`**: Parametric quantity with static NumPy values for JAX
-  static arguments.
+- **`StaticQuantity`**: Quantity holding a static NumPy value, for use as a JAX
+  static argument.
 - **`Angle`**: Specialized quantity type for angular measurements with wrapping
   support.
+
+Dimension-parametrized quantities with runtime checking (`ParametricQuantity`,
+aliased `PQ`) now live in the separate `unxts.parametric` package.
 
 ## Key Functions
 

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -29,8 +29,31 @@ def test_barequantity_not_in_public_all():
     assert "BareQuantity" not in uq.__all__
 
 
+def test_barequantity_top_level_is_deprecated_alias():
+    """`from unxt import BareQuantity` warns and resolves to `Quantity`.
+
+    The top-level shim must match `unxt.quantity`'s (which was already handled).
+    """
+    with pytest.warns(DeprecationWarning, match="renamed to `Quantity`"):
+        from unxt import BareQuantity  # noqa: PLC0415
+
+    assert BareQuantity is u.Quantity
+
+
+def test_barequantity_top_level_attribute_access_warns():
+    """Attribute access on the top-level module also warns."""
+    with pytest.warns(DeprecationWarning, match="renamed to `Quantity`"):
+        cls = u.BareQuantity
+    assert cls is u.Quantity
+
+
 def test_unknown_attribute_raises():
     import unxt.quantity as uq  # noqa: PLC0415
 
     with pytest.raises(AttributeError, match="NotAThing"):
         _ = uq.NotAThing
+
+
+def test_unknown_top_level_attribute_raises():
+    with pytest.raises(AttributeError, match="NotAThing"):
+        _ = u.NotAThing


### PR DESCRIPTION
## Summary

Three v2 public-surface inconsistencies in the core quantity module:

- **`unxt.BareQuantity` shim (M6).** `from unxt import BareQuantity` raised a bare `AttributeError`, while `from unxt.quantity import BareQuantity` correctly returned `Quantity` with a `DeprecationWarning`. Since `from unxt import BareQuantity` was valid v1 code, the top-level `__getattr__` now mirrors the quantity-module shim it claims to mirror.
- **Stale "Core Classes" docstring (M5).** `unxt.quantity`'s module docstring listed `ParametricQuantity`/`PQ` as core classes (they now raise `AttributeError`, having moved to `unxts.parametric`) and mislabeled the non-parametric `StaticQuantity` as "Parametric". Corrected.
- **Dead cross-references (M5).** `_src/quantity/quantity.py` docstrings pointed at the removed `unxt.ParametricQuantity`; now point at `unxts.parametric.ParametricQuantity`.

## Testing (TDD)
Added `test_barequantity_top_level_is_deprecated_alias` and `..._attribute_access_warns` (plus an unknown-attribute negative). Both failed ("DID NOT WARN") before the fix, pass now. Changed-module doctests + full deprecations suite: 40 passed.

## Audit context
Pre-v2.0 release-readiness audit, findings **M5** and **M6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)