### PR TITLE
Backport PR #705 on branch versions/v1.11.x (🐛 fix(quantity): convert angle units in NumPy angle ufuncs)

### DIFF
--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -182,6 +182,30 @@ def my_function(x):
 result = my_function(positions)  # Works with quantities
 ```
 
+### ⚠️ Angle conversions: `deg2rad`, `rad2deg`, and friends
+
+`jnp.deg2rad`, `jnp.rad2deg`, `jnp.radians`, and `jnp.degrees` lower to a plain multiplication by a constant conversion factor (`x * pi/180` for `deg2rad`/`radians`, `x * 180/pi` for `rad2deg`/`degrees`). Under `quaxed`/`quax` that scales the _value_ but leaves the _unit label_ unchanged, so the quantity is silently mislabeled:
+
+```python
+import quaxed.numpy as jnp
+import unxt as u
+
+# ❌ scales the value but keeps 'deg' -> Quantity(3.14159, unit='deg')
+_ = jnp.deg2rad(u.Q(180.0, "deg"))
+```
+
+Convert angles with `uconvert` (or the `.uconvert` method), which tracks units correctly:
+
+```python
+# ✅ converts degrees -> radians (value rescaled, unit label becomes 'rad')
+_ = u.Q(180.0, "deg").uconvert("rad")
+
+# ✅ converts radians -> degrees (value rescaled, unit label becomes 'deg')
+_ = u.uconvert("deg", u.Q(3.14159, "rad"))
+```
+
+The NumPy entry points (`np.deg2rad(q)`, `np.rad2deg(q)`, ...) are handled correctly: they convert the angle and raise on a non-angle quantity.
+
 ### ✅ Dimension Checking Works in JIT
 
 Good news! Dimensions are checked inside JIT:

--- a/src/unxt/_src/quantity/register_ufuncs.py
+++ b/src/unxt/_src/quantity/register_ufuncs.py
@@ -114,3 +114,44 @@ def apply_ufunc(
             return fn(*inputs, **kwargs)
 
     return NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# Built-in overrides
+#
+# ``deg2rad``/``rad2deg``/``radians``/``degrees`` are angle *conversions*, but
+# JAX lowers them to a bare scalar ``mul`` (``x * pi/180`` for deg->rad,
+# ``x * 180/pi`` for rad->deg). The default delegation to ``quaxed.numpy``
+# therefore scales the value while leaving the unit label unchanged -- a
+# silently wrong result (``deg2rad(180 deg) -> 3.14159 deg``).
+# Register explicit handlers that convert an angle quantity to the target unit
+# (and raise on a non-angle quantity, matching astropy).
+
+_ANGLE_CONVERSIONS: dict[np.ufunc, str] = {
+    np.deg2rad: "rad",
+    np.radians: "rad",
+    np.rad2deg: "deg",
+    np.degrees: "deg",
+}
+
+
+def _make_angle_handler(to_unit: str) -> AnyCallable:
+    def handler(ufunc: np.ufunc, method: str, x: Any, /, **kwargs: Any) -> Any:
+        if method != "__call__":
+            return NotImplemented
+        # These handlers reduce to a unit conversion and do not honour ufunc
+        # keyword arguments (``out``, ``where``, ``casting``, ...). Raise loudly
+        # rather than silently ignore them and return a surprising result.
+        if kwargs:
+            msg = (
+                f"`np.{ufunc.__name__}` on a Quantity does not support the ufunc "
+                f"keyword argument(s) {sorted(kwargs)}."
+            )
+            raise TypeError(msg)
+        return x.uconvert(to_unit)
+
+    return handler
+
+
+for _ufunc, _to_unit in _ANGLE_CONVERSIONS.items():
+    _UFUNC_REGISTRY[_ufunc] = _make_angle_handler(_to_unit)

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -6,6 +6,7 @@ units instead of silently dropping them.
 
 from unittest.mock import Mock
 
+import astropy.units as apyu
 import numpy as np
 import pytest
 
@@ -150,6 +151,53 @@ def test_unsupported_method_raises():
 
     with pytest.raises(TypeError):
         np.add.outer(q, q)
+
+
+def test_deg2rad_converts_angle_to_radians():
+    """``np.deg2rad``/``np.radians`` convert an angle quantity to radians.
+
+    Regression: these lower to ``x * (pi/180)`` (a bare ``mul``), so without an
+    explicit handler the value was scaled while the unit label was left as
+    ``deg`` -- a silently wrong result.
+    """
+    for fn in (np.deg2rad, np.radians):
+        got = fn(u.Q(180.0, "deg"))
+        assert isinstance(got, u.quantity.Quantity)
+        assert got.unit == u.unit("rad")
+        assert np.isclose(np.asarray(got.value), np.pi)
+
+        # radians in -> radians out (identity conversion), not re-scaled.
+        got_rad = fn(u.Q(np.pi, "rad"))
+        assert got_rad.unit == u.unit("rad")
+        assert np.isclose(np.asarray(got_rad.value), np.pi)
+
+
+def test_rad2deg_converts_angle_to_degrees():
+    """``np.rad2deg``/``np.degrees`` convert an angle quantity to degrees."""
+    for fn in (np.rad2deg, np.degrees):
+        got = fn(u.Q(np.pi, "rad"))
+        assert isinstance(got, u.quantity.Quantity)
+        assert got.unit == u.unit("deg")
+        assert np.isclose(np.asarray(got.value), 180.0)
+
+        got_deg = fn(u.Q(180.0, "deg"))
+        assert got_deg.unit == u.unit("deg")
+        assert np.isclose(np.asarray(got_deg.value), 180.0)
+
+
+def test_angle_ufuncs_reject_non_angle():
+    """Angle ufuncs raise on a non-angle quantity instead of mangling it."""
+    for fn in (np.deg2rad, np.rad2deg, np.radians, np.degrees):
+        with pytest.raises(apyu.UnitConversionError, match="not convertible"):
+            fn(u.Q(5.0, "m"))
+
+
+def test_angle_ufuncs_reject_unsupported_kwargs():
+    """Angle ufuncs raise on ufunc kwargs rather than silently ignoring them."""
+    q = u.Q(180.0, "deg")
+    for kwargs in ({"where": np.array([True])}, {"casting": "same_kind"}):
+        with pytest.raises(TypeError, match="does not support"):
+            np.deg2rad(q, **kwargs)
 
 
 def test_bare_quantity_also_supported():


### PR DESCRIPTION
Backport of #705 to `versions/v1.11.x`.

In v1.11.4, `np.deg2rad`/`np.rad2deg`/`np.radians`/`np.degrees` **silently mislabel units** on angle quantities:

```python
np.deg2rad(u.Q(180.0, "deg"))   # Quantity(3.14159, unit='deg')  ← should be rad
```

JAX lowers these to a bare `x * (pi/180)` (`x * 180/pi` for the reverse), which the ufunc registry delegated to `quaxed.numpy` → the `mul` rule scales the value but keeps the old unit label. Fix registers explicit `_UFUNC_REGISTRY` handlers that convert via `uconvert` (and raise `UnitConversionError` on non-angle input, matching astropy).

Includes the review-hardening from #705 (raise on ufunc kwargs; explicit `Quantity` in isinstance checks) and the `sharp-bits` note that the `quaxed.numpy.deg2rad` path can't be intercepted (use `uconvert`).

Cherry-picked cleanly; ufunc tests + sharp-bits doctest pass on this branch.