### PR TITLE
🐛 fix(quantity): unit-blind equality + consistent hash/ne for static quantities

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,6 +57,6 @@ Equality
   For quantities, `==`. On a `StaticValue`-backed quantity it is **unit-blind** — two quantities are equal only when their unit *labels* match (so they remain distinct `jax.jit` `static_argnames` keys). Array-backed quantities compare element-wise and unit-aware. See {term}`Equivalence` for a cross-unit comparison.
 
 Equivalence
-  Whether two quantities are the **same physical amount**, accounting for unit conversion — e.g. `1000 m` and `1 km` are equivalent though not equal. Exposed as {func}`unxt.equivalent` and the `is_equivalent` method. The same `equivalent` function also reports whether two {term}`Unit System`\ s span the same dimensions.
+  Whether two quantities are the **same physical amount**, accounting for unit conversion — e.g. `1000 m` and `1 km` are equivalent though not equal. Exposed as {func}`unxt.equivalent` and the `is_equivalent` method. The same `equivalent` function also reports whether two {term}`Unit System`s span the same dimensions.
 
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -53,4 +53,10 @@ Non-parametric Class
   A non-parametric class is a class that is not defined by a set of parameters.
   The `unxt.quantity.Quantity` class is an example of a non-parametric class; it does not use any parameter.
 
+Equality
+  For quantities, `==`. On a `StaticValue`-backed quantity it is **unit-blind** — two quantities are equal only when their unit *labels* match (so they remain distinct `jax.jit` `static_argnames` keys). Array-backed quantities compare element-wise and unit-aware. See {term}`Equivalence` for a cross-unit comparison.
+
+Equivalence
+  Whether two quantities are the **same physical amount**, accounting for unit conversion — e.g. `1000 m` and `1 km` are equivalent though not equal. Exposed as {func}`unxt.equivalent` and the `is_equivalent` method. The same `equivalent` function also reports whether two {term}`Unit System`\ s span the same dimensions.
+
 ```

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -548,12 +548,12 @@ True
 False
 ```
 
-Unit conversion is applied before comparison, so equivalent quantities in different units compare equal:
+For a `StaticValue`-backed quantity this comparison is **unit-blind**: they are equal only when their unit labels match. Unit-aware equality would collapse physically-equal but differently-labelled quantities (e.g. `1000 m` and `1 km`) into one `jax.jit` `static_argnames` cache key and break the `__eq__`/`__hash__` contract, so convert first if you want to compare across units:
 
 ```{code-block} python
 >>> sv_km = u.quantity.StaticValue(np.array([0.001, 0.002]))
->>> u.Q(sv1, "m") == u.Q(sv_km, "km")  # 0.001 km == 1 m → True
-True
+>>> u.Q(sv1, "m") == u.Q(sv_km, "km")  # different unit labels → False
+False
 ```
 
 This contrasts with a regular `Quantity` (JAX array value), where `==` follows NumPy broadcasting and returns a per-element boolean array wrapped in a dimensionless `Quantity` (so the result shares a namespace with the input, per the Array API):

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -565,6 +565,30 @@ This contrasts with a regular `Quantity` (JAX array value), where `==` follows N
 Quantity(Array([ True, False], dtype=bool), unit='')
 ```
 
+### Equality vs. equivalence
+
+Because `==` on a `StaticValue`-backed quantity is **unit-blind**, reach for {func}`unxt.equivalent` (or the {meth}`~unxt.quantity.AbstractQuantity.is_equivalent` method) when you want a **unit-aware** "same physical quantity" check:
+
+```{code-block} python
+>>> u.Q(sv1, "m") == u.Q(sv_km, "km")               # unit-blind: labels differ
+False
+>>> u.equivalent(u.Q(sv1, "m"), u.Q(sv_km, "km"))   # unit-aware: same amount
+True
+>>> u.Q(sv1, "m").is_equivalent(u.Q(sv_km, "km"))
+True
+```
+
+`equivalent` mirrors `==`'s shape — a scalar `bool` for `StaticValue`-backed operands, an element-wise dimensionless `Quantity` for array-backed ones — and returns `False` (never raises) for incompatible dimensions:
+
+```{code-block} python
+>>> u.equivalent(u.Q([1.0, 2.0], "m"), u.Q([0.001, 0.009], "km"))
+Quantity(Array([ True, False], dtype=bool), unit='')
+>>> u.equivalent(u.Q(1.0, "m"), u.Q(1.0, "s"))       # incompatible dimensions
+False
+```
+
+**Rule of thumb:** use `==` for structural identity (and as a `jax.jit` `static_argnames` key); use `equivalent` to ask whether two quantities represent the same physical amount regardless of unit. The same `equivalent` function also compares unit systems (see {doc}`units_and_systems`).
+
 ### Using `Quantity(StaticValue)` as a `jax.jit` static argument
 
 Because equality returns `bool` and `StaticValue` is hashable, the whole `Quantity` is hashable, which lets JAX use it as a compile-time constant:

--- a/packages/unxts.parametric/docs/sharp-bits.md
+++ b/packages/unxts.parametric/docs/sharp-bits.md
@@ -29,7 +29,7 @@ What `ParametricQuantity` _does_ add is a new Python class — and a new registe
 
 ## Equality with `StaticValue`
 
-A normal `ParametricQuantity` (backed by a JAX array) follows NumPy broadcasting: `==` returns an **element-wise boolean array**, not a scalar `bool`. That makes it unusable as a `jax.jit` `static_argnames` argument. Wrapping the value in a `StaticValue` makes `==` return a **scalar `bool`** (structural equality, like a tuple), so the whole quantity is hashable and safe as a static argument. This comparison is **unit-blind** — quantities are equal only when their unit labels match, so physically-equal but differently-labelled quantities stay distinct static-arg cache keys; convert first to compare across units:
+A normal `ParametricQuantity` (backed by a JAX array) follows NumPy broadcasting: `==` returns an **element-wise boolean array**, not a scalar `bool`. That makes it unusable as a `jax.jit` `static_argnames` argument. Wrapping the value in a `StaticValue` makes `==` return a **scalar `bool`** (structural equality, like a tuple), so the whole quantity is hashable and safe as a static argument. This comparison is **unit-blind** — quantities are equal only when their unit labels match, so physically-equal but differently-labelled quantities stay distinct static-arg cache keys. Use {func}`unxt.equivalent` (or the `.is_equivalent` method) for a unit-aware "same physical quantity" check; the example below shows the unit-blind `==`:
 
 ```{code-block} python
 >>> import numpy as np

--- a/packages/unxts.parametric/docs/sharp-bits.md
+++ b/packages/unxts.parametric/docs/sharp-bits.md
@@ -29,13 +29,13 @@ What `ParametricQuantity` _does_ add is a new Python class — and a new registe
 
 ## Equality with `StaticValue`
 
-A normal `ParametricQuantity` (backed by a JAX array) follows NumPy broadcasting: `==` returns an **element-wise boolean array**, not a scalar `bool`. That makes it unusable as a `jax.jit` `static_argnames` argument. Wrapping the value in a `StaticValue` makes `==` return a **scalar `bool`** (structural equality, like a tuple), so the whole quantity is hashable and safe as a static argument. Unit conversion is applied before comparing, so equal physical values in compatible units compare equal:
+A normal `ParametricQuantity` (backed by a JAX array) follows NumPy broadcasting: `==` returns an **element-wise boolean array**, not a scalar `bool`. That makes it unusable as a `jax.jit` `static_argnames` argument. Wrapping the value in a `StaticValue` makes `==` return a **scalar `bool`** (structural equality, like a tuple), so the whole quantity is hashable and safe as a static argument. This comparison is **unit-blind** — quantities are equal only when their unit labels match, so physically-equal but differently-labelled quantities stay distinct static-arg cache keys; convert first to compare across units:
 
 ```{code-block} python
 >>> import numpy as np
 
 >>> scale = up.PQ(u.quantity.StaticValue(np.array([2.0, 3.0])), "m")
 >>> sv_km = u.quantity.StaticValue(np.array([0.002, 0.003]))
->>> bool(up.PQ(scale.value, "m") == up.PQ(sv_km, "km"))  # same physical value
-True
+>>> bool(up.PQ(scale.value, "m") == up.PQ(sv_km, "km"))  # different unit labels
+False
 ```

--- a/packages/unxts.parametric/tests/test_quantity_staticvalue_eq.py
+++ b/packages/unxts.parametric/tests/test_quantity_staticvalue_eq.py
@@ -17,9 +17,9 @@ def test_quantity_staticvalue_equality_scalar_bool():
     assert result is True
     assert (u.Q(sv1, "m") == u.Q(sv3, "m")) is False
 
-    # Unit conversion is applied before comparing.
+    # Equality is unit-blind: different unit labels compare not-equal.
     sv_km = u.quantity.StaticValue(np.array([0.001, 0.002]))
-    assert (u.Q(sv1, "m") == u.Q(sv_km, "km")) is True
+    assert (u.Q(sv1, "m") == u.Q(sv_km, "km")) is False
 
     # Incompatible dimensions are never equal.
     sv_s = u.quantity.StaticValue(np.array([1.0, 2.0]))

--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -56,6 +56,7 @@ __all__ = (
     "uconvert",  # convert units
     "ustrip",  # strip units
     "is_unit_convertible",  # check if units can be converted
+    "equivalent",  # physical equivalence (unit-aware), incl. unit systems
 )
 
 from .setup_package import install_import_hook
@@ -77,7 +78,12 @@ with install_import_hook("unxt"):
         ustrip,
     )
     from .units import AbstractUnit, unit, unit_of
-    from .unitsystems import AbstractUnitSystem, unitsystem, unitsystem_of
+    from .unitsystems import (
+        AbstractUnitSystem,
+        equivalent,
+        unitsystem,
+        unitsystem_of,
+    )
 
 from ._src import experimental  # noqa: F401
 

--- a/src/unxt/_src/quantity/__init__.py
+++ b/src/unxt/_src/quantity/__init__.py
@@ -13,6 +13,7 @@ from .value import *
 
 # isort: split
 from .register_api import *
+from .register_compare import *
 from .register_conversions import *
 from .register_dispatches import *
 from .register_primitives import *

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -6,6 +6,8 @@
 #    `_astropy_quantity_types` lazily imports `unxt._interop.OptDeps` and
 #    `astropy.units.Quantity`; importing `_interop` at module scope would cycle
 #    back through the interop registration into this package.
+#    `is_equivalent` imports `equivalent` from `register_compare` lazily to avoid
+#    an import cycle (register_compare imports this module)
 
 __all__ = ("AbstractQuantity", "is_any_quantity")
 
@@ -766,6 +768,23 @@ class AbstractQuantity(
             and isinstance(other, AbstractQuantity)
             and isinstance(other.value, StaticValue)
         )
+
+    def is_equivalent(self, other: "AbstractQuantity", /) -> Any:
+        """Whether ``self`` and ``other`` are physically equal (unit-aware).
+
+        The method form of `unxt.equivalent`; unlike ``==`` (which is unit-blind
+        for `StaticValue`-backed quantities) this accounts for unit conversion.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> u.Q(1000.0, "m").is_equivalent(u.Q(1.0, "km"))
+        Quantity(Array(True, dtype=bool...), unit='')
+
+        """
+        from .register_compare import equivalent  # noqa: PLC0415
+
+        return equivalent(self, other)
 
     def __hash__(self) -> int:
         """Return the hash of the quantity.

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -719,31 +719,50 @@ class AbstractQuantity(
         >>> u.Q(sv1, "m") == u.Q(sv3, "m")
         False
 
-        Unit conversion is applied before comparing, so equivalent quantities in
-        different units compare equal:
+        Equality is **unit-blind**: quantities are equal only when their unit
+        labels match. Unit-aware equality (``1000 m == 1 km``) is incompatible
+        with using a static quantity as a ``jax.jit`` ``static_argnames``
+        argument, where distinct units must remain distinct compilation cache
+        keys; it would also break the ``__eq__``/``__hash__`` contract, since the
+        hash is unit-label sensitive. Convert first if you want to compare
+        across units (e.g. ``a == b.uconvert(a.unit)``).
 
         >>> sv_km = u.quantity.StaticValue(np.array([0.001, 0.002]))
         >>> u.Q(sv1, "m") == u.Q(sv_km, "km")
-        True
-
-        Quantities with incompatible dimensions are never equal:
+        False
 
         >>> sv_s = u.quantity.StaticValue(np.array([1.0, 2.0]))
         >>> u.Q(sv1, "m") == u.Q(sv_s, "s")
         False
 
         """
-        if (
+        if self._is_static_backed(other):
+            return bool(
+                self.unit == other.unit
+                and np.array_equal(self.value.array, other.value.array)
+            )
+
+        return quax_blocks.NumpyEqMixin.__eq__(self, other)
+
+    def __ne__(self, other: object, /) -> Any:
+        """Return inequality, mirroring :meth:`__eq__`.
+
+        For two `StaticValue`-backed quantities this returns the scalar-`bool`
+        negation of the unit-blind equality, so ``==`` and ``!=`` stay
+        consistent (and usable as ``jax.jit`` static args). Otherwise it defers
+        to the element-wise NumPy comparison.
+        """
+        if self._is_static_backed(other):
+            return not self.__eq__(other)
+        return quax_blocks.NumpyNeMixin.__ne__(self, other)
+
+    def _is_static_backed(self, other: object, /) -> bool:
+        """Whether ``self`` and ``other`` are both `StaticValue`-backed."""
+        return (
             isinstance(self.value, StaticValue)
             and isinstance(other, AbstractQuantity)
             and isinstance(other.value, StaticValue)
-        ):
-            if not uapi.is_unit_convertible(other.unit, self.unit):
-                return False
-            converted = uapi.uconvert_value(self.unit, other.unit, other.value.array)
-            return bool(np.array_equal(self.value.array, converted))
-
-        return quax_blocks.NumpyEqMixin.__eq__(self, other)
+        )
 
     def __hash__(self) -> int:
         """Return the hash of the quantity.

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -691,9 +691,10 @@ class AbstractQuantity(
 
         When both operands carry a `StaticValue`, structural (scalar bool)
         equality is returned so that the quantity can be used safely as a
-        ``static_argnames`` argument in `jax.jit`. Units are accounted for by
-        converting `other` to `self`'s units before comparing. In all other
-        cases the element-wise `NumpyEqMixin` behaviour is preserved.
+        ``static_argnames`` argument in `jax.jit`; this comparison is
+        **unit-blind** -- the operands are equal only when their unit labels
+        match, with no unit conversion (see below). In all other cases the
+        element-wise `NumpyEqMixin` behaviour is preserved.
 
         Examples
         --------

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -719,8 +719,10 @@ class AbstractQuantity(
         >>> u.Q(sv1, "m") == u.Q(sv3, "m")
         False
 
-        Equality is **unit-blind**: quantities are equal only when their unit
-        labels match. Unit-aware equality (``1000 m == 1 km``) is incompatible
+        For `StaticValue`-backed quantities this comparison is **unit-blind**:
+        they are equal only when their unit labels match (unlike the
+        array-backed path above, which returns an element-wise mask after unit
+        conversion). Unit-aware equality (``1000 m == 1 km``) is incompatible
         with using a static quantity as a ``jax.jit`` ``static_argnames``
         argument, where distinct units must remain distinct compilation cache
         keys; it would also break the ``__eq__``/``__hash__`` contract, since the

--- a/src/unxt/_src/quantity/register_compare.py
+++ b/src/unxt/_src/quantity/register_compare.py
@@ -1,0 +1,69 @@
+"""Comparison operations for quantities.
+
+`==` on a `StaticValue`-backed quantity is *unit-blind* (equal only when the unit
+labels match -- so it is safe as a `jax.jit` ``static_argnames`` key). This module
+provides :func:`equivalent`, the unit-*aware* "same physical quantity" check.
+"""
+
+__all__ = ("equivalent",)
+
+from typing import Any
+
+import numpy as np
+from plum import dispatch
+
+import unxt_api as uapi
+from .base import AbstractQuantity
+from .value import StaticValue
+
+
+@dispatch  # type: ignore[misc]
+def equivalent(a: AbstractQuantity, b: AbstractQuantity, /) -> Any:
+    """Whether two quantities are physically equal, accounting for units.
+
+    This is the unit-*aware* counterpart to ``==`` (which is unit-blind for
+    `StaticValue`-backed quantities -- see `AbstractQuantity.__eq__`). The result
+    mirrors ``==``'s shape: a scalar `bool` for `StaticValue`-backed operands, and
+    an element-wise dimensionless `Quantity` of booleans for array-backed ones.
+    Quantities with incompatible dimensions are never equivalent (and this never
+    raises).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import unxt as u
+    >>> from unxt.quantity import StaticValue
+
+    Physically-equal static quantities in different units are *equivalent*, even
+    though unit-blind ``==`` reports ``False``:
+
+    >>> a = u.Q(StaticValue(np.array([1.0, 2.0])), "m")
+    >>> b = u.Q(StaticValue(np.array([0.001, 0.002])), "km")
+    >>> a == b
+    False
+    >>> u.equivalent(a, b)
+    True
+    >>> a.is_equivalent(b)
+    True
+
+    Array-backed quantities compare element-wise (unit-aware):
+
+    >>> u.equivalent(u.Q([1.0, 2.0], "m"), u.Q([0.001, 0.009], "km"))
+    Quantity(Array([ True, False], dtype=bool), unit='')
+
+    Incompatible dimensions are never equivalent:
+
+    >>> u.equivalent(u.Q(1.0, "m"), u.Q(1.0, "s"))
+    False
+
+    """
+    # Incompatible dimensions are never equivalent (and must not raise).
+    if not uapi.is_unit_convertible(b.unit, a.unit):
+        return False
+    # ``StaticValue``-backed ``==`` is unit-blind, so do the unit-aware compare
+    # explicitly to keep the scalar-bool result.
+    if isinstance(a.value, StaticValue) and isinstance(b.value, StaticValue):
+        converted = uapi.uconvert_value(a.unit, b.unit, b.value.array)
+        return bool(np.array_equal(a.value.array, converted))
+    # Array-backed ``==`` is already unit-aware -> element-wise result.
+    return a == b

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -137,6 +137,8 @@ __all__ = (
     "is_any_quantity",
     "convert_to_quantity_value",
     "AllowValue",
+    # Comparison
+    "equivalent",
     # NumPy ufunc registry
     "register_ufunc",
 )
@@ -155,6 +157,7 @@ with install_import_hook("unxt.quantity"):
         StaticQuantity,
         StaticValue,
         convert_to_quantity_value,
+        equivalent,
         is_any_quantity,
         register_ufunc,
     )

--- a/tests/unit/test_quantity_equivalence.py
+++ b/tests/unit/test_quantity_equivalence.py
@@ -1,0 +1,60 @@
+"""Tests for physical equivalence of quantities (unit-aware).
+
+`==` on `StaticValue`-backed quantities is unit-blind (label match); `equivalent`
+(and the `is_equivalent` method) is the unit-aware "same physical quantity" check.
+"""
+
+import numpy as np
+
+import unxt as u
+from unxt.quantity import StaticValue
+
+
+def test_static_equivalent_across_units_where_equality_is_false():
+    """The #708 case: equivalent True while unit-blind ``==`` is False."""
+    sv1 = StaticValue(np.array([1.0, 2.0]))
+    sv_km = StaticValue(np.array([0.001, 0.002]))  # == [1, 2] m
+
+    a = u.Q(sv1, "m")
+    b = u.Q(sv_km, "km")
+
+    assert (a == b) is False  # unit-blind equality
+    assert u.equivalent(a, b) is True  # unit-aware equivalence
+    assert a.is_equivalent(b) is True  # method parity
+
+
+def test_static_equivalent_scalar_bool_and_unequal_values():
+    """StaticValue-backed equivalence returns a scalar bool."""
+    sv1 = StaticValue(np.array([1.0, 2.0]))
+    sv_other = StaticValue(np.array([9.0, 9.0]))
+    assert u.equivalent(u.Q(sv1, "m"), u.Q(sv1, "m")) is True
+    assert u.equivalent(u.Q(sv1, "m"), u.Q(sv_other, "m")) is False
+
+
+def test_incompatible_dimensions_are_not_equivalent():
+    """Incompatible dimensions -> False (never raises)."""
+    sv = StaticValue(np.array([1.0, 2.0]))
+    assert u.equivalent(u.Q(sv, "m"), u.Q(sv, "s")) is False
+    # array-backed too
+    assert u.equivalent(u.Q([1.0], "m"), u.Q([1.0], "s")) is False
+
+
+def test_array_backed_equivalent_is_elementwise_and_unit_aware():
+    """Array-backed equivalence mirrors ``==`` (element-wise), unit-aware."""
+    got = u.equivalent(u.Q([1.0, 2.0], "m"), u.Q([0.001, 0.009], "km"))
+    assert isinstance(got, u.quantity.Quantity)
+    assert got.unit == u.unit("")
+    assert np.array_equal(np.asarray(got.value), np.asarray([True, False]))
+
+
+def test_equivalent_is_reflexive():
+    """A quantity is equivalent to itself."""
+    q = u.Q([1.0, 2.0, 3.0], "m")
+    assert bool(np.all(np.asarray(u.equivalent(q, q).value)))
+
+
+def test_equivalent_is_shared_plum_function_with_unitsystems():
+    """`unxt.equivalent` is the same dispatched function unit systems use."""
+    assert u.equivalent is u.unitsystems.equivalent
+    # unit-system dispatch still works (no regression)
+    assert u.equivalent(u.unitsystem("m", "s", "kg"), u.unitsystem("km", "s", "kg"))

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -424,6 +424,65 @@ def test_static_value_eq_hash() -> None:
     assert hash(sv1) == hash(sv2)
 
 
+def test_static_backed_equality_is_unit_blind() -> None:
+    """StaticValue-backed equality requires the same unit label.
+
+    Unit-aware equality (``1000 m == 1 km``) is incompatible with using a
+    static quantity as a ``jax.jit`` static arg, where different units must
+    stay distinct cache keys. Equality is therefore unit-blind for
+    StaticValue-backed quantities, and the base class agrees with
+    ``StaticQuantity``.
+    """
+    sv_m = u.quantity.StaticValue(np.array([1000.0, 2000.0]))
+    sv_km = u.quantity.StaticValue(np.array([1.0, 2.0]))
+
+    # Physically equal but different unit labels -> not equal (unit-blind).
+    assert bool(u.Q(sv_m, "m") == u.Q(sv_km, "km")) is False
+    sq_m = u.StaticQuantity(np.array([1000.0]), "m")
+    sq_km = u.StaticQuantity(np.array([1.0]), "km")
+    assert bool(sq_m == sq_km) is False
+
+    # Same unit + equal values -> equal.
+    assert bool(u.Q(sv_m, "m") == u.Q(sv_m, "m")) is True
+
+    # Base Quantity(StaticValue) and StaticQuantity agree.
+    base_eq = bool(u.Q(sv_m, "m") == u.Q(sv_km, "km"))
+    static_eq = bool(
+        u.StaticQuantity(np.array([1000.0, 2000.0]), "m")
+        == u.StaticQuantity(np.array([1.0, 2.0]), "km")
+    )
+    assert base_eq == static_eq
+
+
+def test_static_backed_eq_hash_contract() -> None:
+    """Equal StaticValue-backed quantities hash equal (eq/hash contract)."""
+    a = u.StaticQuantity(np.array([1000.0]), "m")
+    b = u.StaticQuantity(np.array([1000.0]), "m")
+    assert a == b
+    assert hash(a) == hash(b)
+
+    # A physically-equal but differently-labelled quantity is neither equal
+    # nor forced to share a hash -- so it stays a distinct jit static arg.
+    c = u.StaticQuantity(np.array([1.0]), "km")
+    assert a != c
+    # __ne__ mirrors __eq__ for static-backed quantities (scalar bool).
+    assert (a != b) is False
+    assert (a != c) is True
+
+
+def test_static_quantity_jit_distinguishes_units() -> None:
+    """Different-unit static args must not collapse to one jit compilation."""
+
+    @partial(jax.jit, static_argnames=("q",))
+    def f(x, q):
+        return u.Q(x, q.unit)
+
+    out_km = f(5.0, u.StaticQuantity(np.array(1.0), "km"))
+    out_m = f(5.0, u.StaticQuantity(np.array(1000.0), "m"))
+    assert out_km.unit == u.unit("km")
+    assert out_m.unit == u.unit("m")
+
+
 def test_static_value_rich_comparisons() -> None:
     """StaticValue supports all rich comparison operators."""
     sv1 = u.quantity.StaticValue(np.array([1.0, 2.0, 3.0]))

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -445,6 +445,13 @@ def test_static_backed_equality_is_unit_blind() -> None:
     # Same unit + equal values -> equal.
     assert bool(u.Q(sv_m, "m") == u.Q(sv_m, "m")) is True
 
+    # ``!=`` mirrors ``==`` as a scalar bool for the base ``Q(StaticValue)``
+    # path too (not just ``StaticQuantity``).
+    ne_diff_unit = u.Q(sv_m, "m") != u.Q(sv_km, "km")
+    ne_same = u.Q(sv_m, "m") != u.Q(sv_m, "m")
+    assert ne_diff_unit is True
+    assert ne_same is False
+
     # Base Quantity(StaticValue) and StaticQuantity agree.
     base_eq = bool(u.Q(sv_m, "m") == u.Q(sv_km, "km"))
     static_eq = bool(


### PR DESCRIPTION
## Problem

Equality for `StaticValue`-backed quantities was internally inconsistent and violated the `__eq__`/`__hash__` contract:

```python
import numpy as np, unxt as u
sv_m  = u.quantity.StaticValue(np.array([1000.]))
sv_km = u.quantity.StaticValue(np.array([1.]))
u.Q(sv_m, "m") == u.Q(sv_km, "km")            # True  (base: unit-aware)
hash(u.Q(sv_m,"m")) == hash(u.Q(sv_km,"km"))  # False (hash is unit-label sensitive)  ← contract violated
u.StaticQuantity(np.array([1000.]),"m") == u.StaticQuantity(np.array([1.]),"km")  # False (StaticQuantity: unit-blind — disagrees with base)
```

Additionally, the static path overrode `__eq__` but **not** `__ne__`, so `a != b` fell through to the element-wise NumPy comparison and returned an array instead of the scalar-`bool` negation of `==`.

## Design decision

There is a three-way conflict for `StaticValue`-backed quantities — you can have at most two of:

- **(a)** unit-aware equality (`1000 m == 1 km`)
- **(b)** the eq/hash contract (equal ⇒ hash equal)
- **(c)** jit static-arg unit correctness (`Q(1,'km')` and `Q(1000,'m')` stay distinct compilation cache keys)

Unit-aware equality + a unit-invariant hash (a+b) demonstrably breaks (c): a jitted function with a `StaticQuantity` static arg would reuse the wrong compilation and mislabel the output (`f(5, Q(1000,'m'))` → `5 km`). Since being a correct `jax.jit` static arg is the entire reason `StaticQuantity` exists, this resolves toward **(b)+(c): unit-blind equality**.

## Fix

- Make the base class's `StaticValue`-backed `__eq__` **unit-blind** (equal only when unit labels match), aligning it with `StaticQuantity`. The existing `hash((value, unit))` is now contract-consistent, and different-unit static quantities stay distinct jit cache keys.
- Add a matching `__ne__` (via a shared `_is_static_backed` helper) so `==`/`!=` are consistent scalar `bool`s for static-backed quantities.
- Element-wise `==`/`!=` on normal (array-backed) quantities is unchanged.

To compare across units, convert first: `a == b.uconvert(a.unit)`.

## Tests

- `test_static_backed_equality_is_unit_blind` — unit-blind; base and `StaticQuantity` agree.
- `test_static_backed_eq_hash_contract` — equal ⇒ hash equal; different-unit stays distinct.
- `test_static_quantity_jit_distinguishes_units` — regression guard: different-unit static args don't collapse to one compilation.
- Full `tests/unit/test_static_quantity.py` (39) passes; full `tests/unit` green apart from the pre-existing `test_package::test_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)