### PR TITLE
Backport PR #687 on branch versions/v1.11.x (🐛 fix(unxt): preserve named unit labels in uconvert fast-path)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,6 +299,11 @@ xfail_strict = true
 
 [tool.pytest_env]
 UNXT_ENABLE_RUNTIME_TYPECHECKING = "beartype.beartype"
+# Force matplotlib's non-interactive backend so the interop tests never load a
+# GUI toolkit (e.g. Tk). The Windows hosted-runner Pythons (3.13/3.14) ship a
+# broken Tcl, so an auto-selected TkAgg backend raised `_tkinter.TclError` at
+# figure creation; Agg is also what `pytest-mpl` renders with.
+MPLBACKEND = "Agg"
 
 
 [tool.repo-review]

--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -252,8 +252,13 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     Quantity(Array([1., 2., 3.], dtype=float32, ...), unit='')
 
     """
-    # Hot-path: if no unit conversion is necessary
-    if x.unit == u:
+    # Hot-path: skip the conversion only when the unit is genuinely unchanged.
+    # NB: astropy treats physically-equal units as ``==`` (e.g. ``J == m2 kg /
+    # s2``), so ``x.unit == u`` alone would silently return ``x`` without
+    # relabeling to the requested (equal but differently-named) unit. Require
+    # the string forms to match too so the relabel still happens; the cheap
+    # ``==`` check short-circuits the common (unequal) case before formatting.
+    if x.unit == u and x.unit.to_string() == u.to_string():
         return x
 
     value = x.unit.to(u, uapi.ustrip(x))

--- a/src/unxt/quantity.py
+++ b/src/unxt/quantity.py
@@ -98,7 +98,7 @@ Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
 Convert to standard energy units
 
 >>> u.uconvert("J", energy)
-Quantity(Array(100., dtype=float32...), unit='m2 kg / s2')
+Quantity(Array(100., dtype=float32...), unit='J')
 
 JIT compilation works seamlessly
 

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -217,6 +217,30 @@ class TestUconvertValueAstropyDistanceAngle:
         assert jnp.isclose(result, jnp.pi)
 
 
+class TestUconvertRelabelsEquivalentNamedUnit:
+    """`uconvert` to an equal-but-differently-named unit must relabel."""
+
+    def test_uconvert_to_named_energy_unit_relabels(self) -> None:
+        """`m2 kg / s2` converted to the equal named unit `J` becomes `J`.
+
+        Astropy treats ``m2 kg / s2 == J``, so a naive ``if x.unit == u``
+        hot-path would silently return the quantity unchanged (keeping the
+        composite label) instead of relabeling to the requested named unit.
+        """
+        energy = u.Q(2.0, "kg") * (u.Q(3.0, "m") / u.Q(1.0, "s")) ** 2
+        assert str(energy.unit) == "m2 kg / s2"
+
+        result = u.uconvert("J", energy)
+
+        assert str(result.unit) == "J"
+        assert jnp.isclose(result.value, 18.0)
+
+    def test_uconvert_to_identical_unit_is_noop_identity(self) -> None:
+        """Converting to the identical unit still returns the same object."""
+        q = u.Q(5.0, "J")
+        assert u.uconvert(apyu.Unit("J"), q) is q
+
+
 class TestUconvertValueAstropyErrorHandling:
     """Test error handling in uconvert_value with Astropy units."""
 


### PR DESCRIPTION
Backport of #687 to `versions/v1.11.x`.

In v1.11.4, `uconvert` fails to **relabel** when converting to an equivalent *named* unit (e.g. `m2 kg / s2` → `J`): the no-op fast-path used astropy unit equality, which treats physically-equivalent units as equal regardless of their string form, so the input was returned with its original label instead of the requested one.

Fix: skip the conversion only when the units compare equal **and** their string representations match (the cheap `==` short-circuits before the string compare, preserving the hot-path).

Also carries the original PR's `MPLBACKEND=Agg` test-env setting (avoids Windows CI `_tkinter.TclError`) and the corresponding `unxt.quantity` doctest update.

Cherry-picked cleanly; relabel test + module doctest pass on this branch.