### PR TITLE
🐛 fix(quantity): correct linalg.solve shape and unbreak linalg.inv

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -1504,6 +1504,14 @@ def custom_linear_solve_q(
         **kw,
     )
 
+    # ``linear_solve_p`` has ``multiple_results=True`` and returns a
+    # single-element list ``[solution]``. Passing that list straight to the
+    # quantity constructor made ``jnp.asarray([arr])`` add a spurious leading
+    # axis (e.g. ``(1, n)`` for a 1-D ``b``); unwrap it so the solution keeps
+    # the RHS shape.
+    if isinstance(result_value, (list, tuple)):
+        (result_value,) = result_value
+
     # Cannot use replace() because physical type may change (e.g., m*s -> s when
     # dividing by m) Use type_np to get the unparametrized quantity constructor
     # Return as list to match JAX primitive conventions
@@ -1534,6 +1542,11 @@ def custom_linear_solve_q_array_arg6(
     result_value = lax.linear_solve_p.bind(  # type: ignore[no-untyped-call]
         ustrip(u0, x0), ustrip(u0, x1), ustrip(u0, x2), x3, ustrip(u0, x4), x5, x6, **kw
     )
+
+    # ``linear_solve_p`` returns a single-element list ``[solution]``; unwrap it
+    # so wrapping into a quantity does not add a spurious leading axis.
+    if isinstance(result_value, (list, tuple)):
+        (result_value,) = result_value
 
     # Cannot use replace() because physical type changes (m -> 1/m)
     # Use type_np to get the unparametrized quantity constructor

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -1963,7 +1963,6 @@ def test_linalg_eigvalsh():
     assert jnp.allclose(got.value, exp.value)
 
 
-@pytest.mark.xfail(reason="TODO: fix")
 def test_linalg_inv():
     """Test `linalg.inv`."""
     # Inverse of matrix with unit m has unit 1/m
@@ -1973,6 +1972,7 @@ def test_linalg_inv():
 
     assert isinstance(got, u.Q)
     assert got.unit == exp.unit
+    assert got.value.shape == exp.value.shape
     assert jnp.allclose(got.value, exp.value)
 
 
@@ -2088,7 +2088,7 @@ def test_linalg_slogdet():
 
 
 def test_linalg_solve():
-    """Test `linalg.solve`."""
+    """Test `linalg.solve` with a 1-D right-hand side."""
     # Solve Ax = b where A has unit m and b has unit m*s, x has unit s
     a = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 5.0]]), "m")
     b = u.Q(jnp.asarray([1.0, 2.0]), "m*s")
@@ -2097,6 +2097,21 @@ def test_linalg_solve():
 
     assert isinstance(got, u.Q)
     assert got.unit == exp.unit
+    # The solution has the same shape as the RHS (regression: was ``(1, n)``).
+    assert got.value.shape == exp.value.shape == (2,)
+    assert jnp.allclose(got.value, exp.value)
+
+
+def test_linalg_solve_2d_rhs():
+    """Test `linalg.solve` with a 2-D right-hand side (regression: crashed)."""
+    a = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 5.0]]), "m")
+    b = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 4.0]]), "m*s")
+    got = jnp.linalg.solve(a, b)
+    exp = u.Q(jnp.linalg.solve(a.value, b.value), "s")
+
+    assert isinstance(got, u.Q)
+    assert got.unit == exp.unit
+    assert got.value.shape == exp.value.shape == (2, 2)
     assert jnp.allclose(got.value, exp.value)
 
 


### PR DESCRIPTION
## Problem

`jnp.linalg.solve` / `inv` on `Quantity` matrices were broken:

```python
import unxt as u, quaxed.numpy as jnp
M = u.Quantity([[1., 2.], [3., 4.]], "m")
jnp.linalg.solve(M, u.Quantity([1., 2.], "s"))   # shape (1, 2) — numpy gives (2,)
jnp.linalg.solve(M, u.Quantity([[1.],[2.]], "s"))# crashed (2-D RHS)
jnp.linalg.inv(M)                                # TypeError: transpose permutation isn't a permutation...
jnp.linalg.matrix_power(M, -1)                   # same crash
```

The 1-D `solve` silently produced the wrong shape (a `(1, n)` result), which can corrupt downstream computation; `inv` and `matrix_power(M, -1)` crashed outright.

## Root cause

`lax.linear_solve_p` has `multiple_results=True` and returns a **single-element list** `[solution]`. The two quax rules for `linear_solve_p` passed that *list* straight to the quantity constructor, so `jnp.asarray([solution])` added a spurious leading axis — turning `(n,)` into `(1, n)` for `solve`, and producing the malformed rank that made `inv` (which is `solve` against the identity) crash inside `jnp.vectorize`'s transpose.

## Fix

Unwrap the single-element list in both `linear_solve_p` rules before constructing the quantity. Verified:

- `solve` returns the RHS shape for **1-D** and **2-D** right-hand sides, values match NumPy.
- `inv` and `matrix_power(M, -1)` return the correct `1/unit` and match NumPy (`A @ inv(A) == I`, dimensionless).
- Batched `vmap(solve)` stays correct.

## Tests

- Remove the now-passing `@pytest.mark.xfail` from `test_linalg_inv` (and add a shape assertion).
- Strengthen `test_linalg_solve` with a shape check — the previous `allclose` **broadcast** `(1, n)` against `(n,)` and silently hid the bug.
- Add `test_linalg_solve_2d_rhs` (previously crashed).
- Full `tests/integration/quaxed` suite: 267 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)