### PR TITLE
🧹 chore(hypothesis): canonical docstrings + dead-code cleanup

### DIFF
--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/dimensions.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/dimensions.py
@@ -181,7 +181,7 @@ def named_dimensions(draw: st.DrawFn) -> u.AbstractDimension:
 
     >>> from hypothesis import given
     >>> import unxt as u
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
 
     >>> @given(dim=ust.named_dimensions())
     ... def test_physics_dimension(dim):

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
@@ -2,7 +2,7 @@
 
 __all__ = ("quantities", "wrap_to", "angles")
 
-from typing import Any, T, TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar
 
 import jax.numpy as jnp
 import numpy as np
@@ -58,7 +58,7 @@ def quantities(
         - str: Fixed unit (e.g., "kpc", "km/s")
         - `unxt.AbstractUnit`: Fixed unit object
         - `unxt.AbstractDimension`: Dimension to derive unit from (uses
-          `unxt_hypothesis.units` strategy)
+          `unxts.hypothesis.units` strategy)
         - SearchStrategy: Strategy that generates units (e.g., from `units()`)
           or dimensions. The default strategy samples from SI base units.
     quantity_cls : type[`unxt.AbstractQuantity`], optional
@@ -98,7 +98,7 @@ def quantities(
     >>> from hypothesis import given, strategies as st
     >>> import jax.numpy as jnp
     >>> import unxt as u
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
 
     >>> @given(q=ust.quantities("kpc", shape=3))
     ... def test_position(q):
@@ -246,7 +246,7 @@ def wrap_to(
     >>> from hypothesis import given
     >>> import hypothesis.strategies as st
     >>> import unxt as u
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
 
     >>> @given(
     ...     angle=ust.wrap_to(
@@ -304,7 +304,7 @@ def angles(
         Strategy for generating (min, max) bounds for angle wrapping.
         If `None`, the angle will have no wrapping specified.
     **kwargs
-        Additional keyword arguments passed to `unxt_hypothesis.quantities`.
+        Additional keyword arguments passed to `unxts.hypothesis.quantities`.
         Common options include 'dtype', 'shape', 'elements', 'unique'.  The
         arguments 'unit' and 'quantity_cls' are set automatically and should not
         be provided.
@@ -317,7 +317,7 @@ def angles(
     Examples
     --------
     >>> from hypothesis import given
-    >>> from unxt_hypothesis import angles
+    >>> from unxts.hypothesis import angles
     >>> import unxt as u
 
     >>> @given(angle=angles())
@@ -338,7 +338,7 @@ def angles(
 
     # Extract unit if provided (to avoid conflicts with dimension) Default to
     # angle dimension, but user can override with specific unit. If user
-    # provides a bad unit, unxt_hypothesis.quantities will raise an error given
+    # provides a bad unit, unxts.hypothesis.quantities will raise an error given
     # the `u.Angle` quantity_cls.
     unit = kwargs.pop("unit", u.dimension("angle"))
 

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
@@ -12,7 +12,7 @@ from .dimensions import named_dimensions
 
 
 @st.composite
-def derived_units(  # pylint: disable=unreachable
+def derived_units(
     draw: st.DrawFn,
     base: str | u.AbstractUnit | st.SearchStrategy[u.AbstractUnit],
     /,
@@ -49,7 +49,7 @@ def derived_units(  # pylint: disable=unreachable
     --------
     >>> import hypothesis.strategies as st
     >>> from hypothesis import given
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
     >>> import unxt as u
 
     Generate units derived from a base unit:
@@ -97,7 +97,6 @@ def derived_units(  # pylint: disable=unreachable
         # Get SI base decomposition
         decomposed = base_unit.decompose()
         si_bases = list(decomposed.bases)
-        list(decomposed.powers)
 
         # Get a pool of other SI base units to use as cancelling factors
         all_si_bases = [
@@ -183,7 +182,7 @@ def units(
     --------
     >>> import hypothesis.strategies as st
     >>> from hypothesis import given
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
     >>> import unxt as u
 
     >>> @given(unit=ust.units("velocity"))

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
@@ -37,7 +37,7 @@ def unitsystems(
     --------
     >>> from hypothesis import given
     >>> import unxt as u
-    >>> import unxt_hypothesis as ust
+    >>> import unxts.hypothesis as ust
 
     Create a unit system with fixed units:
 


### PR DESCRIPTION
## Summary

Cleanups in `unxts.hypothesis`:

- **Canonical name in docstrings (M4).** The canonical package's own docstrings imported the deprecated shim (`>>> import unxt_hypothesis as ust`, plus prose refs like `unxt_hypothesis.units`). Pointed them at `unxts.hypothesis` so examples don't depend on the legacy name they supersede. The intentional shim mention in `__init__` is unchanged.
- **Dead code (Low).** Removed `typing.T` from an import (undocumented; immediately shadowed by `T = TypeVar("T")`); removed the discard-only `list(decomposed.powers)` statement; removed a spurious `# pylint: disable=unreachable` on `derived_units` (pylint reports no unreachable code — verified 10.00/10 with the check enabled).

Import + package tests pass; ruff and the `unreachable` pylint check clean.

## Audit context
Pre-v2.0 audit, finding **M4** plus Low-severity dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)