### PR TITLE
Backport PR #710 on branch versions/v1.11.x (🐛 fix(quantity): correct linalg.solve shape and unbreak linalg.inv)

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -1582,6 +1582,14 @@ def custom_linear_solve_q(
         **kw,
     )
 
+    # ``linear_solve_p`` has ``multiple_results=True`` and returns a
+    # single-element list ``[solution]``. Passing that list straight to the
+    # quantity constructor made ``jnp.asarray([arr])`` add a spurious leading
+    # axis (e.g. ``(1, n)`` for a 1-D ``b``); unwrap it so the solution keeps
+    # the RHS shape.
+    if isinstance(result_value, (list, tuple)):
+        (result_value,) = result_value
+
     # Cannot use replace() because physical type may change (e.g., m*s -> s when
     # dividing by m) Use type_np to get non-parametric Quantity constructor
     # Return as list to match JAX primitive conventions
@@ -1612,6 +1620,11 @@ def custom_linear_solve_q_array_arg6(
     result_value = lax.linear_solve_p.bind(  # type: ignore[no-untyped-call]
         ustrip(u0, x0), ustrip(u0, x1), ustrip(u0, x2), x3, ustrip(u0, x4), x5, x6, **kw
     )
+
+    # ``linear_solve_p`` returns a single-element list ``[solution]``; unwrap it
+    # so wrapping into a quantity does not add a spurious leading axis.
+    if isinstance(result_value, (list, tuple)):
+        (result_value,) = result_value
 
     # Cannot use replace() because physical type changes (m -> 1/m)
     # Use type_np to get non-parametric Quantity constructor

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -1818,7 +1818,6 @@ def test_linalg_eigvalsh():
     assert jnp.allclose(got.value, exp.value)
 
 
-@pytest.mark.xfail(reason="TODO: fix")
 def test_linalg_inv():
     """Test `linalg.inv`."""
     # Inverse of matrix with unit m has unit 1/m
@@ -1828,6 +1827,7 @@ def test_linalg_inv():
 
     assert isinstance(got, u.Q)
     assert got.unit == exp.unit
+    assert got.value.shape == exp.value.shape
     assert jnp.allclose(got.value, exp.value)
 
 
@@ -1943,7 +1943,7 @@ def test_linalg_slogdet():
 
 
 def test_linalg_solve():
-    """Test `linalg.solve`."""
+    """Test `linalg.solve` with a 1-D right-hand side."""
     # Solve Ax = b where A has unit m and b has unit m*s, x has unit s
     a = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 5.0]]), "m")
     b = u.Q(jnp.asarray([1.0, 2.0]), "m*s")
@@ -1952,6 +1952,21 @@ def test_linalg_solve():
 
     assert isinstance(got, u.Q)
     assert got.unit == exp.unit
+    # The solution has the same shape as the RHS (regression: was ``(1, n)``).
+    assert got.value.shape == exp.value.shape == (2,)
+    assert jnp.allclose(got.value, exp.value)
+
+
+def test_linalg_solve_2d_rhs():
+    """Test `linalg.solve` with a 2-D right-hand side (regression: crashed)."""
+    a = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 5.0]]), "m")
+    b = u.Q(jnp.asarray([[1.0, 2.0], [3.0, 4.0]]), "m*s")
+    got = jnp.linalg.solve(a, b)
+    exp = u.Q(jnp.linalg.solve(a.value, b.value), "s")
+
+    assert isinstance(got, u.Q)
+    assert got.unit == exp.unit
+    assert got.value.shape == exp.value.shape == (2, 2)
     assert jnp.allclose(got.value, exp.value)
 
 


### PR DESCRIPTION
Backport of #710 to `versions/v1.11.x`.

In v1.11.4, `jnp.linalg.solve`/`inv` on `Quantity` matrices are broken:

```python
jnp.linalg.solve(M, u.Quantity([1., 2.], "s"))   # shape (1, 2) — numpy gives (2,)
jnp.linalg.inv(M)                                 # TypeError: transpose permutation ...
jnp.linalg.matrix_power(M, -1)                    # same crash
```

Root cause: `lax.linear_solve_p` has `multiple_results=True` and returns a single-element list `[solution]`; the quax rules passed that *list* to the quantity constructor, so `jnp.asarray([solution])` added a spurious leading axis (→ wrong shape for `solve`, malformed rank that crashed `inv`). Fix unwraps the single-element list in both rules.

Cherry-picked cleanly; `linalg.solve`/`inv` tests pass on this branch (the previously-xfail `inv` test now passes).