### PR TITLE
📝 docs: lead with the canonical packages, not the deprecated shims

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,16 +9,16 @@ sd_hide_title: true
 :hidden:
 :caption: 📦 Packages
 
-unxt-api <packages/unxt-api/index>
 unxt <self>
-unxt-hypothesis <packages/unxt-hypothesis/index>
 unxts.api <packages/unxts.api/index>
 unxts.hypothesis <packages/unxts.hypothesis/index>
-unxts.linalg <packages/unxts.linalg/index>
 unxts.parametric <packages/unxts.parametric/index>
+unxts.linalg <packages/unxts.linalg/index>
 unxts.interop.gala <packages/unxts.interop.gala/index>
 unxts.interop.matplotlib <packages/unxts.interop.matplotlib/index>
 unxts.interop.xarray <packages/unxts.interop.xarray/index>
+unxt-api <packages/unxt-api/index>
+unxt-hypothesis <packages/unxt-hypothesis/index>
 ```
 
 ```{toctree}
@@ -660,11 +660,11 @@ If you found this library to be useful and want to support the development and m
 - [Quax][quax]: JAX + multiple dispatch + custom array-ish objects.
 - [Quaxed][quaxed]: pre-`quaxify`ed Jax.
 - [plum][plum]: multiple dispatch in python
-- [unxt-api][unxt-api]: the API for `unxt`.
+- [unxts.api][unxts-api]: the abstract dispatch API for `unxt`.
 
 ### `unxt`'s Dependents
 
-- [unxt-hypothesis][unxt-hypothesis]: `unxt` integration with `hypothesis` property-based testing.
+- [unxts.hypothesis][unxts-hypothesis]: `unxt` integration with `hypothesis` property-based testing.
 
 - [coordinax][coordinax]: Coordinates in JAX.
 - [galax][galax]: Galactic dynamics in JAX.
@@ -681,8 +681,8 @@ If you found this library to be useful and want to support the development and m
 [plum]: https://pypi.org/project/plum-dispatch/
 [quax]: https://github.com/patrick-kidger/quax
 [quaxed]: https://quaxed.readthedocs.io/en/latest/
-[unxt-api]: https://pypi.org/project/unxt-api/
-[unxt-hypothesis]: https://pypi.org/project/unxt-hypothesis/
+[unxts-api]: https://pypi.org/project/unxts.api/
+[unxts-hypothesis]: https://pypi.org/project/unxts.hypothesis/
 [pypi-link]: https://pypi.org/project/unxt/
 [pypi-platforms]: https://img.shields.io/pypi/pyversions/unxt
 [pypi-version]: https://img.shields.io/pypi/v/unxt


### PR DESCRIPTION
## Summary

The docs landing page (`docs/index.md`) surfaced the backward-compat shims `unxt-api` and `unxt-hypothesis` **first** in the "📦 Packages" nav, and presented them as the canonical packages in the Ecosystem section — even though their doc pages are just symlinks to the canonical `unxts.api` / `unxts.hypothesis` docs.

- Reordered the packages toctree to lead with `unxt` and the canonical `unxts.*` packages; moved the two shims to the end (kept in the nav so their symlinked pages remain in a toctree — avoids `fail_on_warning` "not in any toctree" errors).
- Repointed the Ecosystem section's links from the shim PyPI pages to the canonical `unxts.api` / `unxts.hypothesis`.

No pages added or removed; renamed link-reference keys verified consistent; prettier clean.

## Audit context
Pre-v2.0 audit, finding **M7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)