### PR TITLE
🧹 chore(interop): add the Python 3.14 classifier

### DIFF
--- a/packages/unxts.interop.gala/pyproject.toml
+++ b/packages/unxts.interop.gala/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",

--- a/packages/unxts.interop.matplotlib/pyproject.toml
+++ b/packages/unxts.interop.matplotlib/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",

--- a/packages/unxts.interop.xarray/pyproject.toml
+++ b/packages/unxts.interop.xarray/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",


### PR DESCRIPTION
## Summary

The three `unxts.interop.*` packages listed Python 3.11–3.13 but omitted `Programming Language :: Python :: 3.14`. They're `requires-python = ">=3.11"` (no upper cap), tested on 3.14 in CI (the interop jobs use the shared `["3.11","3.12","3.13","3.14"]` matrix), and their equally-new sibling `unxts.linalg` already advertises 3.14 — so the missing classifier is drift. Added it.

**Left `Development Status :: 4 - Beta` unchanged.** In the audit this looked like it might be drift vs. the `5 - Production/Stable` core packages, but `unxts.linalg` (also new) is `4 - Beta` too — so it's a deliberate newer-package distinction, not an oversight. If you'd rather promote the interops (and linalg) to `5 - Production/Stable`, that's a quick follow-up; I didn't want to make that maturity call for you.

## Audit context
Pre-v2.0 audit, Low-severity packaging item (deferred). This is the "confirm intentional" classifier finding — resolved: 3.14 was drift (fixed), 4-Beta is intentional (kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)