### PR TITLE
📄 license: adopt PEP 639 SPDX license metadata across the workspace

### DIFF
--- a/packages/unxt-api/pyproject.toml
+++ b/packages/unxt-api/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -22,7 +21,7 @@ classifiers = [
 dependencies = ["unxts.api>=2.0.0"]
 description = "Abstract dispatch API definitions for unxt"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxt-api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxt-hypothesis/pyproject.toml
+++ b/packages/unxt-hypothesis/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -22,7 +21,7 @@ classifiers = [
 dependencies = ["unxts.hypothesis>=2.0.0"]
 description = "Hypothesis strategies for unxt"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxt-hypothesis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -22,7 +21,7 @@ classifiers = [
 dependencies = ["plum-dispatch>=2.5.7"]
 description = "Abstract dispatch API definitions for unxt (canonical: unxts.api)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.hypothesis/pyproject.toml
+++ b/packages/unxts.hypothesis/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -22,7 +21,7 @@ classifiers = [
 dependencies = ["unxt>=2.0.0", "hypothesis[numpy]>=6.138.14", "jax>=0.5.3"]
 description = "Hypothesis strategies for unxt (canonical: unxts.hypothesis)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.hypothesis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.interop.gala/pyproject.toml
+++ b/packages/unxts.interop.gala/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -28,7 +27,7 @@ dependencies = [
 ]
 description = "gala integration for unxt (canonical: unxts.interop.gala)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.interop.gala"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.interop.matplotlib/pyproject.toml
+++ b/packages/unxts.interop.matplotlib/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -21,7 +20,7 @@ classifiers = [
 dependencies = ["matplotlib>=3.8", "unxt>=2.0.0", "zeroth>=1.0.0"]
 description = "matplotlib integration for unxt (canonical: unxts.interop.matplotlib)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.interop.matplotlib"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.interop.xarray/pyproject.toml
+++ b/packages/unxts.interop.xarray/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -21,7 +20,7 @@ classifiers = [
 dependencies = ["unxt>=2.0.0", "xarray>=2024.1.0"]
 description = "xarray integration for unxt (canonical: unxts.interop.xarray)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.interop.xarray"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -28,7 +27,7 @@ dependencies = [
 ]
 description = "Heterogeneous-unit matrices and vectors for unxt (canonical: unxts.linalg)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.linalg"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -27,7 +26,7 @@ dependencies = [
 ]
 description = "Dimension-parametrized quantities for unxt (canonical: unxts.parametric)"
 dynamic = ["version"]
-license.text = "BSD-3-Clause"
+license = "BSD-3-Clause"
 name = "unxts.parametric"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
@@ -43,7 +42,8 @@ dependencies = [
 ]
 description = "Quantities in JAX"
 dynamic = ["version"]
-license.file = "LICENSE"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "unxt"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

License metadata was inconsistent — the root used `license.file = "LICENSE"`, while all nine sub-packages used the free-text `license.text = "BSD-3-Clause"`. Unify on the PEP 639 SPDX form:

- `license = "BSD-3-Clause"` everywhere — a proper SPDX expression, emitted as `License-Expression` under Metadata-Version 2.4.
- Root adds `license-files = ["LICENSE"]`, so its wheel bundles the license text (`License-File: LICENSE`).
- Drop the now-redundant `License :: OSI Approved :: BSD License` classifier, which PEP 639 supersedes.

## Verification
Built root `unxt` and package wheels: all carry `License-Expression: BSD-3-Clause` (root also `License-File: LICENSE`); the deprecated classifier is gone. `taplo-format` and `sp-repo-review` pass; `uv.lock` unaffected.

Note: the sub-packages don't bundle their own `LICENSE` file today (they used `license.text`, which bundled nothing). This PR keeps that behavior — adding per-package `LICENSE` files/symlinks would be a separate, optional follow-up.

## Audit context
Pre-v2.0 audit, Low-severity packaging item (deferred from the original series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)