### PR TITLE
♻️ refactor(unitsystems): remove now-unused SingletonMixin

### DIFF
--- a/src/unxt/_src/utils.py
+++ b/src/unxt/_src/utils.py
@@ -5,45 +5,12 @@ Copyright (c) 2023 Galactic Dynamics. All rights reserved.
 
 __all__: tuple[str, ...] = ()
 
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
 from jax import dtypes
 from jax.numpy import dtype as DType  # noqa: N812
 
 import quaxed.lax as qlax
-
-if TYPE_CHECKING:
-    from typing import Self
-
-
-_singleton_insts: dict[type, object] = {}
-
-
-class SingletonMixin:
-    """Singleton class.
-
-    This class is a mixin that can be used to create singletons.
-
-    Examples
-    --------
-    >>> class MySingleton(SingletonMixin):
-    ...     pass
-
-    >>> a = MySingleton()
-    >>> b = MySingleton()
-    >>> a is b
-    True
-
-    """
-
-    def __new__(cls, /, *_: Any, **__: Any) -> "Self":
-        # Check if instance already exists
-        if cls in _singleton_insts:
-            return cast("Self", _singleton_insts[cls])
-        # Create new instance and cache it
-        self = object.__new__(cls)
-        _singleton_insts[cls] = self
-        return self
 
 
 @runtime_checkable


### PR DESCRIPTION
Follow-up to #704, which dropped `SingletonMixin` from the built-in unit systems (`SIUnitSystem`/`CGSUnitSystem`/`DimensionlessUnitSystem`).

With that change merged, nothing in the package uses `SingletonMixin` any more. Remove the dead code: the class, its `_singleton_insts` registry, and the now-unused `TYPE_CHECKING`/`Any`/`cast` imports in `src/unxt/_src/utils.py`.

Verified: no references remain in `src/` or `packages/`, `import unxt` works, ruff/pylint clean (10.00/10), `tests/unit/test_unitsystems.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)