### PR TITLE
✨ feat(quantity): support format specs, e.g. f"{q:.2f}"

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -882,6 +882,31 @@ class AbstractQuantity(
             indent=config.quantity_str.indent,
         )
 
+    def __format__(self, format_spec: str, /) -> str:
+        """Format the quantity, applying ``format_spec`` to the value.
+
+        An empty spec preserves the default :meth:`__str__` representation. A
+        non-empty spec is applied to the value and the unit is appended (as in
+        `astropy.units.Quantity`); a dimensionless quantity has no unit suffix.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> q = u.Q(3.14159, "m")
+        >>> f"{q:.2f}"
+        '3.14 m'
+        >>> format(q, ".3e")
+        '3.142e+00 m'
+        >>> format(u.Q(3.14159, ""), ".2f")
+        '3.14'
+
+        """
+        if not format_spec:
+            return str(self)
+        value_str = format(self.value, format_spec)
+        unit_str = str(self.unit)
+        return f"{value_str} {unit_str}" if unit_str else value_str
+
 
 def _is_different_from_default(value: Any, default: Any) -> bool:
     """Check if value differs from default using equality when safe."""

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -138,6 +138,15 @@ class StaticValue:
     def __repr__(self) -> str:
         return wl.pformat(self, short_arrays=False, max_width=80)
 
+    def __format__(self, format_spec: str, /) -> str:
+        """Format the wrapped value, delegating to the NumPy array.
+
+        This makes ``format(sv, spec)`` (and hence formatting a
+        ``StaticQuantity``) behave like formatting the underlying scalar; a
+        non-scalar value raises ``TypeError`` as NumPy does.
+        """
+        return format(self._array, format_spec)
+
     @override
     def __eq__(self, other: object, /) -> bool | np.ndarray:  # type: ignore[override]
         if isinstance(other, StaticValue):

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -3,6 +3,8 @@
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
+import pytest
 import wadler_lindig as wl
 
 import unxt as u
@@ -228,3 +230,18 @@ def test_format_empty_spec_matches_str() -> None:
     q = u.Q(3.14159, "m")
     assert f"{q}" == str(q)
     assert format(q, "") == str(q)
+
+
+def test_format_static_quantity() -> None:
+    """A ``StaticQuantity`` (value is a ``StaticValue``) formats like a scalar."""
+    q = u.StaticQuantity(3.14159, "m")
+    assert f"{q:.2f}" == "3.14 m"
+    assert f"{u.StaticQuantity(3.14159, ''):.2f}" == "3.14"
+    assert f"{q}" == str(q)
+
+
+def test_format_non_scalar_raises() -> None:
+    """A non-empty spec on a non-scalar quantity raises (NumPy semantics)."""
+    for q in (u.Q([1.5, 2.5], "m"), u.StaticQuantity(np.array([1.5, 2.5]), "m")):
+        with pytest.raises(TypeError, match="unsupported format string"):
+            format(q, ".2f")

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -208,3 +208,23 @@ class TestStringConversionWithJIT:
         assert result.unit == q.unit
 
         assert jnp.allclose(result.value, q.value * 2)
+
+
+def test_format_spec_applies_to_value_and_appends_unit() -> None:
+    """``f"{q:.2f}"`` formats the value per the spec and appends the unit."""
+    q = u.Q(3.14159, "m")
+    assert f"{q:.2f}" == "3.14 m"
+    assert format(q, ".3e") == "3.142e+00 m"
+
+
+def test_format_dimensionless_has_no_trailing_unit() -> None:
+    """A dimensionless quantity formats to just the value (no trailing space)."""
+    q = u.Q(3.14159, "")
+    assert f"{q:.2f}" == "3.14"
+
+
+def test_format_empty_spec_matches_str() -> None:
+    """An empty format spec preserves the existing ``str`` representation."""
+    q = u.Q(3.14159, "m")
+    assert f"{q}" == str(q)
+    assert format(q, "") == str(q)


### PR DESCRIPTION
## Problem

`Quantity` defines no `__format__`, so it inherits `object.__format__`, which rejects any format spec:

```python
>>> import unxt as u
>>> q = u.Q(3.14159, "m")
>>> f"{q:.2f}"
TypeError: unsupported format string passed to Quantity.__format__
```

`f"{q:.2f}"` is the single most common way users format physical quantities for logging, plots, and tables — astropy gives `"3.14 m"`. For a Production/Stable 2.0 this is a conspicuous ergonomic hole.

## Fix

Add `__format__` to `AbstractQuantity`:

- **Empty spec** → the existing `__str__` representation, so `f"{q}"` and `format(q, "")` are unchanged (no regression).
- **Non-empty spec** → applied to the value, with the unit appended (as in `astropy.units.Quantity`). A dimensionless quantity has no unit suffix (no trailing space).

```python
>>> f"{u.Q(3.14159, 'm'):.2f}"
'3.14 m'
>>> format(u.Q(3.14159, 'm'), ".3e")
'3.142e+00 m'
>>> f"{u.Q(3.14159, ''):.2f}"
'3.14'
```

Applying a spec to a multi-element array raises `TypeError` (numpy/astropy behavior), consistent with astropy's scalar-only format support.

## Tests

- `test_format_spec_applies_to_value_and_appends_unit`
- `test_format_dimensionless_has_no_trailing_unit`
- `test_format_empty_spec_matches_str` (regression guard for `f"{q}"`)
- Plus a runnable doctest on the method. Full `tests/unit/test_quantity_printing.py` (18) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)