### PR TITLE
Backport PR #709 on branch versions/v1.11.x (🐛 fix(quantity): stop unxt * astropy.Quantity silently dropping the unit)

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -160,17 +160,28 @@ def convert_unxt_quantity_to_astropy_angle(q: AbstractQuantity, /) -> AstropyAng
 # Quantity
 
 
-@plum.conversion_method(type_from=AstropyQuantity, type_to=Quantity)
+@plum.conversion_method(type_from=AstropyQuantity, type_to=AbstractQuantity)  # type: ignore[arg-type]
 def convert_astropy_quantity_to_unxt_quantity(q: AstropyQuantity, /) -> Quantity:
     """Convert a `astropy.units.Quantity` to a `unxt.Quantity`.
+
+    Registered against the abstract base: `plum` matches a conversion whose
+    ``type_to`` is a supertype of the requested target, so this single method
+    serves both ``convert(q, AbstractQuantity)`` and ``convert(q, Quantity)``
+    (``Quantity`` is a subclass of `~unxt.quantity.AbstractQuantity`). Targeting
+    the base also lets callers that only have `AbstractQuantity` in scope (e.g.
+    arithmetic coercion in ``AbstractQuantity``) request the conversion without
+    importing the concrete class.
 
     Examples
     --------
     >>> from astropy.units import Quantity as AstropyQuantity
     >>> from plum import convert
-    >>> from unxt import Quantity
+    >>> from unxt.quantity import AbstractQuantity, Quantity
 
     >>> convert(AstropyQuantity(1.0, "cm"), Quantity)
+    Quantity(Array(1., dtype=float32), unit='cm')
+
+    >>> convert(AstropyQuantity(1.0, "cm"), AbstractQuantity)
     Quantity(Array(1., dtype=float32), unit='cm')
 
     """

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -2,6 +2,10 @@
 
 # pylint: disable=import-error, no-member, unsubscriptable-object
 #    b/c it doesn't understand dataclass fields
+# pylint: disable=import-outside-toplevel
+#    `_astropy_quantity_types` lazily imports `unxt._interop.OptDeps` and
+#    `astropy.units.Quantity`; importing `_interop` at module scope would cycle
+#    back through the interop registration into this package.
 
 __all__ = ("AbstractQuantity", "is_any_quantity")
 
@@ -30,7 +34,7 @@ import quax_blocks
 import wadler_lindig as wl
 from jax._src.numpy.array_methods import _IndexUpdateHelper, _IndexUpdateRef
 from jaxtyping import Array, ArrayLike, Bool, ScalarLike, Shaped
-from plum import add_promotion_rule, dispatch, type_nonparametric
+from plum import add_promotion_rule, convert, dispatch, type_nonparametric
 from quax import ArrayValue
 
 import quaxed.numpy as jnp
@@ -47,6 +51,39 @@ if TYPE_CHECKING:
 
 
 ArrayLikeSequence: TypeAlias = list[ScalarLike] | tuple[ScalarLike, ...]
+
+
+@ft.cache
+def _astropy_quantity_types() -> tuple[type, ...]:
+    """Return the astropy ``Quantity`` types to coerce, else ``()``.
+
+    Astropy is an optional backend, gated through the ``OptDeps`` mechanism.
+    The lookup is done lazily and cached (``functools.cache``): importing
+    ``unxt._interop`` (where ``OptDeps`` lives) at module scope would cycle back
+    through the interop registration into this package.
+    """
+    from unxt._interop import OptDeps  # noqa: PLC0415  # avoids an import cycle
+
+    if OptDeps.ASTROPY.installed:
+        from astropy.units import Quantity  # noqa: PLC0415
+
+        return (Quantity,)
+    return ()
+
+
+def _coerce_foreign_quantity(other: Any) -> Any:
+    """Convert an `astropy.units.Quantity` operand to an `unxt` quantity.
+
+    Any other operand is returned unchanged. Used by the arithmetic dunders so
+    that a foreign astropy quantity combines by its unit instead of being
+    stripped to a bare array by `quax`.
+    """
+    if isinstance(other, _astropy_quantity_types()):
+        # A conversion to the abstract base is registered in the astropy interop
+        # (loaded whenever astropy is present), returning a concrete Quantity --
+        # so we needn't import the concrete class here.
+        return convert(other, AbstractQuantity)
+    return other
 
 
 class AbstractQuantity(
@@ -659,6 +696,28 @@ class AbstractQuantity(
 
         """
         return hash((self.value, self.unit))
+
+    # ---------------------------------------------------------------
+    # Arithmetic with foreign (astropy) quantities
+    #
+    # When an ``astropy.units.Quantity`` is the right operand, ``quax`` would
+    # materialise it via ``__array__`` -- stripping it to a bare array in its
+    # own unit -- so ``*``/``/`` silently dropped its unit and ``+``/``-`` saw
+    # it as dimensionless. Convert such an operand to an ``unxt`` quantity first
+    # so units combine correctly. (Reflected ops are unnecessary: astropy's own
+    # ``__array_ufunc__`` handles ``astropy_q <op> unxt_q``.)
+
+    def __mul__(self, other: Any) -> Any:
+        return super().__mul__(_coerce_foreign_quantity(other))
+
+    def __truediv__(self, other: Any) -> Any:
+        return super().__truediv__(_coerce_foreign_quantity(other))
+
+    def __add__(self, other: Any) -> Any:
+        return super().__add__(_coerce_foreign_quantity(other))
+
+    def __sub__(self, other: Any) -> Any:
+        return super().__sub__(_coerce_foreign_quantity(other))
 
     def __pdoc__(
         self,

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -5,8 +5,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from plum import convert
 
 import unxt as u
+from unxt.quantity import AbstractQuantity
 
 
 class TestUconvertValueWithAstropyUnits:
@@ -231,3 +233,60 @@ class TestUconvertValueAstropyErrorHandling:
         # Try to convert to incompatible unit (time)
         with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             u.uconvert_value("s", "m", apy_q)
+
+
+class TestMixedUnxtAstropyArithmetic:
+    """Arithmetic with an ``unxt.Quantity`` on the left and an astropy one on the right.
+
+    Regression: quax materialised the astropy operand via ``__array__`` (in its
+    own unit, stripped), so ``*``/``/`` silently dropped its unit and ``+``/``-``
+    raised as if it were dimensionless.
+    """
+
+    def test_mul_combines_units(self) -> None:
+        """``unxt_q * astropy_q`` keeps both units."""
+        got = u.Q(1.0, "m") * apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert np.isclose(np.asarray(got.value), 2.0)
+        assert got.unit == u.unit("m km")
+
+    def test_truediv_combines_units(self) -> None:
+        """``unxt_q / astropy_q`` keeps both units."""
+        got = u.Q(1.0, "m") / apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert np.isclose(np.asarray(got.value), 0.5)
+        assert got.unit == u.unit("m / km")
+
+    def test_add_converts_and_combines(self) -> None:
+        """``unxt_q + astropy_q`` converts the astropy operand first."""
+        got = u.Q(1.0, "m") + apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("m")
+        assert np.isclose(np.asarray(got.value), 2001.0)
+
+    def test_sub_converts_and_combines(self) -> None:
+        """``unxt_q - astropy_q`` converts the astropy operand first."""
+        got = u.Q(1.0, "m") - apyu.Quantity(2.0, "km")
+        assert isinstance(got, u.Q)
+        assert got.unit == u.unit("m")
+        assert np.isclose(np.asarray(got.value), -1999.0)
+
+    def test_add_incompatible_units_raises(self) -> None:
+        """Adding an incompatible astropy quantity still raises."""
+        with pytest.raises(apyu.UnitConversionError, match="not convertible"):
+            _ = u.Q(1.0, "m") + apyu.Quantity(2.0, "s")
+
+    def test_plum_convert_astropy_to_unxt(self) -> None:
+        """`plum.convert` from an astropy Quantity yields an ``unxt`` Quantity.
+
+        The astropy->unxt conversion is registered against the abstract base
+        (``type_to=AbstractQuantity``); `plum` resolves a conversion whose
+        ``type_to`` is a supertype of the requested target, so both the concrete
+        ``Quantity`` and the base ``AbstractQuantity`` targets must resolve.
+        """
+        aq = apyu.Quantity(2.0, "km")
+        for target in (u.quantity.Quantity, AbstractQuantity):
+            got = convert(aq, target)
+            assert isinstance(got, u.quantity.Quantity)
+            assert got.unit == u.unit("km")
+            assert np.isclose(np.asarray(got.value), 2.0)


### PR DESCRIPTION
Backport of #709 to the `versions/v1.11.x` release line.

## The bug (confirmed present in v1.11.4)

When an `astropy.units.Quantity` is the right operand of arithmetic with an `unxt` quantity, `quax` materialised it via `__array__` — stripping it to a bare array in its own unit. So:

- `u.Q(1.0, "m") * apyu.Quantity(2.0, "km")` → `Quantity(2., unit='m')` (the `km` was **silently dropped**; should be `2. km m`)
- `u.Q(1.0, "m") + apyu.Quantity(2.0, "km")` → `UnitConversionError` treating the astropy operand as dimensionless (should be `2001. m`)

## The fix

`AbstractQuantity` now coerces a foreign astropy operand to an `unxt` quantity (via `_coerce_foreign_quantity`) in `__mul__`/`__truediv__`/`__add__`/`__sub__` before delegating to `super()`, so units combine correctly. The astropy→unxt conversion is broadened to register against the abstract base (`type_to=AbstractQuantity`) so `convert(q, AbstractQuantity)` resolves.

## Backport notes

Cherry-pick of `16b5f16` was not clean: v1.11.x registers the astropy→`Quantity` conversion separately from astropy→`BareQuantity` (v2 later renamed these), so the interop decorator conflict was resolved manually to broaden the `Quantity`-returning method to `type_to=AbstractQuantity`. `base.py` and the regression tests auto-merged. Both concrete targets (`Quantity`, `BareQuantity`) still resolve their own conversions; `convert(q, AbstractQuantity)` newly resolves.

## Verification (on v1.11.x)

- Bug reproduced on `versions/v1.11.4` before the change; fixed after.
- `tests/integration/astropy/test_astropy_interop_quantity.py`: 30 passed
- `tests/unit/` + `src/unxt/_src/quantity/` (tests + doctests): 1919 passed
- interop + base doctests: 195 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)