### PR TITLE
📌 pin: add unxt>=2.0.0 floor to unxts.linalg and unxts.parametric

### DIFF
--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unxt",
+  "unxt>=2.0.0",
   "equinox>=0.11.8",
   "jaxtyping>=0.2.34",
   "plum-dispatch>=2.5.7",

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
   "astropy>=7.0.0",
   "plum-dispatch>=2.5.7",
-  "unxt",
+  "unxt>=2.0.0",
   "unxts.api>=2.0.0",
 ]
 description = "Dimension-parametrized quantities for unxt (canonical: unxts.parametric)"


### PR DESCRIPTION
## The problem

`unxts.linalg` and `unxts.parametric` both declared a bare `unxt` runtime dependency with **no version floor**:

```toml
# unxts.parametric/pyproject.toml
dependencies = ["astropy>=7.0.0", "plum-dispatch>=2.5.7", "unxt", "unxts.api>=2.0.0"]
```

A resolver is free to satisfy `unxt` (unfloored) against **unxt 1.11.x**, which predates the v2 public surface (the lightweight `Quantity`, the `unxts.*` namespace). The package then imports against an incompatible unxt and crashes. For `unxts.parametric` — the migration target for every v1 `Quantity` user — this is a release blocker.

## The fix

Pin `unxt>=2.0.0` in both, matching the floor the other v2 siblings (`unxts.hypothesis`, `unxts.interop.matplotlib`, `unxts.interop.xarray`) already use.

## Deliberately **not** changed

`unxts.api` also has a bare `unxt`, but it lives in the **test** dependency-group, not runtime — and that is intentional and documented in its pyproject: `unxt` depends on `unxts.api`, so a runtime floor there would create a dependency cycle. As a dev/test-group dep, uv resolves it within the workspace. Left as-is.

## Verification

`uv lock --check` passes (222 packages resolved, existing lock still consistent — no regen needed).

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)