### PR TITLE
💚 ci: run the older packages' src doctests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
 
       - name: Test package
         run: |
+          uv run --frozen --package unxts-api pytest packages/unxts.api/src
           uv run --frozen --package unxts-api pytest packages/unxts.api/tests --cov=packages/unxts.api/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
@@ -231,6 +232,11 @@ jobs:
 
       - name: Test package
         run: |
+          # src doctests: leaf dir `unxts/hypothesis` shadows the installed
+          # `hypothesis`, so sybil mis-imports it. Run these via pytest's
+          # namespace-aware --doctest-modules (doctest plugin re-enabled by
+          # overriding addopts, which otherwise sets `-p no:doctest`).
+          uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
           uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/tests --cov=packages/unxts.hypothesis/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
@@ -270,6 +276,9 @@ jobs:
 
       - name: Test package
         run: |
+          # src doctests: leaf dir `unxts/interop/gala` shadows the installed
+          # `gala`, so sybil mis-imports it; use namespace-aware --doctest-modules.
+          uv run --frozen --package unxts-interop-gala pytest packages/unxts.interop.gala/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
           uv run --frozen --package unxts-interop-gala pytest packages/unxts.interop.gala/tests --cov=packages/unxts.interop.gala/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
@@ -348,6 +357,9 @@ jobs:
 
       - name: Test package
         run: |
+          # src doctests: leaf dir `unxts/interop/xarray` shadows the installed
+          # `xarray`, so sybil mis-imports it; use namespace-aware --doctest-modules.
+          uv run --frozen --package unxts-interop-xarray pytest packages/unxts.interop.xarray/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
           uv run --frozen --package unxts-interop-xarray pytest packages/unxts.interop.xarray/tests --cov=packages/unxts.interop.xarray/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage report

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@
 import os
 from collections.abc import Callable, Iterable, Sequence
 from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
+from pathlib import Path
 from typing import Any
 
 from sybil import Document, Region, Sybil
@@ -62,7 +63,29 @@ python = Sybil(
 )
 
 
-pytest_collect_file = (docs + python).pytest()
+_sybil_collect_file = (docs + python).pytest()
+
+# Sybil imports a doctest module by walking up through ``__init__.py`` dirs, so
+# at a PEP 420 namespace boundary it computes a leaf-based module name. For the
+# ``unxts.*`` packages whose leaf shadows an installed library
+# (gala/xarray/hypothesis) that name collides with the real library and the
+# import fails. Their ``src`` doctests are instead run with pytest's
+# ``--doctest-modules --import-mode=importlib`` (namespace-aware) in each
+# package's CI job, so skip them here to avoid the failing sybil import.
+# (unxts.interop.matplotlib also collides but has no ``src`` doctests, so sybil
+# never imports it; it stays on the normal path.)
+_DOCTEST_MODULE_SRC = (
+    "packages/unxts.interop.gala/src/",
+    "packages/unxts.interop.xarray/src/",
+    "packages/unxts.hypothesis/src/",
+)
+
+
+def pytest_collect_file(file_path: Path, parent: object) -> object:
+    """Collect doctests with Sybil, except the namespace ``src`` handled above."""
+    if any(marker in file_path.as_posix() for marker in _DOCTEST_MODULE_SRC):
+        return None
+    return _sybil_collect_file(file_path, parent)
 
 
 class OptDeps(OptionalDependencyEnum):


### PR DESCRIPTION
## Summary

Wires the `unxts.api` / `unxts.hypothesis` / `unxts.interop.*` packages' **`src` doctests** into CI. Those jobs previously ran only `tests/`, never their docstring examples — which is exactly how the broken `u.ParametricQuantity(...)` examples in the xarray interop (fixed in #690) reached `main` uncaught.

This is the follow-up flagged in #690.

## Root cause of the gap

sybil imports a doctest module by walking up through `__init__.py` dirs. At the PEP 420 namespace boundary (`unxts/interop/` has no `__init__.py`) it computes a **leaf-based** module name (`xarray._src.conversion`). For the packages whose leaf shadows an installed library — `gala`, `xarray`, `hypothesis` — that name collides with the real library and the import fails, so sybil can't collect their `src`. (`api`, `parametric`, `linalg` don't collide, so sybil handles them fine — which is why parametric/linalg already run `src` in CI.)

## Fix

- **`conftest.py`**: wrap the sybil `pytest_collect_file` to return `None` for the three colliding packages' `src`, so sybil doesn't choke on them. (matplotlib also collides but has no `src` doctests, so sybil never imports it — left on the normal path.)
- **`ci.yml`**: run those three packages' `src` doctests with pytest's namespace-aware collector: `--doctest-modules --import-mode=importlib -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"`. The `addopts` override re-enables the doctest plugin, which the repo otherwise disables (`-p no:doctest`, in favour of sybil). Also added a plain `pytest .../src` step to the `unxts.api` job (no collision → sybil handles it, like parametric/linalg).

## Verification (local)

- New `src` doctest coverage passes: `unxts.api` 19, `unxts.interop.gala` 2, `unxts.interop.xarray` 11, `unxts.hypothesis` 7.
- The conftest wrapper does not disturb the main sybil sweep: `pytest src/` still passes **1912** doctests.
- Pre-commit incl. "Validate GitHub Workflows" passes.

## Audit context
Pre-v2.0 audit finding **M8** (deferred in the original series; now unblocked by #690).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
