### PR TITLE
🐛 fix(unxts-linalg): update from_cdict doctests for weak_type values

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -151,7 +151,7 @@ class QuantityMatrix(u.AbstractQuantity):
         >>> qv.unit.to_string()
         '(m, s, kg)'
         >>> qv.value
-        Array([1., 2., 3.], dtype=float32)
+        Array([1., 2., 3.], dtype=float32, weak_type=True)
 
         Selecting and reordering a subset of keys:
 
@@ -159,7 +159,7 @@ class QuantityMatrix(u.AbstractQuantity):
         >>> qv2.unit.to_string()
         '(kg, m)'
         >>> qv2.value
-        Array([3., 1.], dtype=float32)
+        Array([3., 1.], dtype=float32, weak_type=True)
 
         Dimensionless entries (bare arrays) are accepted:
 


### PR DESCRIPTION
Fixes the `unxts-linalg` CI failures on `main` ([run 29513107989](https://github.com/GalacticDynamics/unxt/actions/runs/29513107989)), which fail on all of Python 3.11–3.14:

```
Example at .../unxts/linalg/_src/_quantity_matrix.py, line 153:
Expected: Array([1., 2., 3.], dtype=float32)
Got:      Array([1., 2., 3.], dtype=float32, weak_type=True)
```

## Root cause

#715 ("preserve weak_type for scalar quantity values") merged at 15:47; the first `main` run after it (15:52) exposed this. `u.Q(1.0, "m").value` is now `weak_type=True`, matching `jnp.asarray(1.0)`.

`QuantityMatrix.from_cdict` stacks the stripped values, and `jnp.stack` of all-weak scalars yields a weak array — identical to plain JAX:

```python
>>> jnp.stack([jnp.asarray(1.0), jnp.asarray(2.0), jnp.asarray(3.0)])
Array([1., 2., 3.], dtype=float32, weak_type=True)
```

So this is a **stale doctest expectation, not a behavior regression** — the packing itself is unchanged, and `from_cdict` propagates weakness exactly as JAX does. Only the two `from_cdict` examples that build from *scalar* quantities are affected; every other example in the file builds from lists/arrays (strong-typed) and is unaffected.

## The fix

Update the two expectations to the actual (correct) output. I kept them **explicit** rather than eliding with `dtype=float32...`:

- this file uses precise reprs throughout, with no ellipsis anywhere; and
- the explicit form is exactly what caught #715's change — eliding it would remove that regression-detection value.

## Why CI didn't catch this on #715

The `tests-unxts-linalg` job only runs on `push`/`workflow_dispatch`, or when the PR has the `🧩 unxts-linalg` label, or the branch starts with `unxts-linalg/`. #715's branch (`fix-weaktype-promotion`) matched none of these, so the job never ran on that PR and the break only surfaced once merged to `main`. This PR's branch is prefixed `unxts-linalg/` so the job runs here.

Worth considering separately: `unxt`-package changes that alter array/dtype semantics can silently break dependent `unxts.*` packages. Happy to file an issue if you'd like the trigger rules revisited.

## Verification

Reproduced CI's exact two-invocation command locally (they're split deliberately to avoid double-importing the namespace package):

- `pytest packages/unxts.linalg/src` — was `2 failed, 306 passed`, now **308 passed**
- `pytest packages/unxts.linalg/tests` — **253 passed** (was already clean; CI never reached it because the first command exited 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)