### PR TITLE
🐛 fix(quantity): StaticQuantity dtype preservation + keep static across ops

### DIFF
--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -25,7 +25,9 @@ class StaticQuantity(AbstractQuantity):
     Unlike `~unxt.Quantity`, its value is stored as a static (hashable) NumPy
     array, which lets a `StaticQuantity` be passed as a static argument to a
     `jax.jit`-compiled function. It accepts Python scalars and array-like
-    inputs convertible to NumPy arrays, and rejects JAX arrays.
+    inputs convertible to NumPy arrays; a concrete (eager) JAX array is
+    materialised back to NumPy, and only a *traced* value -- which cannot be
+    static -- is rejected.
 
     Examples
     --------

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -43,14 +43,12 @@ class StaticQuantity(AbstractQuantity):
     >>> isinstance(hash(q), int)
     True
 
-    JAX arrays are rejected:
+    A concrete JAX array is materialised back to NumPy (a static value is just
+    data); only *traced* values (under ``jit``/``vmap``/``grad``) are rejected:
 
     >>> import jax.numpy as jnp
-    >>> try:
-    ...     u.StaticQuantity(jnp.array([1.0, 2.0]), "m")
-    ... except TypeError as e:
-    ...     print(e)
-    StaticQuantity does not accept JAX arrays. Use Quantity for traced values.
+    >>> u.StaticQuantity(jnp.array([1.0, 2.0]), "m")
+    StaticQuantity(array([1., 2.], dtype=float32), unit='m')
 
     The Wadler-Lindig representation hides the internal static wrapper:
 

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -289,9 +289,23 @@ def from_(cls: type[StaticValue], value: StaticValue, /) -> StaticValue:
 
 @StaticValue.from_.dispatch
 def from_(cls: type[StaticValue], value: jax.Array | jax.core.Tracer, /) -> StaticValue:
-    """Reject JAX arrays for `StaticQuantity`."""
-    msg = "StaticQuantity does not accept JAX arrays. Use Quantity for traced values."
-    raise TypeError(msg)
+    """Materialise a concrete JAX array to NumPy, or reject a traced value.
+
+    A concrete (eager) ``jax.Array`` is just data, so it can back a static
+    value -- materialise it. This also lets ops on a ``StaticQuantity`` stay
+    static: the primitive rules rebuild via ``replace(x, value=<jax array>)``,
+    and that concrete array round-trips back to NumPy here instead of raising.
+
+    A *tracer* (under ``jit``/``vmap``/``grad``) is a placeholder for a value
+    that does not exist yet, so it genuinely cannot be static and is rejected.
+    """
+    if isinstance(value, jax.core.Tracer):
+        msg = (
+            "StaticQuantity cannot hold a traced JAX value; "
+            "use Quantity under jit/vmap/grad."
+        )
+        raise TypeError(msg)
+    return cls(np.asarray(value))
 
 
 # ==================================================================

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -142,7 +142,14 @@ class StaticValue:
         if name.startswith("_"):
             msg = f"{type(self).__name__!r} object has no attribute {name!r}"
             raise AttributeError(msg)
-        return getattr(jnp.asarray(self._array), name)
+        # Forward to the wrapped *NumPy* array, not ``jnp.asarray(self._array)``:
+        # the latter applies JAX's x64-disabled dtype rules and silently
+        # downcasts a faithfully-stored int64/float64 value (the whole point of
+        # StaticValue is to keep such values verbatim). NumPy implements
+        # ``dtype``/``min``/``max``/``mean``/``round``/``astype``/``flatten`` with
+        # the correct dtype semantics; the ``_jnparray`` property remains the
+        # JAX-conversion path for the arithmetic primitives.
+        return getattr(self._array, name)
 
     def __repr__(self) -> str:
         return wl.pformat(self, short_arrays=False, max_width=80)

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -111,7 +111,7 @@ def test_static_quantity_rejects_traced_value() -> None:
     def make(x):
         return u.StaticQuantity(x, "m")
 
-    with pytest.raises(TypeError, match="trac"):
+    with pytest.raises(TypeError, match="cannot hold a traced JAX value"):
         make(jnp.array([1.0, 2.0]))
 
 

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -52,6 +52,24 @@ def test_static_value_deepcopy_preserves_type_and_dtype() -> None:
     assert np.array_equal(np.asarray(shallow), np.asarray(sv))
 
 
+def test_static_value_getattr_preserves_dtype() -> None:
+    """Attributes/methods forwarded through ``__getattr__`` keep the real dtype.
+
+    Regression: ``__getattr__`` forwarded to ``jnp.asarray(self._array)``, which
+    applies JAX's x64-disabled dtype rules, so ``sv.dtype`` / ``sv.min()`` on a
+    faithfully-stored int64 / float64 array reported (and returned) the
+    downcast int32 / float32 instead.
+    """
+    sv = StaticValue(np.array([3, 1, 2], dtype=np.int64))
+    assert sv.dtype == np.int64
+    assert np.asarray(sv.min()).dtype == np.int64
+    assert int(sv.min()) == 1
+
+    svf = StaticValue(np.array([3.0, 1.0, 2.0], dtype=np.float64))
+    assert svf.dtype == np.float64
+    assert np.asarray(svf.sum()).dtype == np.float64
+
+
 def test_static_quantity_pickle_roundtrip() -> None:
     """A `StaticQuantity` survives a pickle round-trip unchanged."""
     sq = u.StaticQuantity(np.array([1.0, 2.0], dtype=np.float64), "m")

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -14,6 +14,8 @@ from hypothesis import given, strategies as st
 from hypothesis.extra.numpy import arrays as np_arrays
 from plum import promote
 
+import quaxed.numpy as qnp
+
 import unxt as u
 from unxt.quantity import StaticValue
 
@@ -90,10 +92,46 @@ def test_static_quantity_accepts_numpy() -> None:
     assert np.array_equal(np.asarray(vec.value), arr)
 
 
-def test_static_quantity_rejects_jax_array() -> None:
-    """StaticQuantity rejects JAX arrays."""
-    with pytest.raises(TypeError, match="StaticQuantity does not accept JAX arrays"):
-        u.StaticQuantity(jnp.array([1.0, 2.0]), "m")
+def test_static_quantity_materialises_concrete_jax_array() -> None:
+    """A concrete (eager) JAX array is materialised to NumPy, not rejected.
+
+    A concrete array is just data, so it can back a static value; only a
+    *tracer* (under jit/vmap/grad) genuinely cannot.
+    """
+    sq = u.StaticQuantity(jnp.array([1.0, 2.0]), "m")
+    assert isinstance(sq.value, StaticValue)
+    assert isinstance(sq.value.array, np.ndarray)
+    assert np.array_equal(np.asarray(sq.value), np.array([1.0, 2.0]))
+
+
+def test_static_quantity_rejects_traced_value() -> None:
+    """A traced JAX value cannot be static and is rejected under jit."""
+
+    @jax.jit
+    def make(x):
+        return u.StaticQuantity(x, "m")
+
+    with pytest.raises(TypeError, match="trac"):
+        make(jnp.array([1.0, 2.0]))
+
+
+def test_static_quantity_ops_preserve_staticness() -> None:
+    """Ops on a StaticQuantity stay static (return a StaticQuantity).
+
+    Regression: unary/reduction/scalar-arithmetic rules rebuild via
+    ``replace(x, value=<jax array>)``; the converter rejected that concrete
+    JAX array, so ``-sq``, ``abs(sq)``, ``sq * 2`` etc. crashed.
+    """
+    sq = u.StaticQuantity(np.array([3.0, 1.0, 2.0]), "m")
+
+    for got in (-sq, abs(sq), sq * 2, 2 * sq, sq / 2):
+        assert isinstance(got, u.StaticQuantity)
+        assert isinstance(got.value, StaticValue)
+
+    assert isinstance(qnp.sum(sq), u.StaticQuantity)
+    assert float(np.asarray(qnp.sum(sq).value)) == 6.0
+    assert isinstance(qnp.sqrt(sq), u.StaticQuantity)
+    assert float(np.asarray((sq * 2).value.sum())) == 12.0
 
 
 def test_static_quantity_accepts_array_like() -> None:
@@ -586,8 +624,11 @@ def test_static_value_from_dispatch() -> None:
     sv2 = u.quantity.StaticValue.from_(sv)
     assert sv2 is sv
 
-    with pytest.raises(TypeError, match="StaticQuantity does not accept JAX arrays"):
-        u.quantity.StaticValue.from_(jnp.array([1.0, 2.0]))
+    # A concrete (eager) JAX array is materialised to NumPy, not rejected.
+    sv3 = u.quantity.StaticValue.from_(jnp.array([1.0, 2.0]))
+    assert isinstance(sv3, u.quantity.StaticValue)
+    assert isinstance(sv3.array, np.ndarray)
+    assert np.array_equal(np.asarray(sv3), np.array([1.0, 2.0]))
 
 
 def test_static_value_unary_ops() -> None:


### PR DESCRIPTION
Two related `StaticQuantity` correctness fixes (both in `StaticValue`). Addresses several findings from the v2.0 release-gate audit.

## 1. `__getattr__` silently downcast the stored dtype

Every attribute/method reached through `StaticValue.__getattr__` forwarded to `getattr(jnp.asarray(self._array), name)`. `jnp.asarray` applies JAX's x64-disabled dtype rules, so a faithfully-stored int64 / float64 array was re-typed to int32 / float32 before the attribute ran:

```python
>>> sq = u.StaticQuantity(np.array([3, 1, 2], dtype=np.int64), "m")
>>> sq.value.array.dtype   # faithfully stored
dtype('int64')
>>> sq.value.dtype         # via __getattr__
dtype('int32')             # downcast!
>>> sq.value.min()
np.int32(1)                # downcast!
```

**Fix:** forward to the wrapped **NumPy** array (`getattr(self._array, name)`). NumPy has correct dtype semantics; `_jnparray` remains the JAX-conversion path for arithmetic.

## 2. Ops on a StaticQuantity crashed instead of staying static

`-sq`, `abs(sq)`, `sq * 2`, `2 * sq`, `sq / 2`, `qnp.sum(sq)`, `qnp.sqrt(sq)` all crashed with a misleading `TypeError` ("does not accept JAX arrays", or "unsupported operand type(s)" for the scalar-mul case). The primitive rules rebuild via `replace(x, value=<jax array>)`, and the `StaticValue.from_` converter rejected **every** `jax.Array` — including the *concrete* array those rules produce — so the whole unary / reduction / scalar-arithmetic surface was unusable.

**Fix (policy: preserve staticness):** materialise a concrete (eager) `jax.Array` back to NumPy in `StaticValue.from_` via `np.asarray`, rather than rejecting it. A concrete array is just data, so it can back a static value, and ops on a `StaticQuantity` therefore return a `StaticQuantity`. Only a **tracer** (under `jit`/`vmap`/`grad`) — a value that doesn't exist yet — is rejected, now with a message that names the real problem.

### Behavior change worth a look

This also makes the **constructor** accept a concrete `jax.Array` (materialising it) instead of raising. That's the coherent consequence of "concrete arrays are data, only tracers can't be static," and it's the audit's recommended approach — but it does relax the old "StaticQuantity rejects JAX arrays" contract, so flagging it explicitly. The `StaticQuantity` docstring and the `from_` / reject-jax tests are updated to the new contract (`jit` still correctly rejects the tracer).

## Verification

New regressions: `test_static_value_getattr_preserves_dtype`, `test_static_quantity_ops_preserve_staticness`, `test_static_quantity_materialises_concrete_jax_array`, `test_static_quantity_rejects_traced_value` (all fail on `main`). Updated: `test_static_value_from_dispatch`, the reject-jax test, and the `StaticQuantity` doctest. Full run under beartype: **151 passed** in the representative slice; `unxts.parametric` 103 src + 73 tests pass. (A pre-existing sybil doctest-collection quirk with the pickle test — reproduces on clean `main`, unrelated — is not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)