### PR TITLE
✨ feat(config): add config.reload() and deprecate [tool.unxt] section

### DIFF
--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -855,7 +855,10 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -
     if not loaded:
         return False
 
-    # Apply config values using the mapping
+    # Apply config values using the mapping, tracking whether any value was
+    # actually applied (a non-empty section whose keys are all unknown or whose
+    # every ``setattr`` fails must not report success).
+    applied = False
     for class_name, class_config in loaded.items():
         if class_name not in _CONFIG_CLASS_TO_INSTANCE:
             continue
@@ -869,8 +872,9 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -
                 setattr(config_instance, key, value)
             except (TraitError, AttributeError):
                 continue
+            applied = True
 
-    return True
+    return applied
 
 
 # Create the global singleton instance

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -15,6 +15,7 @@ __all__ = (
 import contextlib
 import threading
 import tomllib
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
@@ -557,6 +558,24 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
         self.quantity_repr = QuantityReprConfig(config=self.config, parent=self)
         self.quantity_str = QuantityStrConfig(config=self.config, parent=self)
 
+    def reload(self) -> None:
+        """Re-read configuration from the nearest project ``pyproject.toml``.
+
+        The ``[tool.unxts.unxt]`` section is auto-loaded once at import, using
+        the current working directory at that moment. If ``unxt`` was imported
+        before the process changed into the project directory (common in
+        notebooks and test runners), that section is missed; call this to pick
+        it up. Values already set on the config are overwritten by the file;
+        unset ones are left as-is.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> u.config.reload()  # re-read pyproject.toml from the current cwd
+
+        """
+        _auto_load_project_toml_config(self)
+
 
 @dataclass(slots=True)
 class _ConfigContext:
@@ -754,6 +773,30 @@ def _initialize_config_mapping(cfg: UnxtConfig) -> None:
     )
 
 
+def _warn_if_legacy_unxt_config(path: Path, /) -> None:
+    """Warn if the deprecated ``[tool.unxt]`` pyproject section is present.
+
+    Before the namespace rename (unxt#685), configuration lived under
+    ``[tool.unxt]``; it is now read from ``[tool.unxts.unxt]``. A leftover
+    ``[tool.unxt]`` section is silently ignored, so warn the user to migrate.
+    """
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return
+
+    tool = data.get("tool")
+    if isinstance(tool, dict) and isinstance(tool.get("unxt"), dict):
+        warnings.warn(
+            "The '[tool.unxt]' pyproject.toml section is deprecated and ignored; "
+            "unxt now reads its configuration from '[tool.unxts.unxt]'. Move your "
+            "settings there.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+
 def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
     """Auto-load nearest project TOML config without raising import-time errors.
 
@@ -767,6 +810,8 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
     pyproject = _find_pyproject(Path.cwd())
     if pyproject is None:
         return
+
+    _warn_if_legacy_unxt_config(pyproject)
 
     try:
         loaded = _load_toml_config_from_pyproject(pyproject)

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -558,7 +558,7 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
         self.quantity_repr = QuantityReprConfig(config=self.config, parent=self)
         self.quantity_str = QuantityStrConfig(config=self.config, parent=self)
 
-    def reload(self) -> None:
+    def reload(self) -> bool:
         """Re-read configuration from the nearest project ``pyproject.toml``.
 
         The ``[tool.unxts.unxt]`` section is auto-loaded once at import, using
@@ -568,13 +568,22 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
         it up. Only keys present in the file are applied (overwriting the
         current value); any other settings keep their current value.
 
+        Returns
+        -------
+        bool
+            Whether any configuration was found and applied. This is ``False``
+            if no ``pyproject.toml`` was found from the current directory, it
+            could not be read/parsed, or it had no ``[tool.unxts.unxt]``
+            settings -- letting callers detect a no-op reload. (A missing or
+            malformed file is never raised, matching the import-time behavior.)
+
         Examples
         --------
         >>> import unxt as u
-        >>> u.config.reload()  # re-read pyproject.toml from the current cwd
+        >>> loaded = u.config.reload()  # re-read pyproject.toml from the cwd
 
         """
-        _auto_load_project_toml_config(self)
+        return _auto_load_project_toml_config(self, stacklevel=3)
 
 
 @dataclass(slots=True)
@@ -791,13 +800,17 @@ def _initialize_config_mapping(cfg: UnxtConfig) -> None:
     )
 
 
-def _warn_if_legacy_unxt_config(data: dict[str, Any], /) -> None:
+def _warn_if_legacy_unxt_config(
+    data: dict[str, Any], /, *, stacklevel: int = 2
+) -> None:
     """Warn if the deprecated ``[tool.unxt]`` pyproject section is present.
 
     Takes the already-parsed ``pyproject.toml`` data. Before the namespace
     rename (unxt#685), configuration lived under ``[tool.unxt]``; it is now read
     from ``[tool.unxts.unxt]``. A leftover ``[tool.unxt]`` section is silently
-    ignored, so warn the user to migrate.
+    ignored, so warn the user to migrate. ``stacklevel`` is forwarded to
+    :func:`warnings.warn` so callers can attribute the warning to the user's
+    call site (e.g. their ``import`` or ``config.reload()``).
     """
     tool = data.get("tool")
     if isinstance(tool, dict) and isinstance(tool.get("unxt"), dict):
@@ -806,11 +819,11 @@ def _warn_if_legacy_unxt_config(data: dict[str, Any], /) -> None:
             "unxt now reads its configuration from '[tool.unxts.unxt]'. Move your "
             "settings there.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=stacklevel,
         )
 
 
-def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
+def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -> bool:
     """Auto-load nearest project TOML config without raising import-time errors.
 
     This function:
@@ -819,10 +832,13 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
     3. Applies valid settings to config instances
     4. Silently ignores invalid values or missing files
 
+    ``stacklevel`` is the caller's distance from this function, forwarded (offset
+    by this frame) to the legacy-config `DeprecationWarning` so it points at the
+    user's site. Returns whether any configuration was found and applied.
     """
     pyproject = _find_pyproject(Path.cwd())
     if pyproject is None:
-        return
+        return False
 
     # Read and parse the file once, then reuse the data for both the legacy
     # deprecation check and the config load.
@@ -831,13 +847,13 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError):
         # Never fail import because project config is missing or malformed.
-        return
+        return False
 
-    _warn_if_legacy_unxt_config(data)
+    _warn_if_legacy_unxt_config(data, stacklevel=stacklevel + 1)
     loaded = _config_from_toml_data(data)
 
     if not loaded:
-        return
+        return False
 
     # Apply config values using the mapping
     for class_name, class_config in loaded.items():
@@ -853,6 +869,8 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
                 setattr(config_instance, key, value)
             except (TraitError, AttributeError):
                 continue
+
+    return True
 
 
 # Create the global singleton instance

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -565,8 +565,8 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
         the current working directory at that moment. If ``unxt`` was imported
         before the process changed into the project directory (common in
         notebooks and test runners), that section is missed; call this to pick
-        it up. Values already set on the config are overwritten by the file;
-        unset ones are left as-is.
+        it up. Only keys present in the file are applied (overwriting the
+        current value); any other settings keep their current value.
 
         Examples
         --------
@@ -728,11 +728,29 @@ def _load_toml_config_from_pyproject(
         Traitlets Config object with nested configuration
 
     """
-    if path_to_class is None:
-        path_to_class = _TOML_PATH_TO_CONFIG_CLASS
-
     with path.open("rb") as f:
         data = tomllib.load(f)
+    return _config_from_toml_data(
+        data, tool_path=tool_path, path_to_class=path_to_class
+    )
+
+
+def _config_from_toml_data(
+    data: dict[str, Any],
+    /,
+    *,
+    tool_path: tuple[str, ...] = ("unxts", "unxt"),
+    path_to_class: dict[tuple[str, ...], str] | None = None,
+) -> Config:
+    """Build a :class:`Config` from already-parsed ``pyproject.toml`` data.
+
+    Split from :func:`_load_toml_config_from_pyproject` so a caller that has
+    already parsed the file (e.g. :func:`_auto_load_project_toml_config`, which
+    also needs the raw data for the legacy-section check) can reuse it without
+    re-reading and re-parsing the file.
+    """
+    if path_to_class is None:
+        path_to_class = _TOML_PATH_TO_CONFIG_CLASS
 
     # Navigate to the tool.<tool_path> section
     section: Any = data.get("tool")
@@ -773,19 +791,14 @@ def _initialize_config_mapping(cfg: UnxtConfig) -> None:
     )
 
 
-def _warn_if_legacy_unxt_config(path: Path, /) -> None:
+def _warn_if_legacy_unxt_config(data: dict[str, Any], /) -> None:
     """Warn if the deprecated ``[tool.unxt]`` pyproject section is present.
 
-    Before the namespace rename (unxt#685), configuration lived under
-    ``[tool.unxt]``; it is now read from ``[tool.unxts.unxt]``. A leftover
-    ``[tool.unxt]`` section is silently ignored, so warn the user to migrate.
+    Takes the already-parsed ``pyproject.toml`` data. Before the namespace
+    rename (unxt#685), configuration lived under ``[tool.unxt]``; it is now read
+    from ``[tool.unxts.unxt]``. A leftover ``[tool.unxt]`` section is silently
+    ignored, so warn the user to migrate.
     """
-    try:
-        with path.open("rb") as f:
-            data = tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError):
-        return
-
     tool = data.get("tool")
     if isinstance(tool, dict) and isinstance(tool.get("unxt"), dict):
         warnings.warn(
@@ -811,13 +824,17 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /) -> None:
     if pyproject is None:
         return
 
-    _warn_if_legacy_unxt_config(pyproject)
-
+    # Read and parse the file once, then reuse the data for both the legacy
+    # deprecation check and the config load.
     try:
-        loaded = _load_toml_config_from_pyproject(pyproject)
-    except (OSError, tomllib.TOMLDecodeError, TypeError, KeyError):
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
         # Never fail import because project config is missing or malformed.
         return
+
+    _warn_if_legacy_unxt_config(data)
+    loaded = _config_from_toml_data(data)
 
     if not loaded:
         return

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1040,10 +1040,20 @@ def test_reload_picks_up_project_config(tmp_path: Path, monkeypatch) -> None:
     before = u.config.quantity_repr.use_short_name
     monkeypatch.chdir(tmp_path)
     try:
-        u.config.reload()
+        loaded = u.config.reload()
+        assert loaded is True  # reports that it applied configuration
         assert u.config.quantity_repr.use_short_name is True
     finally:
         u.config.quantity_repr.use_short_name = before
+
+
+def test_reload_returns_false_without_config(tmp_path: Path, monkeypatch) -> None:
+    """``config.reload()`` returns ``False`` when there's nothing to load."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'x'\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert u.config.reload() is False
 
 
 def test_legacy_tool_unxt_section_warns() -> None:
@@ -1057,5 +1067,7 @@ def test_new_namespace_does_not_warn() -> None:
     """The current ``[tool.unxts.unxt]`` section does not warn."""
     data = tomllib.loads("[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n")
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Only turn DeprecationWarning into an error so the test stays targeted
+        # and isn't made fragile by unrelated warnings.
+        warnings.simplefilter("error", DeprecationWarning)
         _warn_if_legacy_unxt_config(data)  # must not raise

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 import threading
 import time
+import warnings
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from unxt._src.config import (
     _find_pyproject,
     _load_toml_config_from_pyproject,
     _walk_toml_config,
+    _warn_if_legacy_unxt_config,
 )
 
 # =============================================================================
@@ -1017,3 +1019,50 @@ named_unit = false
     assert (package_root / "pyproject.toml").exists()
     assert (package_root / "src" / "my_physics_project" / "__init__.py").exists()
     assert (package_root / "README.md").exists()
+
+
+# =============================================================================
+# Reload and legacy-config-deprecation
+
+
+def test_config_has_reload() -> None:
+    """The config exposes a public ``reload`` method."""
+    assert callable(u.config.reload)
+
+
+def test_reload_picks_up_project_config(tmp_path: Path, monkeypatch) -> None:
+    """``config.reload()`` re-reads pyproject.toml from the current cwd."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n",
+        encoding="utf-8",
+    )
+    before = u.config.quantity_repr.use_short_name
+    monkeypatch.chdir(tmp_path)
+    try:
+        u.config.reload()
+        assert u.config.quantity_repr.use_short_name is True
+    finally:
+        u.config.quantity_repr.use_short_name = before
+
+
+def test_legacy_tool_unxt_section_warns(tmp_path: Path) -> None:
+    """A deprecated ``[tool.unxt]`` section emits a DeprecationWarning."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[tool.unxt.quantity.repr]\nuse_short_name = true\n",
+        encoding="utf-8",
+    )
+    with pytest.warns(DeprecationWarning, match="tool.unxt"):
+        _warn_if_legacy_unxt_config(pyproject)
+
+
+def test_new_namespace_does_not_warn(tmp_path: Path) -> None:
+    """The current ``[tool.unxts.unxt]`` section does not warn."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n",
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_legacy_unxt_config(pyproject)  # must not raise

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1056,7 +1056,9 @@ def test_reload_returns_false_without_config(tmp_path: Path, monkeypatch) -> Non
     assert u.config.reload() is False
 
 
-def test_reload_returns_false_when_only_unknown_keys(tmp_path: Path, monkeypatch):
+def test_reload_returns_false_when_only_unknown_keys(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A recognized section with only unknown keys applies nothing -> ``False``."""
     (tmp_path / "pyproject.toml").write_text(
         "[tool.unxts.unxt.quantity.repr]\nnot_a_real_key = true\n",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 import threading
 import time
+import tomllib
 import warnings
 from pathlib import Path
 
@@ -1045,24 +1046,16 @@ def test_reload_picks_up_project_config(tmp_path: Path, monkeypatch) -> None:
         u.config.quantity_repr.use_short_name = before
 
 
-def test_legacy_tool_unxt_section_warns(tmp_path: Path) -> None:
+def test_legacy_tool_unxt_section_warns() -> None:
     """A deprecated ``[tool.unxt]`` section emits a DeprecationWarning."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        "[tool.unxt.quantity.repr]\nuse_short_name = true\n",
-        encoding="utf-8",
-    )
-    with pytest.warns(DeprecationWarning, match="tool.unxt"):
-        _warn_if_legacy_unxt_config(pyproject)
+    data = tomllib.loads("[tool.unxt.quantity.repr]\nuse_short_name = true\n")
+    with pytest.warns(DeprecationWarning, match=r"tool\.unxt"):
+        _warn_if_legacy_unxt_config(data)
 
 
-def test_new_namespace_does_not_warn(tmp_path: Path) -> None:
+def test_new_namespace_does_not_warn() -> None:
     """The current ``[tool.unxts.unxt]`` section does not warn."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        "[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n",
-        encoding="utf-8",
-    )
+    data = tomllib.loads("[tool.unxts.unxt.quantity.repr]\nuse_short_name = true\n")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        _warn_if_legacy_unxt_config(pyproject)  # must not raise
+        _warn_if_legacy_unxt_config(data)  # must not raise

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1056,6 +1056,16 @@ def test_reload_returns_false_without_config(tmp_path: Path, monkeypatch) -> Non
     assert u.config.reload() is False
 
 
+def test_reload_returns_false_when_only_unknown_keys(tmp_path: Path, monkeypatch):
+    """A recognized section with only unknown keys applies nothing -> ``False``."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.unxts.unxt.quantity.repr]\nnot_a_real_key = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    assert u.config.reload() is False
+
+
 def test_legacy_tool_unxt_section_warns() -> None:
     """A deprecated ``[tool.unxt]`` section emits a DeprecationWarning."""
     data = tomllib.loads("[tool.unxt.quantity.repr]\nuse_short_name = true\n")


### PR DESCRIPTION
Two related config robustness gaps from the v2 audit.

## `config.reload()`

`[tool.unxts.unxt]` is auto-loaded **once at import**, using the cwd at that moment. If `unxt` is imported before the process `chdir`s into the project (common in notebooks and test runners), the section is silently missed and there's no way to recover.

Add `UnxtConfig.reload()` to re-read the nearest `pyproject.toml` on demand:

```python
import unxt as u
u.config.reload()   # picks up [tool.unxts.unxt] from the current cwd
```

## Deprecate `[tool.unxt]`

After the namespace rename (#685), config moved from `[tool.unxt]` to `[tool.unxts.unxt]`. A leftover `[tool.unxt]` section is **silently ignored**, so upgraders lose their configuration with no signal. Now a `DeprecationWarning` is emitted pointing them to the new section.

## Tests

- `test_config_has_reload`, `test_reload_picks_up_project_config` (via `monkeypatch.chdir`).
- `test_legacy_tool_unxt_section_warns`, `test_new_namespace_does_not_warn`.
- Full `tests/unit/test_config.py` (78) + config src doctests pass. Verified `import unxt -W error::DeprecationWarning` stays clean (no legacy section in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)