### PR TITLE
🐛 fix: keep true units for min/max/clamp of scaled-dimensionless quantities

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -898,8 +898,13 @@ def clamp_p_vaqaq(min: ArrayLike, x: ABCQ, max: ABCQ) -> ABCQ:
     >>> lax.clamp(min, q, max)
     Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is clamped in true units, not its own:
+
+    >>> lax.clamp(jnp.asarray(0.0), u.Q(100.0, "percent"), u.Q(0.5, ""))
+    Quantity(Array(0.5, dtype=float32), unit='')
+
     """
-    return replace(x, value=lax.clamp(min, ustrip(one, x), ustrip(one, max)))
+    return _as_dimensionless_like(x, lax.clamp(min, ustrip(one, x), ustrip(one, max)))
 
 
 # ---------------------------
@@ -941,8 +946,13 @@ def clamp_p_aqaqv(min: ABCQ, x: ABCQ, max: ArrayLike) -> ABCQ:
     >>> lax.clamp(min, q, max)
     Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is clamped in true units, not its own:
+
+    >>> lax.clamp(u.Q(0.0, ""), u.Q(100.0, "percent"), jnp.asarray(0.5))
+    Quantity(Array(0.5, dtype=float32), unit='')
+
     """
-    return replace(x, value=lax.clamp(ustrip(one, min), ustrip(one, x), max))
+    return _as_dimensionless_like(x, lax.clamp(ustrip(one, min), ustrip(one, x), max))
 
 
 # ==============================================================================
@@ -3280,9 +3290,14 @@ def max_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
     >>> jnp.maximum(x, q2)
     Quantity(Array([2.], dtype=float32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.maximum(x, u.Q(100.0, "percent"))
+    Quantity(Array([1.], dtype=float32), unit='')
+
     """
     yv = ustrip(one, y)
-    return replace(y, value=lax.max(x, yv))
+    return _as_dimensionless_like(y, lax.max(x, yv))
 
 
 @quax.register(lax.max_p)
@@ -3302,9 +3317,14 @@ def max_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> jnp.maximum(q1, y)
     Quantity(Array([2.], dtype=float32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.maximum(u.Q(100.0, "percent"), y)
+    Quantity(Array([1.], dtype=float32), unit='')
+
     """
     xv = ustrip(one, x)
-    return replace(x, value=lax.max(xv, y))
+    return _as_dimensionless_like(x, lax.max(xv, y))
 
 
 @quax.register(lax.max_p)
@@ -3375,8 +3395,13 @@ def min_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
     >>> jnp.minimum(x, q)
     Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.minimum(jnp.array([0.5]), u.Q(100.0, "percent"))
+    Quantity(Array([0.5], dtype=float32), unit='')
+
     """
-    return replace(y, value=lax.min(x, ustrip(one, y)))
+    return _as_dimensionless_like(y, lax.min(x, ustrip(one, y)))
 
 
 @quax.register(lax.min_p)
@@ -3397,8 +3422,13 @@ def min_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> jnp.minimum(q, x)
     Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.minimum(u.Q(100.0, "percent"), jnp.array([0.5]))
+    Quantity(Array([0.5], dtype=float32), unit='')
+
     """
-    return replace(x, value=lax.min(ustrip(one, x), y))
+    return _as_dimensionless_like(x, lax.min(ustrip(one, x), y))
 
 
 # ==============================================================================

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -901,7 +901,7 @@ def clamp_p_vaqaq(min: ArrayLike, x: ABCQ, max: ABCQ) -> ABCQ:
     A scaled-dimensionless quantity is clamped in true units, not its own:
 
     >>> lax.clamp(jnp.asarray(0.0), u.Q(100.0, "percent"), u.Q(0.5, ""))
-    Quantity(Array(0.5, dtype=float32), unit='')
+    Quantity(Array(0.5, dtype=float32...), unit='')
 
     """
     return _as_dimensionless_like(x, lax.clamp(min, ustrip(one, x), ustrip(one, max)))
@@ -949,7 +949,7 @@ def clamp_p_aqaqv(min: ABCQ, x: ABCQ, max: ArrayLike) -> ABCQ:
     A scaled-dimensionless quantity is clamped in true units, not its own:
 
     >>> lax.clamp(u.Q(0.0, ""), u.Q(100.0, "percent"), jnp.asarray(0.5))
-    Quantity(Array(0.5, dtype=float32), unit='')
+    Quantity(Array(0.5, dtype=float32...), unit='')
 
     """
     return _as_dimensionless_like(x, lax.clamp(ustrip(one, min), ustrip(one, x), max))

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -1658,6 +1658,7 @@ def test_clip_scaled_dimensionless():
 
     got = jnp.clip(q, 0.0, 0.5)
 
+    assert got.unit == u.unit("")
     assert u.ustrip("", got) == 0.5
 
 
@@ -1665,16 +1666,18 @@ def test_maximum_scaled_dimensionless():
     """``maximum`` with a bare bound on a scaled-dimensionless quantity."""
     q = u.Q(100.0, "percent")  # == 1.0 dimensionless
 
-    assert u.ustrip("", jnp.maximum(0.0, q)) == 1.0
-    assert u.ustrip("", jnp.maximum(q, 0.0)) == 1.0
+    for got in (jnp.maximum(0.0, q), jnp.maximum(q, 0.0)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 1.0
 
 
 def test_minimum_scaled_dimensionless():
     """``minimum`` with a bare bound on a scaled-dimensionless quantity."""
     q = u.Q(100.0, "percent")  # == 1.0 dimensionless
 
-    assert u.ustrip("", jnp.minimum(0.5, q)) == 0.5
-    assert u.ustrip("", jnp.minimum(q, 0.5)) == 0.5
+    for got in (jnp.minimum(0.5, q), jnp.minimum(q, 0.5)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 0.5
 
 
 def test_clamp_scaled_dimensionless():
@@ -1686,8 +1689,9 @@ def test_clamp_scaled_dimensionless():
     """
     q = u.Q(100.0, "percent")  # == 1.0 dimensionless
 
-    assert u.ustrip("", qlax.clamp(0.0, q, u.Q(0.5, ""))) == 0.5
-    assert u.ustrip("", qlax.clamp(u.Q(0.0, ""), q, 0.5)) == 0.5
+    for got in (qlax.clamp(0.0, q, u.Q(0.5, "")), qlax.clamp(u.Q(0.0, ""), q, 0.5)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 0.5
 
 
 @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")  # TODO: Why?

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -1647,6 +1647,49 @@ def test_min():
     assert jnp.array_equal(got.value, exp.value)
 
 
+def test_clip_scaled_dimensionless():
+    """Bare bounds on a scaled-dimensionless quantity keep true units.
+
+    ``jnp.clip`` lowers to ``maximum``/``minimum``, so bare bounds must be
+    compared against ``q`` in true-dimensionless units and the result must not
+    inherit ``q``'s scaled ('%') unit.
+    """
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    got = jnp.clip(q, 0.0, 0.5)
+
+    assert u.ustrip("", got) == 0.5
+
+
+def test_maximum_scaled_dimensionless():
+    """``maximum`` with a bare bound on a scaled-dimensionless quantity."""
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    assert u.ustrip("", jnp.maximum(0.0, q)) == 1.0
+    assert u.ustrip("", jnp.maximum(q, 0.0)) == 1.0
+
+
+def test_minimum_scaled_dimensionless():
+    """``minimum`` with a bare bound on a scaled-dimensionless quantity."""
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    assert u.ustrip("", jnp.minimum(0.5, q)) == 0.5
+    assert u.ustrip("", jnp.minimum(q, 0.5)) == 0.5
+
+
+def test_clamp_scaled_dimensionless():
+    """``lax.clamp`` with a bare bound on a scaled-dimensionless quantity.
+
+    The mixed array/quantity ``clamp`` rules share the min/max defect: a bound
+    given as a bare array must clamp ``q`` in true-dimensionless units, and the
+    result must not inherit ``q``'s scaled ('%') unit.
+    """
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    assert u.ustrip("", qlax.clamp(0.0, q, u.Q(0.5, ""))) == 0.5
+    assert u.ustrip("", qlax.clamp(u.Q(0.0, ""), q, 0.5)) == 0.5
+
+
 @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")  # TODO: Why?
 def test_prod():
     """Test `prod`."""


### PR DESCRIPTION
## Problem

`jnp.clip` on a scaled-dimensionless quantity mislabels the result:

```python
import unxt as u, quaxed.numpy as jnp
q = u.Q(100.0, "percent")           # == 1.0 dimensionless
jnp.clip(q, 0.0, 0.5)               # -> Quantity(0.01, unit='%')  ❌
                                    #    should be Quantity(0.5, unit='')
```

## Root cause

In this JAX version, `jnp.clip` lowers to `maximum`/`minimum`, not `clamp_p`. The mixed **array/quantity** rules for `max_p`, `min_p` (and, by the same defect, the mixed `clamp_p` rules) strip the quantity to *true*-dimensionless via `ustrip(one, q)` but re-wrap the result with `replace(q, ...)`, which keeps `q`'s **scaled** unit. For a scaled-dimensionless unit like `percent`, the stripped value (`1.0`) is then relabeled `%`, giving `Quantity(1.0, '%')` == `0.01` dimensionless.

## Fix

Wrap these results with `_as_dimensionless_like(q, value)` instead of `replace(q, value=...)`, mirroring the comparison-primitive rules. Affected registrations:

- `max_p_vq`, `max_p_qv`
- `min_p_vq`, `min_p_qv`
- `clamp_p_vaqaq`, `clamp_p_aqaqv` (reachable via `lax.clamp` with a bare bound; identical latent defect)

The all-quantity rules (`max_p_qq`, `min_p_qq`, all-quantity `clamp_p`) already work in the quantity's own unit and are correct for scaled-dimensionless, so they are unchanged.

This is a sibling of #729, which fixed the transcendental and other array-vs-quantity min/max/clamp rules but deliberately left these mixed paths.

## Tests

Added `test_clip_scaled_dimensionless`, `test_maximum_scaled_dimensionless`, `test_minimum_scaled_dimensionless`, and `test_clamp_scaled_dimensionless` (written test-first, confirmed failing before the fix), plus docstring examples on each fixed rule. Full suite (`--doctest-modules` on `register_primitives.py`, `tests/unit/test_quantity.py`, `tests/integration/quaxed/`) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)