### PR TITLE
🐛 fix(unitsystems): stop SI/CGS/dimensionless singletons corrupting globals

### DIFF
--- a/src/unxt/_src/unitsystems/builtin.py
+++ b/src/unxt/_src/unitsystems/builtin.py
@@ -11,7 +11,6 @@ from astropy.units import UnitBase as AstropyUnitBase, dimensionless_unscaled
 
 from . import builtin_dimensions as ud
 from .base import AbstractUnitSystem
-from unxt._src.utils import SingletonMixin
 
 Unit: TypeAlias = AstropyUnitBase
 
@@ -19,17 +18,18 @@ Unit: TypeAlias = AstropyUnitBase
 @jtu.register_static
 @final
 @dataclass(frozen=True, slots=True)
-class DimensionlessUnitSystem(SingletonMixin, AbstractUnitSystem):
+class DimensionlessUnitSystem(AbstractUnitSystem):
     """A unit system with only dimensionless units.
 
-    This is a singleton class.
+    Prefer the ``dimensionless`` realization from `unxt.unitsystems`. Distinct
+    instances compare equal by value:
 
     Examples
     --------
     >>> from unxt.unitsystems import DimensionlessUnitSystem
     >>> dims1 = DimensionlessUnitSystem()
     >>> dims2 = DimensionlessUnitSystem()
-    >>> dims1 is dims2
+    >>> dims1 == dims2
     True
 
     """
@@ -71,7 +71,7 @@ class LTMAUnitSystem(AbstractUnitSystem):
 @jtu.register_static
 @final
 @dataclass(frozen=True, slots=True)
-class SIUnitSystem(SingletonMixin, AbstractUnitSystem):
+class SIUnitSystem(AbstractUnitSystem):
     """SI unit system + angles.
 
     Note: this is not part of the public API! Use the `si` instance (realization) from
@@ -130,7 +130,7 @@ class SIUnitSystem(SingletonMixin, AbstractUnitSystem):
 @jtu.register_static
 @final
 @dataclass(frozen=True, slots=True)
-class CGSUnitSystem(SingletonMixin, AbstractUnitSystem):
+class CGSUnitSystem(AbstractUnitSystem):
     """CGS unit system + angles.
 
     Note: this is not part of the public API! Use the `cgs` instance (realization) from

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -174,9 +174,37 @@ class TestDimensionlessUnitSystem:
         assert str(dimensionless) == "DimensionlessUnitSystem()"
 
 
-def test_dimensionless_singleton():
-    """Test that the dimensionless unit system is a singleton."""
-    assert DimensionlessUnitSystem() is dimensionless
+def test_dimensionless_value_equality():
+    """A freshly-built dimensionless system equals the ``dimensionless`` realization."""
+    assert DimensionlessUnitSystem() == dimensionless
+
+
+def test_building_system_does_not_mutate_realizations():
+    """Building a system must never mutate the global si/cgs/dimensionless.
+
+    Regression test: the built-in realizations were ``SingletonMixin`` frozen
+    dataclasses, so constructing any SI/CGS/dimensionless-dimensioned system via
+    the public ``unitsystem(...)`` API ran ``__init__`` on the cached singleton
+    and overwrote its fields process-wide.
+    """
+    si_before = unitsystems.si.base_units
+    cgs_before = unitsystems.cgs.base_units
+    dimensionless_before = dimensionless.base_units
+
+    # Build unrelated systems with the same dimensions but different units.
+    custom_si = unitsystem("km", "g", "minute", "mol", "A", "K", "cd", "deg")
+    custom_cgs = unitsystem("m", "kg", "s", "N", "J", "Pa", "Pa s", "m2 / s", "deg")
+    custom_dimensionless = unitsystem(unit("percent"))
+
+    # The globals are untouched.
+    assert unitsystems.si.base_units == si_before
+    assert unitsystems.cgs.base_units == cgs_before
+    assert dimensionless.base_units == dimensionless_before
+
+    # And the custom systems really do carry their own (different) units.
+    assert custom_si.base_units != si_before
+    assert custom_cgs.base_units != cgs_before
+    assert custom_dimensionless.base_units != dimensionless_before
 
 
 def test_equivalent():


### PR DESCRIPTION
## Problem

Building **any** SI/CGS/dimensionless-dimensioned unit system through the public `unitsystem(...)` API silently mutates the global `si`/`cgs`/`dimensionless` realizations **process-wide**:

```python
import unxt as u
repr(u.unitsystems.si)   # unitsystem(m, kg, s, mol, A, K, cd, rad)
u.unitsystem('km', 'g', 'minute', 'mol', 'A', 'K', 'cd', 'deg')
repr(u.unitsystems.si)   # unitsystem(km, g, min, mol, A, K, cd, deg)  ← corrupted
```

## Root cause

`SIUnitSystem`, `CGSUnitSystem`, and `DimensionlessUnitSystem` mixed in `SingletonMixin`. Its `__new__` returns the cached instance, but the frozen-dataclass `__init__` still runs on that returned object and overwrites its fields via `object.__setattr__`. The registry (`_UNITSYSTEMS_REGISTRY`, keyed on the dimension signature) dispatches `unitsystem(...)` to `SIUnitSystem(*args)` / `CGSUnitSystem(*args)` / `DimensionlessUnitSystem(*args)` — so constructing a fresh system with those dimensions clobbers the singleton. It also made two distinct SI-dimensioned systems alias the same object.

## Fix

Drop `SingletonMixin` from the three classes. They remain frozen, `jtu.register_static` dataclasses, so equality is still **by value** — identity was never required for correctness. Building a system no longer mutates the globals, and two SI-dimensioned systems with different units can now coexist.

The only observable behavior change is that `DimensionlessUnitSystem() is dimensionless` is no longer `True` (they are `==`); the `dimensionless`/`si`/`cgs` module realizations are unchanged singletons in practice.

## Tests

- `test_building_system_does_not_mutate_realizations` — regression: constructing SI/CGS/dimensionless-dimensioned systems leaves `si`/`cgs`/`dimensionless` untouched, and the custom systems carry their own units.
- Replaced `test_dimensionless_singleton` (identity) with `test_dimensionless_value_equality` (value equality).
- Full `tests/unit/test_unitsystems.py` + `tests/benchmark/test_unitsystems.py` (54) and sybil src doctests (82) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)