### PR TITLE
♻️ refactor(unxt): remove dead __eq__ line and the v2.0 compact_arrays shim

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -7,7 +7,6 @@ __all__ = ("AbstractQuantity", "is_any_quantity")
 
 import contextlib
 import functools as ft
-import warnings
 from collections.abc import Mapping
 from types import ModuleType
 from typing import (
@@ -301,9 +300,6 @@ class AbstractQuantity(
 
         """
         return replace(self, value=self.value.T)
-
-    # required to override mixin methods
-    __eq__ = quax_blocks.NumpyEqMixin.__eq__  # type: ignore[assignment,unused-ignore]
 
     # ---------------------------------------------------------------
     # methods
@@ -822,17 +818,7 @@ class AbstractQuantity(
         del fs["value"]
         del fs["unit"]
 
-        # Customize value representation
-        # (backward compatibility for `compact_arrays` argument)
-        # TODO: remove in v2.0
-        if "compact_arrays" in kwargs:
-            short_arrays = kwargs.pop("compact_arrays")
-            warnings.warn(
-                "`compact_arrays` argument is deprecated; use "
-                "`short_arrays='compact'` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        # Customize value representation.
         # If the value is a tracer, then we ALWAYS use the short array
         # representation since we only have the dtype and shape at trace-time
         # and trying to print out the values will error.


### PR DESCRIPTION
## Summary

Two `AbstractQuantity` (`_src/quantity/base.py`) cleanups for v2.0:

- **Dead `__eq__` assignment.** `__eq__ = quax_blocks.NumpyEqMixin.__eq__` near the top of the class body was unconditionally overwritten by the real `def __eq__` later in the *same* class (which already falls back to `NumpyEqMixin.__eq__` internally). Removed the dead alias.
- **`compact_arrays` shim.** Removed the backward-compatibility handling in `__pdoc__`, explicitly tagged `# TODO: remove in v2.0`. It had no callers, tests, or docs anywhere in the repo; `short_arrays="compact"` is the supported replacement. Also dropped the now-unused `import warnings`.

## Testing
Equality tests + printing tests + `base.py` doctests: 256 passed. Lint clean.

## Audit context
Pre-v2.0 release-readiness audit (Low-severity cleanups, incl. the explicit "remove in v2.0" marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)