### PR TITLE
Backport PR #713 on branch versions/v1.11.x (🐛 fix(dimensions): strip whitespace; reject unary +/-)

### DIFF
--- a/src/unxt/_src/dimensions.py
+++ b/src/unxt/_src/dimensions.py
@@ -131,11 +131,18 @@ def _eval_dimension_node(  # noqa: C901
         raise ValueError(msg)
 
     if isinstance(node, ast.UnaryOp):
-        operand = _eval_dimension_node(node.operand, dim_mapping=dim_mapping)
-        if isinstance(node.op, ast.USub):
-            return operand**-1
+        # A negative exponent (``length**-1``) is handled in the ``Pow`` branch
+        # above, so any ``UnaryOp`` reaching here is a standalone sign applied to
+        # a dimension. Dimensions are invariant under negation, so reject it
+        # rather than silently treating ``-(length)`` as ``1/length``.
+        if isinstance(node.op, (ast.USub, ast.UAdd)):
+            msg = (
+                "Unary '+'/'-' are not supported on dimensions; they are "
+                "invariant under negation."
+            )
+            raise ValueError(msg)  # noqa: TRY004  # a parse error, not a type error
         msg = f"Unsupported unary operator: {node.op.__class__.__name__}"
-        raise ValueError(msg)
+        raise ValueError(msg)  # noqa: TRY004  # a parse error, not a type error
 
     if isinstance(node, ast.Name):
         # Check if this is a temporary identifier that maps to a dimension name
@@ -297,6 +304,10 @@ def dimension(obj: str, /) -> AbstractDimension:
     unxt.units : Unit specifications can also use dimension expressions
 
     """
+    # Strip surrounding whitespace so both the operator path (which strips) and
+    # the simple-name path treat e.g. " length " the same as "length".
+    obj = obj.strip()
+
     # Check if the string contains PEMD operators using regex
     # We only consider (), *, /, ** as operators - not space, +, or -
     if _PEMD_PATTERN.search(obj):

--- a/tests/unit/test_dims.py
+++ b/tests/unit/test_dims.py
@@ -25,6 +25,15 @@ class TestDimensionSimple:
         """Test dimension identity."""
         assert u.dimension(dim) is dim
 
+    def test_simple_name_is_whitespace_stripped(self):
+        """A simple dimension name with surrounding whitespace is stripped.
+
+        The operator path already strips; the simple-name path must too, so
+        ``dimension(" length ")`` matches ``dimension("length")``.
+        """
+        assert u.dimension(" length ") == u.dimension("length")
+        assert u.dimension("  mass\t") == u.dimension("mass")
+
 
 class TestDimensionMathematicalParsing:
     """Test dimension construction from mathematical expressions."""
@@ -127,6 +136,15 @@ class TestDimensionErrors:
         """Test that non-numeric exponents raise TypeError."""
         with pytest.raises(TypeError, match="Power exponent must be a number"):
             u.dimension("length**time")
+
+    def test_unary_minus_raises(self):
+        """A standalone unary ``-`` raises instead of meaning reciprocal.
+
+        Dimensions are invariant under negation; ``-(length)`` must not be
+        silently interpreted as ``1/length`` (``wavenumber``).
+        """
+        with pytest.raises(ValueError, match=r"[Uu]nary"):
+            u.dimension("-(length)")
 
 
 class TestDimensionOperatorDetection:


### PR DESCRIPTION
Backport of #713 to `versions/v1.11.x`.

Two `dimension()` string-parser bugs, both confirmed present in released **v1.11.4**:

- `dimension(" length ")` raised — the simple-name path didn't strip whitespace (the operator path already did). Now stripped once at the top of the dispatch.
- `dimension("-(length)")` returned `wavenumber` — a standalone unary `-` was silently treated as reciprocal. It now raises `ValueError`; genuine negative exponents (`length**-1`) are unaffected.

Cherry-picked cleanly (`git cherry-pick -x`); `tests/unit/test_dims.py` passes on this branch.