### PR TITLE
🧹 chore(unxt): drop spurious pylint disable=unreachable suppressions

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -252,7 +252,7 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     # the dimensions can be part of the type. This won't work if the quantity
     # type itself needs to be changed, e.g. `unxt.Angle` -> `unxt.Quantity`.
     # These cases are handled separately, in other dispatches.
-    fs = dict(dc.field_items(x))  # pylint: disable=unreachable
+    fs = dict(dc.field_items(x))
     fs["value"] = value
     fs["unit"] = u
 

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -111,7 +111,7 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
     # dimension names of all the units
     du = {parse_dimlike_name(x).replace(" ", "_"): dimension_of(x) for x in args}
     # name: physical types
-    cls_name = "".join(k.title().replace("_", "") for k in du) + "UnitSystem"  # pylint: disable=unreachable
+    cls_name = "".join(k.title().replace("_", "") for k in du) + "UnitSystem"
     # fields: name, unit
     fields = [
         (
@@ -195,7 +195,7 @@ def unitsystem(usys: AbstractUnitSystem, *args: Any) -> AbstractUnitSystem:
     current_units = [
         u for u in usys.base_units if dimension_of(u) not in new_usys.base_dimensions
     ]
-    return unitsystem(*current_units, *args)  # pylint: disable=unreachable
+    return unitsystem(*current_units, *args)
 
 
 @dispatch


### PR DESCRIPTION
## Summary

Three lines carried `# pylint: disable=unreachable`, but none actually triggers pylint's `unreachable` check — they're stale/copy-pasted suppressions that also mask any genuine future unreachable-code warning on those lines. Removed from:

- `src/unxt/_src/unitsystems/core.py` (two spots)
- `src/unxt/_interop/unxt_interop_astropy/quantity.py` (the `uconvert` dimension-mismatch path)

## Verification

`uv run pylint --enable=unreachable <files>` stays **10.00/10** after removal; full `pylint src/unxt` exits 0; 74 doctests in the two modules pass; ruff clean.

## Audit context
Pre-v2.0 audit, Low-severity item (deferred from the original series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)