### PR TITLE
🐛 fix(quantity): make StaticValue pickle- and deepcopy-safe

### DIFF
--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -133,6 +133,15 @@ class StaticValue:
         return self._array[key]
 
     def __getattr__(self, name: str) -> Any:
+        # Only forward *public* attributes to the wrapped array. Dunder and
+        # private names must raise ``AttributeError`` so that (a) the copy /
+        # pickle protocol (``__deepcopy__``, ``__setstate__``, ...) falls back
+        # to the correct slot-based default instead of being answered by the
+        # wrapped array, and (b) a lookup during reconstruction -- when the
+        # ``_array`` slot is not yet set -- cannot recurse through this method.
+        if name.startswith("_"):
+            msg = f"{type(self).__name__!r} object has no attribute {name!r}"
+            raise AttributeError(msg)
         return getattr(jnp.asarray(self._array), name)
 
     def __repr__(self) -> str:

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -1,5 +1,7 @@
 """Tests for StaticQuantity."""
 
+import copy
+import pickle
 from functools import partial
 
 import equinox as eqx
@@ -13,6 +15,51 @@ from hypothesis.extra.numpy import arrays as np_arrays
 from plum import promote
 
 import unxt as u
+from unxt.quantity import StaticValue
+
+
+def test_static_value_pickle_roundtrip() -> None:
+    """A `StaticValue` survives a pickle round-trip unchanged.
+
+    Regression: `StaticValue.__getattr__` forwarded ``__setstate__`` to the
+    wrapped array, and dereferenced ``_array`` before it was restored, so
+    unpickling recursed infinitely (`RecursionError`).
+    """
+    sv = StaticValue(np.array([1.0, 2.0], dtype=np.float64))
+    got = pickle.loads(pickle.dumps(sv))  # noqa: S301
+    assert isinstance(got, StaticValue)
+    assert np.array_equal(np.asarray(got), np.asarray(sv))
+    assert np.asarray(got).dtype == np.float64
+
+
+def test_static_value_deepcopy_preserves_type_and_dtype() -> None:
+    """`copy.deepcopy` returns an equal `StaticValue`, not the bare array.
+
+    Regression: numpy arrays define ``__deepcopy__``, so ``__getattr__``
+    forwarded the lookup and deepcopy returned the wrapped array (a
+    ``TypedNdArray``, silently downcast to float32) instead of a `StaticValue`.
+    """
+    sv = StaticValue(np.array([1.0, 2.0], dtype=np.float64))
+    got = copy.deepcopy(sv)
+    assert isinstance(got, StaticValue)
+    assert np.array_equal(np.asarray(got), np.asarray(sv))
+    assert np.asarray(got).dtype == np.float64
+    # deepcopy is independent: the copy is its own read-only buffer.
+    assert not np.shares_memory(np.asarray(got), np.asarray(sv))
+
+    shallow = copy.copy(sv)
+    assert isinstance(shallow, StaticValue)
+    assert np.array_equal(np.asarray(shallow), np.asarray(sv))
+
+
+def test_static_quantity_pickle_roundtrip() -> None:
+    """A `StaticQuantity` survives a pickle round-trip unchanged."""
+    sq = u.StaticQuantity(np.array([1.0, 2.0], dtype=np.float64), "m")
+    got = pickle.loads(pickle.dumps(sq))  # noqa: S301
+    assert isinstance(got, u.StaticQuantity)
+    assert got.unit == u.unit("m")
+    assert np.array_equal(np.asarray(got.value), np.asarray(sq.value))
+    assert hash(got) == hash(sq)
 
 
 def test_static_quantity_accepts_numpy() -> None:


### PR DESCRIPTION
## Problem

`StaticQuantity` (and any `Quantity` backed by a `StaticValue`) cannot be pickled and is silently corrupted by `copy.deepcopy`:

```python
import pickle, copy, numpy as np, unxt as u
sq = u.StaticQuantity(np.array([1., 2.]), "m")
pickle.loads(pickle.dumps(sq))   # RecursionError: maximum recursion depth exceeded
copy.deepcopy(sq)                # StaticQuantity(TypedNdArray([1., 2.], dtype=float32), ...) ← corrupted
```

This matters because `StaticQuantity`'s entire reason to exist is being a **static, hashable `jax.jit` argument** — exactly the context where multiprocessing (`pickle`) and equinox/JAX transforms (`copy.deepcopy`) exercise these protocols.

## Root cause

`StaticValue.__getattr__` (`value.py`) forwarded *every* missing attribute to the wrapped array:

```python
def __getattr__(self, name):
    return getattr(jnp.asarray(self._array), name)
```

- **deepcopy**: numpy arrays define `__deepcopy__`, so the lookup was answered by the *array*, and `copy.deepcopy` returned the bare array (a `TypedNdArray`, silently downcast float64 → float32) instead of a `StaticValue`.
- **pickle**: unpickling probes `__setstate__` (not on `object`), so `__getattr__` fired and dereferenced `self._array` — which is not yet restored during reconstruction — recursing infinitely.

## Fix

Guard `__getattr__` to raise `AttributeError` for underscore/dunder names, so only **public** numpy attributes forward to the array. The copy/pickle protocol then falls back to the correct slot-based default, and a lookup during reconstruction (when `_array` is unset) can no longer recurse.

```python
pickle.loads(pickle.dumps(sq))   # StaticQuantity(...)  ✅ round-trips, hash preserved
copy.deepcopy(sq)                # StaticQuantity(...)  ✅ float64 preserved, independent buffer
```

Public forwarding (`sv.dtype`, `sv.shape`, `sv.reshape`, ...) is unchanged.

## Tests

- `test_static_value_pickle_roundtrip`, `test_static_quantity_pickle_roundtrip` — pickle round-trips preserve type, values, dtype, and hash.
- `test_static_value_deepcopy_preserves_type_and_dtype` — deepcopy returns an independent `StaticValue` with dtype intact; `copy.copy` too.
- Full `tests/unit/test_static_quantity.py` (39) + `value.py` doctests pass; full `tests/unit` green apart from the pre-existing `test_package::test_version` metadata check (fails identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
