### PR TITLE
🐛 fix(quantity): stop unxt * astropy.Quantity silently dropping the unit

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -165,46 +165,33 @@ def convert_unxt_quantity_to_astropy_angle(q: AbstractQuantity, /) -> AstropyAng
 # Quantity
 
 
-@plum.conversion_method(type_from=AstropyQuantity, type_to=Quantity)  # type: ignore[arg-type]
+@plum.conversion_method(type_from=AstropyQuantity, type_to=AbstractQuantity)  # type: ignore[arg-type]
 def convert_astropy_quantity_to_unxt_quantity(q: AstropyQuantity, /) -> Quantity:
     """Convert a `astropy.units.Quantity` to a `unxt.Quantity`.
 
+    Registered against the abstract base: `plum` matches a conversion whose
+    ``type_to`` is a supertype of the requested target, so this single method
+    serves both ``convert(q, AbstractQuantity)`` and ``convert(q, Quantity)``
+    (``Quantity`` is a subclass of `~unxt.quantity.AbstractQuantity`). Targeting
+    the base also lets callers that only have `AbstractQuantity` in scope (e.g.
+    arithmetic coercion in ``AbstractQuantity``) request the conversion without
+    importing the concrete class.
+
     Examples
     --------
     >>> from astropy.units import Quantity as AstropyQuantity
     >>> from plum import convert
-    >>> from unxt.quantity import Quantity
+    >>> from unxt.quantity import AbstractQuantity, Quantity
 
     >>> convert(AstropyQuantity(1.0, "cm"), Quantity)
     Quantity(Array(1., dtype=float32), unit='cm')
-
-    """
-    u = uapi.unit_of(q)
-    return Quantity(uapi.ustrip(u, q), u)
-
-
-@plum.conversion_method(type_from=AstropyQuantity, type_to=AbstractQuantity)  # type: ignore[arg-type]
-def convert_astropy_quantity_to_unxt_abstractquantity(
-    q: AstropyQuantity, /
-) -> AbstractQuantity:
-    """Convert a `astropy.units.Quantity` to a `unxt.Quantity`.
-
-    Registered against the abstract base so callers that only have
-    `~unxt.quantity.AbstractQuantity` in scope (e.g. arithmetic coercion in
-    ``AbstractQuantity``) can request the conversion without importing the
-    concrete `~unxt.Quantity`. The result is a concrete `unxt.Quantity`.
-
-    Examples
-    --------
-    >>> from astropy.units import Quantity as AstropyQuantity
-    >>> from plum import convert
-    >>> from unxt.quantity import AbstractQuantity
 
     >>> convert(AstropyQuantity(1.0, "cm"), AbstractQuantity)
     Quantity(Array(1., dtype=float32), unit='cm')
 
     """
-    return convert_astropy_quantity_to_unxt_quantity(q)
+    u = uapi.unit_of(q)
+    return Quantity(uapi.ustrip(u, q), u)
 
 
 ###############################################################################

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -183,6 +183,30 @@ def convert_astropy_quantity_to_unxt_quantity(q: AstropyQuantity, /) -> Quantity
     return Quantity(uapi.ustrip(u, q), u)
 
 
+@plum.conversion_method(type_from=AstropyQuantity, type_to=AbstractQuantity)  # type: ignore[arg-type]
+def convert_astropy_quantity_to_unxt_abstractquantity(
+    q: AstropyQuantity, /
+) -> AbstractQuantity:
+    """Convert a `astropy.units.Quantity` to a `unxt.Quantity`.
+
+    Registered against the abstract base so callers that only have
+    `~unxt.quantity.AbstractQuantity` in scope (e.g. arithmetic coercion in
+    ``AbstractQuantity``) can request the conversion without importing the
+    concrete `~unxt.Quantity`. The result is a concrete `unxt.Quantity`.
+
+    Examples
+    --------
+    >>> from astropy.units import Quantity as AstropyQuantity
+    >>> from plum import convert
+    >>> from unxt.quantity import AbstractQuantity
+
+    >>> convert(AstropyQuantity(1.0, "cm"), AbstractQuantity)
+    Quantity(Array(1., dtype=float32), unit='cm')
+
+    """
+    return convert_astropy_quantity_to_unxt_quantity(q)
+
+
 ###############################################################################
 
 

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -77,9 +77,10 @@ def _coerce_foreign_quantity(other: Any) -> Any:
     stripped to a bare array by `quax`.
     """
     if isinstance(other, _astropy_quantity_types()):
-        from .quantity import Quantity  # noqa: PLC0415  # avoids an import cycle
-
-        return convert(other, Quantity)
+        # A conversion to the abstract base is registered in the astropy interop
+        # (loaded whenever astropy is present), returning a concrete Quantity --
+        # so we needn't import the concrete class here.
+        return convert(other, AbstractQuantity)
     return other
 
 

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -30,7 +30,6 @@ import jax.core
 import numpy as np
 import quax_blocks
 import wadler_lindig as wl
-from astropy.units import Quantity as AstropyQuantity
 from jax._src.numpy.array_methods import _IndexUpdateHelper, _IndexUpdateRef
 from jaxtyping import Array, ArrayLike, Bool, ScalarLike, Shaped
 from plum import add_promotion_rule, convert, dispatch, type_nonparametric
@@ -52,6 +51,24 @@ if TYPE_CHECKING:
 ArrayLikeSequence: TypeAlias = list[ScalarLike] | tuple[ScalarLike, ...]
 
 
+@ft.cache
+def _astropy_quantity_types() -> tuple[type, ...]:
+    """Return the astropy ``Quantity`` types to coerce, else ``()``.
+
+    Astropy is an optional backend, gated through the ``OptDeps`` mechanism.
+    The lookup is done lazily and cached (``functools.cache``): importing
+    ``unxt._interop`` (where ``OptDeps`` lives) at module scope would cycle back
+    through the interop registration into this package.
+    """
+    from unxt._interop import OptDeps  # noqa: PLC0415  # avoids an import cycle
+
+    if OptDeps.ASTROPY.installed:
+        from astropy.units import Quantity  # noqa: PLC0415
+
+        return (Quantity,)
+    return ()
+
+
 def _coerce_foreign_quantity(other: Any) -> Any:
     """Convert an `astropy.units.Quantity` operand to an `unxt` quantity.
 
@@ -59,7 +76,7 @@ def _coerce_foreign_quantity(other: Any) -> Any:
     that a foreign astropy quantity combines by its unit instead of being
     stripped to a bare array by `quax`.
     """
-    if isinstance(other, AstropyQuantity):
+    if isinstance(other, _astropy_quantity_types()):
         from .quantity import Quantity  # noqa: PLC0415  # avoids an import cycle
 
         return convert(other, Quantity)

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -3,8 +3,9 @@
 # pylint: disable=import-error, no-member, unsubscriptable-object
 #    b/c it doesn't understand dataclass fields
 # pylint: disable=import-outside-toplevel
-#    the astropy-coercion helper imports the concrete Quantity lazily to avoid
-#    an import cycle
+#    `_astropy_quantity_types` lazily imports `unxt._interop.OptDeps` and
+#    `astropy.units.Quantity`; importing `_interop` at module scope would cycle
+#    back through the interop registration into this package.
 
 __all__ = ("AbstractQuantity", "is_any_quantity")
 

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -30,17 +30,11 @@ import jax.core
 import numpy as np
 import quax_blocks
 import wadler_lindig as wl
+from astropy.units import Quantity as AstropyQuantity
 from jax._src.numpy.array_methods import _IndexUpdateHelper, _IndexUpdateRef
 from jaxtyping import Array, ArrayLike, Bool, ScalarLike, Shaped
 from plum import add_promotion_rule, convert, dispatch, type_nonparametric
 from quax import ArrayValue
-
-try:  # ``astropy`` is an optional dependency; coerce its quantities when present.
-    from astropy.units import Quantity as _AstropyQuantity
-
-    _ASTROPY_QUANTITY_TYPES: tuple[type, ...] = (_AstropyQuantity,)
-except ImportError:  # pragma: no cover
-    _ASTROPY_QUANTITY_TYPES = ()
 
 import quaxed.numpy as jnp
 from dataclassish import field_items, replace
@@ -65,7 +59,7 @@ def _coerce_foreign_quantity(other: Any) -> Any:
     that a foreign astropy quantity combines by its unit instead of being
     stripped to a bare array by `quax`.
     """
-    if _ASTROPY_QUANTITY_TYPES and isinstance(other, _ASTROPY_QUANTITY_TYPES):
+    if isinstance(other, AstropyQuantity):
         from .quantity import Quantity  # noqa: PLC0415  # avoids an import cycle
 
         return convert(other, Quantity)

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -2,6 +2,9 @@
 
 # pylint: disable=import-error, no-member, unsubscriptable-object
 #    b/c it doesn't understand dataclass fields
+# pylint: disable=import-outside-toplevel
+#    the astropy-coercion helper imports the concrete Quantity lazily to avoid
+#    an import cycle
 
 __all__ = ("AbstractQuantity", "is_any_quantity")
 
@@ -29,8 +32,15 @@ import quax_blocks
 import wadler_lindig as wl
 from jax._src.numpy.array_methods import _IndexUpdateHelper, _IndexUpdateRef
 from jaxtyping import Array, ArrayLike, Bool, ScalarLike, Shaped
-from plum import add_promotion_rule, dispatch, type_nonparametric
+from plum import add_promotion_rule, convert, dispatch, type_nonparametric
 from quax import ArrayValue
+
+try:  # ``astropy`` is an optional dependency; coerce its quantities when present.
+    from astropy.units import Quantity as _AstropyQuantity
+
+    _ASTROPY_QUANTITY_TYPES: tuple[type, ...] = (_AstropyQuantity,)
+except ImportError:  # pragma: no cover
+    _ASTROPY_QUANTITY_TYPES = ()
 
 import quaxed.numpy as jnp
 from dataclassish import field_items, replace
@@ -46,6 +56,20 @@ if TYPE_CHECKING:
 
 
 ArrayLikeSequence: TypeAlias = list[ScalarLike] | tuple[ScalarLike, ...]
+
+
+def _coerce_foreign_quantity(other: Any) -> Any:
+    """Convert an `astropy.units.Quantity` operand to an `unxt` quantity.
+
+    Any other operand is returned unchanged. Used by the arithmetic dunders so
+    that a foreign astropy quantity combines by its unit instead of being
+    stripped to a bare array by `quax`.
+    """
+    if _ASTROPY_QUANTITY_TYPES and isinstance(other, _ASTROPY_QUANTITY_TYPES):
+        from .quantity import Quantity  # noqa: PLC0415  # avoids an import cycle
+
+        return convert(other, Quantity)
+    return other
 
 
 class AbstractQuantity(
@@ -728,6 +752,28 @@ class AbstractQuantity(
 
         """
         return hash((self.value, self.unit))
+
+    # ---------------------------------------------------------------
+    # Arithmetic with foreign (astropy) quantities
+    #
+    # When an ``astropy.units.Quantity`` is the right operand, ``quax`` would
+    # materialise it via ``__array__`` -- stripping it to a bare array in its
+    # own unit -- so ``*``/``/`` silently dropped its unit and ``+``/``-`` saw
+    # it as dimensionless. Convert such an operand to an ``unxt`` quantity first
+    # so units combine correctly. (Reflected ops are unnecessary: astropy's own
+    # ``__array_ufunc__`` handles ``astropy_q <op> unxt_q``.)
+
+    def __mul__(self, other: Any) -> Any:
+        return super().__mul__(_coerce_foreign_quantity(other))
+
+    def __truediv__(self, other: Any) -> Any:
+        return super().__truediv__(_coerce_foreign_quantity(other))
+
+    def __add__(self, other: Any) -> Any:
+        return super().__add__(_coerce_foreign_quantity(other))
+
+    def __sub__(self, other: Any) -> Any:
+        return super().__sub__(_coerce_foreign_quantity(other))
 
     def __pdoc__(
         self,

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -5,8 +5,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from plum import convert
 
 import unxt as u
+from unxt.quantity import AbstractQuantity
 
 
 class TestUconvertValueWithAstropyUnits:
@@ -297,3 +299,18 @@ class TestMixedUnxtAstropyArithmetic:
         """Adding an incompatible astropy quantity still raises."""
         with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             _ = u.Q(1.0, "m") + apyu.Quantity(2.0, "s")
+
+    def test_plum_convert_astropy_to_unxt(self) -> None:
+        """`plum.convert` from an astropy Quantity yields an ``unxt`` Quantity.
+
+        The astropy->unxt conversion is registered against the abstract base
+        (``type_to=AbstractQuantity``); `plum` resolves a conversion whose
+        ``type_to`` is a supertype of the requested target, so both the concrete
+        ``Quantity`` and the base ``AbstractQuantity`` targets must resolve.
+        """
+        aq = apyu.Quantity(2.0, "km")
+        for target in (u.quantity.Quantity, AbstractQuantity):
+            got = convert(aq, target)
+            assert isinstance(got, u.quantity.Quantity)
+            assert got.unit == u.unit("km")
+            assert np.isclose(np.asarray(got.value), 2.0)

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -255,3 +255,45 @@ class TestUconvertValueAstropyErrorHandling:
         # Try to convert to incompatible unit (time)
         with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             u.uconvert_value("s", "m", apy_q)
+
+
+class TestMixedUnxtAstropyArithmetic:
+    """Arithmetic with an ``unxt.Quantity`` on the left and an astropy one on the right.
+
+    Regression: quax materialised the astropy operand via ``__array__`` (in its
+    own unit, stripped), so ``*``/``/`` silently dropped its unit and ``+``/``-``
+    raised as if it were dimensionless.
+    """
+
+    def test_mul_combines_units(self) -> None:
+        """``unxt_q * astropy_q`` keeps both units."""
+        got = u.Q(1.0, "m") * apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert np.isclose(np.asarray(got.value), 2.0)
+        assert got.unit == u.unit("m km")
+
+    def test_truediv_combines_units(self) -> None:
+        """``unxt_q / astropy_q`` keeps both units."""
+        got = u.Q(1.0, "m") / apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert np.isclose(np.asarray(got.value), 0.5)
+        assert got.unit == u.unit("m / km")
+
+    def test_add_converts_and_combines(self) -> None:
+        """``unxt_q + astropy_q`` converts the astropy operand first."""
+        got = u.Q(1.0, "m") + apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("m")
+        assert np.isclose(np.asarray(got.value), 2001.0)
+
+    def test_sub_converts_and_combines(self) -> None:
+        """``unxt_q - astropy_q`` converts the astropy operand first."""
+        got = u.Q(1.0, "m") - apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("m")
+        assert np.isclose(np.asarray(got.value), -1999.0)
+
+    def test_add_incompatible_units_raises(self) -> None:
+        """Adding an incompatible astropy quantity still raises."""
+        with pytest.raises(Exception, match="convert"):
+            _ = u.Q(1.0, "m") + apyu.Quantity(2.0, "s")

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -295,5 +295,5 @@ class TestMixedUnxtAstropyArithmetic:
 
     def test_add_incompatible_units_raises(self) -> None:
         """Adding an incompatible astropy quantity still raises."""
-        with pytest.raises(Exception, match="convert"):
+        with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             _ = u.Q(1.0, "m") + apyu.Quantity(2.0, "s")


### PR DESCRIPTION
## Problem

With an `unxt` quantity on the left and an `astropy.units.Quantity` on the right, the astropy unit was silently dropped (`*`, `/`) or the operand was treated as dimensionless (`+`, `-`):

```python
import unxt as u, astropy.units as apyu
u.Q(1, "m") * apyu.Quantity(2, "km")   # Quantity(2., unit='m')   ← km silently dropped
u.Q(1, "m") / apyu.Quantity(2, "km")   # Quantity(2., unit='m')   ← should be 0.5 m/km
u.Q(1, "m") + apyu.Quantity(2, "km")   # UnitConversionError       ← seen as dimensionless
```

The asymmetry is the trap: `astropy_q * unxt_q` (astropy on the **left**) works correctly via astropy's own `__array_ufunc__` and returns `2.0 km m`, so users reasonably assume the reverse is safe.

## Root cause

The arithmetic dunders route through `quaxed.numpy` (`qnp.multiply(self, other)`, etc.). When `other` is an astropy `Quantity`, `quax` materialises it via `__array__`, which returns the bare value in the operand's own unit (`np.asarray(apyu.Quantity(2,'km'))` → `2.0`) — so the unit is lost before the unit-aware rule ever runs.

## Fix

Override the forward `__mul__`/`__truediv__`/`__add__`/`__sub__` on `AbstractQuantity` to coerce an astropy-quantity operand to an `unxt` quantity first (the `convert(astropy_q, Quantity)` path already exists), then delegate to the existing unit-aware arithmetic:

```python
u.Q(1, "m") * apyu.Quantity(2, "km")   # Quantity(2.,    unit='m km')
u.Q(1, "m") / apyu.Quantity(2, "km")   # Quantity(0.5,   unit='m / km')
u.Q(1, "m") + apyu.Quantity(2, "km")   # Quantity(2001., unit='m')
u.Q(1, "m") + apyu.Quantity(2, "s")    # UnitConversionError (still raises)
```

- **Reflected ops** need no change — astropy's `__array_ufunc__` already handles `astropy_q <op> unxt_q` correctly.
- The astropy import and coercion are **guarded** (`astropy` is an optional dependency), so unxt still works without astropy installed.
- Normal `Quantity`/`StaticQuantity`/scalar arithmetic is unchanged (verified across the full unit suite).

## Tests

New `TestMixedUnxtAstropyArithmetic`: mul/truediv combine units, add/sub convert-and-combine, incompatible-dimension add still raises. Full `tests/unit` + astropy integration suites pass (apart from the pre-existing `test_package::test_version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)