### PR TITLE
🐛 fix(quantity): convert angle units in deg2rad/rad2deg numpy ufuncs

### DIFF
--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -184,7 +184,7 @@ result = my_function(positions)  # Works with quantities
 
 ### ⚠️ Angle conversions: `deg2rad`, `rad2deg`, and friends
 
-`jnp.deg2rad`, `jnp.rad2deg`, `jnp.radians`, and `jnp.degrees` lower to a plain multiplication (`x * pi/180`). Under `quaxed`/`quax` that scales the _value_ but leaves the _unit label_ unchanged, so the quantity is silently mislabeled:
+`jnp.deg2rad`, `jnp.rad2deg`, `jnp.radians`, and `jnp.degrees` lower to a plain multiplication by a constant conversion factor (`x * pi/180` for `deg2rad`/`radians`, `x * 180/pi` for `rad2deg`/`degrees`). Under `quaxed`/`quax` that scales the _value_ but leaves the _unit label_ unchanged, so the quantity is silently mislabeled:
 
 ```python
 import quaxed.numpy as jnp

--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -197,10 +197,10 @@ _ = jnp.deg2rad(u.Q(180.0, "deg"))
 Convert angles with `uconvert` (or the `.uconvert` method), which tracks units correctly:
 
 ```python
-# ✅ Quantity(3.14159, unit='rad')
+# ✅ converts degrees -> radians (value rescaled, unit label becomes 'rad')
 _ = u.Q(180.0, "deg").uconvert("rad")
 
-# ✅ Quantity(180., unit='deg')
+# ✅ converts radians -> degrees (value rescaled, unit label becomes 'deg')
 _ = u.uconvert("deg", u.Q(3.14159, "rad"))
 ```
 

--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -182,6 +182,30 @@ def my_function(x):
 result = my_function(positions)  # Works with quantities
 ```
 
+### ⚠️ Angle conversions: `deg2rad`, `rad2deg`, and friends
+
+`jnp.deg2rad`, `jnp.rad2deg`, `jnp.radians`, and `jnp.degrees` lower to a plain multiplication (`x * pi/180`). Under `quaxed`/`quax` that scales the _value_ but leaves the _unit label_ unchanged, so the quantity is silently mislabeled:
+
+```python
+import quaxed.numpy as jnp
+import unxt as u
+
+# ❌ scales the value but keeps 'deg' -> Quantity(3.14159, unit='deg')
+_ = jnp.deg2rad(u.Q(180.0, "deg"))
+```
+
+Convert angles with `uconvert` (or the `.uconvert` method), which tracks units correctly:
+
+```python
+# ✅ Quantity(3.14159, unit='rad')
+_ = u.Q(180.0, "deg").uconvert("rad")
+
+# ✅ Quantity(180., unit='deg')
+_ = u.uconvert("deg", u.Q(3.14159, "rad"))
+```
+
+The NumPy entry points (`np.deg2rad(q)`, `np.rad2deg(q)`, ...) are handled correctly: they convert the angle and raise on a non-angle quantity.
+
 ### ✅ Dimension Checking Works in JIT
 
 Good news! Dimensions are checked inside JIT:

--- a/src/unxt/_src/quantity/register_ufuncs.py
+++ b/src/unxt/_src/quantity/register_ufuncs.py
@@ -114,3 +114,34 @@ def apply_ufunc(
             return fn(*inputs, **kwargs)
 
     return NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# Built-in overrides
+#
+# ``deg2rad``/``rad2deg``/``radians``/``degrees`` are angle *conversions*, but
+# JAX lowers them to ``x * (pi/180)`` (a bare ``mul``). The default delegation
+# to ``quaxed.numpy`` therefore scales the value while leaving the unit label
+# unchanged -- a silently wrong result (``deg2rad(180 deg) -> 3.14159 deg``).
+# Register explicit handlers that convert an angle quantity to the target unit
+# (and raise on a non-angle quantity, matching astropy).
+
+_ANGLE_CONVERSIONS: dict[np.ufunc, str] = {
+    np.deg2rad: "rad",
+    np.radians: "rad",
+    np.rad2deg: "deg",
+    np.degrees: "deg",
+}
+
+
+def _make_angle_handler(to_unit: str) -> AnyCallable:
+    def handler(_ufunc: np.ufunc, method: str, x: Any, /, **_kwargs: Any) -> Any:
+        if method != "__call__":
+            return NotImplemented
+        return x.uconvert(to_unit)
+
+    return handler
+
+
+for _ufunc, _to_unit in _ANGLE_CONVERSIONS.items():
+    _UFUNC_REGISTRY[_ufunc] = _make_angle_handler(_to_unit)

--- a/src/unxt/_src/quantity/register_ufuncs.py
+++ b/src/unxt/_src/quantity/register_ufuncs.py
@@ -135,9 +135,18 @@ _ANGLE_CONVERSIONS: dict[np.ufunc, str] = {
 
 
 def _make_angle_handler(to_unit: str) -> AnyCallable:
-    def handler(_ufunc: np.ufunc, method: str, x: Any, /, **_kwargs: Any) -> Any:
+    def handler(ufunc: np.ufunc, method: str, x: Any, /, **kwargs: Any) -> Any:
         if method != "__call__":
             return NotImplemented
+        # These handlers reduce to a unit conversion and do not honour ufunc
+        # keyword arguments (``out``, ``where``, ``casting``, ...). Raise loudly
+        # rather than silently ignore them and return a surprising result.
+        if kwargs:
+            msg = (
+                f"`np.{ufunc.__name__}` on a Quantity does not support the ufunc "
+                f"keyword argument(s) {sorted(kwargs)}."
+            )
+            raise TypeError(msg)
         return x.uconvert(to_unit)
 
     return handler

--- a/src/unxt/_src/quantity/register_ufuncs.py
+++ b/src/unxt/_src/quantity/register_ufuncs.py
@@ -120,9 +120,10 @@ def apply_ufunc(
 # Built-in overrides
 #
 # ``deg2rad``/``rad2deg``/``radians``/``degrees`` are angle *conversions*, but
-# JAX lowers them to ``x * (pi/180)`` (a bare ``mul``). The default delegation
-# to ``quaxed.numpy`` therefore scales the value while leaving the unit label
-# unchanged -- a silently wrong result (``deg2rad(180 deg) -> 3.14159 deg``).
+# JAX lowers them to a bare scalar ``mul`` (``x * pi/180`` for deg->rad,
+# ``x * 180/pi`` for rad->deg). The default delegation to ``quaxed.numpy``
+# therefore scales the value while leaving the unit label unchanged -- a
+# silently wrong result (``deg2rad(180 deg) -> 3.14159 deg``).
 # Register explicit handlers that convert an angle quantity to the target unit
 # (and raise on a non-angle quantity, matching astropy).
 

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -191,6 +191,14 @@ def test_angle_ufuncs_reject_non_angle():
             fn(u.Q(5.0, "m"))
 
 
+def test_angle_ufuncs_reject_unsupported_kwargs():
+    """Angle ufuncs raise on ufunc kwargs rather than silently ignoring them."""
+    q = u.Q(180.0, "deg")
+    for kwargs in ({"where": np.array([True])}, {"casting": "same_kind"}):
+        with pytest.raises(TypeError, match="does not support"):
+            np.deg2rad(q, **kwargs)
+
+
 def test_bare_quantity_also_supported():
     """``__array_ufunc__`` is inherited by all quantity types."""
     q = u.quantity.Quantity(5.0, "m")

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -162,7 +162,7 @@ def test_deg2rad_converts_angle_to_radians():
     """
     for fn in (np.deg2rad, np.radians):
         got = fn(u.Q(180.0, "deg"))
-        assert isinstance(got, u.Q)
+        assert isinstance(got, u.quantity.Quantity)
         assert got.unit == u.unit("rad")
         assert np.isclose(np.asarray(got.value), np.pi)
 
@@ -176,7 +176,7 @@ def test_rad2deg_converts_angle_to_degrees():
     """``np.rad2deg``/``np.degrees`` convert an angle quantity to degrees."""
     for fn in (np.rad2deg, np.degrees):
         got = fn(u.Q(np.pi, "rad"))
-        assert isinstance(got, u.Q)
+        assert isinstance(got, u.quantity.Quantity)
         assert got.unit == u.unit("deg")
         assert np.isclose(np.asarray(got.value), 180.0)
 

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -152,6 +152,45 @@ def test_unsupported_method_raises():
         np.add.outer(q, q)
 
 
+def test_deg2rad_converts_angle_to_radians():
+    """``np.deg2rad``/``np.radians`` convert an angle quantity to radians.
+
+    Regression: these lower to ``x * (pi/180)`` (a bare ``mul``), so without an
+    explicit handler the value was scaled while the unit label was left as
+    ``deg`` -- a silently wrong result.
+    """
+    for fn in (np.deg2rad, np.radians):
+        got = fn(u.Q(180.0, "deg"))
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("rad")
+        assert np.isclose(np.asarray(got.value), np.pi)
+
+        # radians in -> radians out (identity conversion), not re-scaled.
+        got_rad = fn(u.Q(np.pi, "rad"))
+        assert got_rad.unit == u.unit("rad")
+        assert np.isclose(np.asarray(got_rad.value), np.pi)
+
+
+def test_rad2deg_converts_angle_to_degrees():
+    """``np.rad2deg``/``np.degrees`` convert an angle quantity to degrees."""
+    for fn in (np.rad2deg, np.degrees):
+        got = fn(u.Q(np.pi, "rad"))
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("deg")
+        assert np.isclose(np.asarray(got.value), 180.0)
+
+        got_deg = fn(u.Q(180.0, "deg"))
+        assert got_deg.unit == u.unit("deg")
+        assert np.isclose(np.asarray(got_deg.value), 180.0)
+
+
+def test_angle_ufuncs_reject_non_angle():
+    """Angle ufuncs raise on a non-angle quantity instead of mangling it."""
+    for fn in (np.deg2rad, np.rad2deg, np.radians, np.degrees):
+        with pytest.raises(Exception, match=r"convert|angle|dimension"):
+            fn(u.Q(5.0, "m"))
+
+
 def test_bare_quantity_also_supported():
     """``__array_ufunc__`` is inherited by all quantity types."""
     q = u.quantity.Quantity(5.0, "m")

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -6,6 +6,7 @@ units instead of silently dropping them.
 
 from unittest.mock import Mock
 
+import astropy.units as apyu
 import numpy as np
 import pytest
 
@@ -187,7 +188,7 @@ def test_rad2deg_converts_angle_to_degrees():
 def test_angle_ufuncs_reject_non_angle():
     """Angle ufuncs raise on a non-angle quantity instead of mangling it."""
     for fn in (np.deg2rad, np.rad2deg, np.radians, np.degrees):
-        with pytest.raises(Exception, match=r"convert|angle|dimension"):
+        with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             fn(u.Q(5.0, "m"))
 
 


### PR DESCRIPTION
## Problem

`np.deg2rad`, `np.rad2deg`, `np.radians`, and `np.degrees` produced **silently wrong** results on angle quantities:

```python
import numpy as np, unxt as u
np.deg2rad(u.Q(180.0, "deg"))   # Quantity(3.14159, unit='deg')  ← wrong: value scaled, unit label kept
```

astropy gives `3.14159 rad`. The number is converted (×π/180) but the unit stays `deg`, so the result is wrong by a factor of 180/π in every downstream unit-aware operation — the worst failure mode for a units library.

## Root cause

JAX lowers these to a bare multiplication `x * (pi/180)` (verified: `jax.make_jaxpr(jnp.deg2rad)(1.0)` → `mul a 0.01745…`). There is no `deg2rad_p` primitive to intercept. `AbstractQuantity.__array_ufunc__` → `apply_ufunc` delegated the built-in ufunc to `quaxed.numpy.deg2rad`, which decomposes to the `mul_p` rule that (correctly, for a scalar multiply) keeps the left operand's unit.

## Fix

Register explicit `_UFUNC_REGISTRY` handlers for the four ufuncs that convert the angle quantity to the target unit via `uconvert`:

| ufunc | target |
|---|---|
| `deg2rad`, `radians` | `rad` |
| `rad2deg`, `degrees` | `deg` |

astropy's convertibility rules give the angle-only guard for free — a non-angle quantity raises `UnitConversionError` (`'m' (length) and 'rad' (angle) are not convertible`), matching astropy's behavior of rejecting non-angle input.

```python
np.deg2rad(u.Q(180.0, "deg"))   # Quantity(3.14159, unit='rad')  ✅
np.rad2deg(u.Q(np.pi, "rad"))   # Quantity(180.,    unit='deg')  ✅
np.deg2rad(u.Q(5.0, "m"))       # UnitConversionError            ✅
```

## Known limitation (documented)

The `quaxed.numpy.deg2rad` path — i.e. the `import quaxed.numpy as jnp; jnp.deg2rad(q)` idiom — is a `quax._core._Quaxify` object with no registration hook, and it decomposes to `mul` before unxt sees it, so it **cannot** be intercepted from unxt. This PR adds a `docs/guides/sharp-bits.md` section documenting the pitfall and steering users to `uconvert`/`.uconvert` (which track units correctly) for angle conversion. A complete fix for that path needs an upstream hook in `quax`/`quaxed`; happy to file that separately.

## Tests

- `test_deg2rad_converts_angle_to_radians`, `test_rad2deg_converts_angle_to_degrees` — deg↔rad conversion both directions (incl. identity `rad→rad`).
- `test_angle_ufuncs_reject_non_angle` — non-angle input raises.
- Full `tests/unit/test_numpy_ufunc.py` (15) and `docs/guides/sharp-bits.md` sybil doctests (24) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)