### PR TITLE
💚 ci: make unxt a test-only dep of unxts.api so its src doctests run

### DIFF
--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -35,6 +35,11 @@ build-backend = "hatchling.build"
 requires      = ["hatch-vcs", "hatchling"]
 
 [dependency-groups]
+# ``unxt`` is a test-only dependency: it is the reference implementation of this
+# abstract API and is imported by the ``src`` doctests. It cannot be a runtime
+# dependency because ``unxt`` itself depends on ``unxts.api`` (that would be a
+# cycle); as a dev/test-group dependency the cycle is dev-only and uv resolves
+# it within the workspace.
 test = [
   "optional-dependencies>=0.3.2",
   "pytest>=8.4.2",
@@ -43,6 +48,7 @@ test = [
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
   "sybil[pytest]>=9.2.0",
+  "unxt",
 ]
 
 [tool.hatch.version]
@@ -78,3 +84,6 @@ version_tuple = {version_tuple!r}
 # and includes unxts/api/ in the wheel. Without src/unxts/__init__.py,
 # Python treats unxts as a namespace package. Matches coordinax pattern.
 packages = ["src/unxts"]
+
+[tool.uv.sources]
+unxt = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -4724,6 +4724,7 @@ test = [
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "sybil", extra = ["pytest"] },
+    { name = "unxt" },
 ]
 
 [package.metadata]
@@ -4738,6 +4739,7 @@ test = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
+    { name = "unxt", editable = "." },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `unxts-api` package CI job fails on `main` ([run](https://github.com/GalacticDynamics/unxt/actions/runs/29446554057/job/87458673872)): the `Test package` step runs `pytest packages/unxts.api/src`, and every `src` doctest fails with

```
ModuleNotFoundError: No module named 'unxt'
```

`unxts.api` is the *abstract* dispatch API, and its docstrings demonstrate the concrete behaviour with `>>> import unxt as u`. The per-package job (added in #699) syncs an isolated env with only `unxts-api` + its `test` group, where `unxt` is not installed — so the 5 unxt-using doctests all fail.

## Fix

`unxt` can't be a **runtime** dependency of `unxts.api` — that's a cycle (`unxt` depends on `unxts.api`). Add it to the **`test` dependency group** instead, with a `[tool.uv.sources] unxt = { workspace = true }` entry. The cycle is then dev-only and uv resolves it within the workspace (`uv lock` → 222 packages, no error).

Verified by reproducing the isolated CI env locally:

```
uv sync --no-default-groups --group test --locked --package unxts-api
uv run --frozen --package unxts-api pytest packages/unxts.api/src
# 19 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)