### PR TITLE
🧹 chore: drop the unused hatch-vcs version-file hook from the shims

### DIFF
--- a/packages/unxt-api/pyproject.toml
+++ b/packages/unxt-api/pyproject.toml
@@ -65,8 +65,5 @@ describe_command = [
   "unxt-api-v*",
 ]
 
-[tool.hatch.build.hooks.vcs]
-version-file = "src/unxt_api/_version.py"
-
 [tool.uv.sources]
 "unxts.api" = { workspace = true }

--- a/packages/unxt-hypothesis/pyproject.toml
+++ b/packages/unxt-hypothesis/pyproject.toml
@@ -65,14 +65,6 @@ describe_command = [
   "unxt-hypothesis-v*",
 ]
 
-[tool.hatch.build.hooks.vcs]
-version-file = "src/unxt_hypothesis/_version.py"
-version-file-template = """\
-version: str = {version!r}
-version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]
-version_tuple = {version_tuple!r}
-"""
-
 
 [tool.uv.sources]
 "unxts.hypothesis" = { workspace = true }


### PR DESCRIPTION
## Summary

`unxt-api` and `unxt-hypothesis` are backward-compat shims that re-export `__version__` from their canonical package (`unxts.api` / `unxts.hypothesis`) — neither imports a local `_version.py`. So the `[tool.hatch.build.hooks.vcs] version-file = ...` hook wrote a file nothing used, and the two shims were inconsistent (only `unxt-hypothesis` carried a `version-file-template`).

Removed the hook from both. The package/dist version still comes from `[tool.hatch.version] source = "vcs"`.

## Verification
Both shims build with a proper hatch-vcs version (`unxt_api-1.11.1.dev58`, `unxt_hypothesis-1.11.1.dev58`), not `0.0.0`. taplo/toml checks pass.

## Audit context
Pre-v2.0 audit, Low-severity packaging item (deferred from the original series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)