### PR TITLE
🐛 fix(quantity): unpack multiple-results top_k/approx_top_k on quantities

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -428,7 +428,7 @@ def and_p_vq(x1: ArrayLike, x2: ABCQ, /) -> ABCQ:
 
 
 @quax.register(lax.approx_top_k_p)
-def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> list[Any]:
+def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> list[ABCQ | Array]:
     """Approximate top-k of a quantity.
 
     ``approx_top_k_p`` has ``multiple_results=True``: it returns
@@ -5158,7 +5158,7 @@ def tanh_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
 
 @quax.register(lax.top_k_p)
-def top_k_p(operand: ABCQ, /, **kw: Any) -> list[Any]:
+def top_k_p(operand: ABCQ, /, **kw: Any) -> list[ABCQ | Array]:
     """Top k elements of a quantity.
 
     ``top_k_p`` has ``multiple_results=True``: it returns ``[values, indices]``.

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -428,8 +428,12 @@ def and_p_vq(x1: ArrayLike, x2: ABCQ, /) -> ABCQ:
 
 
 @quax.register(lax.approx_top_k_p)
-def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
+def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> list[Any]:
     """Approximate top-k of a quantity.
+
+    ``approx_top_k_p`` has ``multiple_results=True``: it returns
+    ``[values, indices]``. Only the values carry the operand's unit; the indices
+    are a raw ``int`` array (dimensionless), like plain JAX.
 
     Examples
     --------
@@ -439,10 +443,11 @@ def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
     >>> x = u.quantity.Quantity([1.0, 2, 3], "m")
     >>> qlax.approx_max_k(x, k=2)
     [Quantity(Array([3., 2.], dtype=float32), unit='m'),
-     Quantity(Array([2., 1.], dtype=float32), unit='m')]
+     Array([2, 1], dtype=int32)]
 
     """
-    return replace(x, value=lax.approx_top_k_p.bind(ustrip(x), **kwargs))  # type: ignore[no-untyped-call]
+    vals, idx = lax.approx_top_k_p.bind(ustrip(x), **kwargs)  # type: ignore[no-untyped-call]
+    return [replace(x, value=vals), idx]
 
 
 # ==============================================================================
@@ -5153,26 +5158,31 @@ def tanh_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
 
 @quax.register(lax.top_k_p)
-def top_k_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
+def top_k_p(operand: ABCQ, /, **kw: Any) -> list[Any]:
     """Top k elements of a quantity.
+
+    ``top_k_p`` has ``multiple_results=True``: it returns ``[values, indices]``.
+    Only the values carry the operand's unit; the indices are a raw ``int``
+    array (dimensionless), like plain JAX.
 
     Examples
     --------
     >>> import quaxed.lax as qlax
     >>> import unxt as u
 
-    >>> q = u.quantity.Quantity([1, 2, 3], "m")
+    >>> q = u.quantity.Quantity([1.0, 2, 3], "m")
     >>> qlax.top_k(q, k=2)
-    [Quantity(Array([3, 2], dtype=int32), unit='m'),
-     Quantity(Array([2, 1], dtype=int32), unit='m')]
+    [Quantity(Array([3., 2.], dtype=float32), unit='m'),
+     Array([2, 1], dtype=int32)]
 
-    >>> q = u.Q([1, 2, 3], "m")
+    >>> q = u.Q([1.0, 2, 3], "m")
     >>> qlax.top_k(q, k=2)
-    [Quantity(Array([3, 2], dtype=int32), unit='m'),
-     Quantity(Array([2, 1], dtype=int32), unit='m')]
+    [Quantity(Array([3., 2.], dtype=float32), unit='m'),
+     Array([2, 1], dtype=int32)]
 
     """
-    return replace(operand, value=lax.top_k_p.bind(ustrip(operand), **kw))  # type: ignore[no-untyped-call]
+    vals, idx = lax.top_k_p.bind(ustrip(operand), **kw)  # type: ignore[no-untyped-call]
+    return [replace(operand, value=vals), idx]
 
 
 # ==============================================================================

--- a/tests/integration/quaxed/test_lax.py
+++ b/tests/integration/quaxed/test_lax.py
@@ -3,6 +3,7 @@
 
 import operator as ops
 
+import jax
 import jax.numpy as jnp
 import jax.tree as jtu
 import pytest
@@ -59,7 +60,7 @@ xround = u.Q(xround_val, unit="m")
             "approx_max_k",
             (x_L,),
             {"k": 2},
-            [u.Q([[2.0, 1], [4, 3]], unit="m"), u.Q([[1.0, 0], [1, 0]], unit="m")],
+            [u.Q([[2.0, 1], [4, 3]], unit="m"), jnp.asarray([[1, 0], [1, 0]])],
         ),
         (
             "approx_min_k",
@@ -67,7 +68,7 @@ xround = u.Q(xround_val, unit="m")
             {"k": 2},
             [
                 u.Q([[1.0, 2.0], [3.0, 4.0]], unit="m"),
-                u.Q([[0.0, 1.0], [0.0, 1.0]], unit="m"),
+                jnp.asarray([[0, 1], [0, 1]]),
             ],
         ),
         ("argmax", (x_L,), {"axis": 0, "index_dtype": int}, jnp.array([1, 1])),
@@ -340,7 +341,7 @@ xround = u.Q(xround_val, unit="m")
         ("sub", (x_L, y_L), {}, u.Q(lax.sub(x_val, y_val), "m")),
         ("tan", (x_ND,), {}, u.Q(lax.tan(x_val), "")),
         ("tanh", (x_ND,), {}, u.Q(lax.tanh(x_val), "")),
-        ("top_k", (x_L, 1), {}, [u.Q([[2.0], [4.0]], "m"), u.Q([[1.0], [1.0]], "m")]),
+        ("top_k", (x_L, 1), {}, [u.Q([[2.0], [4.0]], "m"), jnp.asarray([[1], [1]])]),
         (
             "transpose",
             (x_L, (1, 0)),
@@ -411,3 +412,29 @@ def test_lax_functions(func_name, args, kw, expected):
     assert jtu.all(
         jtu.map(ops.eq, got_units, exp_units, is_leaf=lambda x: isinstance(x, UnitBase))
     )
+
+
+def test_top_k_indices_are_raw_int_arrays():
+    """``top_k`` returns unit-carrying values but raw dimensionless int indices.
+
+    Regression: ``top_k_p`` is a multiple-results primitive returning
+    ``[values, indices]``, but the rule wrapped the whole ``[values, indices]``
+    list in the operand's unit -- so the indices came back as float, unit-'m'
+    quantities (unusable for indexing) and the call crashed under ``jax.jit``.
+    """
+    q = u.Q([1.0, 2.0, 3.0], "m")
+
+    vals, idx = qlax.top_k(q, k=2)
+    assert is_any_quantity(vals)
+    assert vals.unit == u.unit("m")
+    # Indices are a raw JAX int array, not a quantity.
+    assert not is_any_quantity(idx)
+    assert jnp.issubdtype(idx.dtype, jnp.integer)
+    assert jnp.array_equal(idx, jnp.asarray([2, 1]))
+    # They can actually index the quantity.
+    assert jnp.array_equal(u.ustrip(q[idx]), jnp.asarray([3.0, 2.0]))
+
+    # And it survives jit (previously raised UnexpectedTracerError).
+    jvals, jidx = jax.jit(lambda x: qlax.top_k(x, k=2))(q)
+    assert jvals.unit == u.unit("m")
+    assert jnp.array_equal(jidx, jnp.asarray([2, 1]))


### PR DESCRIPTION
## The bug

`top_k` on a `Quantity` corrupts the returned indices and crashes under `jit`:

```python
>>> import unxt as u, quaxed.lax as qlax
>>> q = u.Q([1.0, 2.0, 3.0], "m")
>>> qlax.top_k(q, k=2)
[Quantity(Array([3., 2.], dtype=float32), unit='m'),
 Quantity(Array([2., 1.], dtype=float32), unit='m')]   # indices: float, unit='m'!
```

Compare plain JAX, whose indices are `Array([2, 1], dtype=int32)`. The unit-carrying float indices can't index the quantity (`q[idx]` → `UnitConversionError`), and under `jax.jit` the call raises `UnexpectedTracerError`. `approx_top_k` / `approx_max_k` / `approx_min_k` are corrupted identically.

## Root cause

`top_k_p` and `approx_top_k_p` are `multiple_results=True` primitives returning `[values, indices]`, but the rules did `replace(operand, value=lax.<op>_p.bind(...))` — passing the 2-element `[values, indices]` list as the value. The constructor's `jnp.asarray` stacked them into one `(2, k)` array, promoting the int indices to the values' float dtype and tagging them with the operand's unit. Under jit, the same stacking leaks a tracer.

## JAX 0.11.0 turns this into a hard crash (why CI is red now)

Under JAX ≤ 0.10.x the stacked-array bug is *silent*: wrong indices, plus a jit-only `UnexpectedTracerError`. **JAX 0.11.0 changed how `quax` receives `multiple_results` primitives** — it now iterates the rule's return value expecting one element per result. Returning a single stacked `Quantity` therefore blows up at collection time, iterating the `Quantity` into an out-of-trace slice:

```
AttributeError: 'NoneType' object has no attribute 'process_primitive'
```

That is what took the **"Newest supported deps"** job (jax==0.11.0, Python 3.11–3.14) red — [run 29627929341](https://github.com/GalacticDynamics/unxt/actions/runs/29627929341/job/88035998308): 3 doctests + 3 `test_lax` params. This is cosmetic to the root cause (same stacking bug, surfaced as a crash rather than corruption); the fix below resolves it regardless of JAX version, verified on both 0.10.1 and 0.11.0.

## The fix

Unpack the two bound outputs and wrap **only the values** in the operand's unit, returning the indices as a raw int array — mirroring `split_p` and matching plain JAX:

```python
vals, idx = lax.top_k_p.bind(ustrip(operand), **kw)
return [replace(operand, value=vals), idx]
```

Return annotations corrected to `list[Any]`.

## Also fixed (the bug was enshrined in CI)

The `top_k` / `approx_max_k` / `approx_min_k` entries in `test_lax.py` asserted the buggy float, unit-`m` indices, so the defect passed CI. Updated to raw int arrays, and the doctests switched to float inputs so the index dtype is observable. A dedicated `test_top_k_indices_are_raw_int_arrays` locks in: int-dtype indices, that they can actually index the quantity, and the `jax.jit` path.

## Verification

**1348 passed** (`register_primitives` doctests + `tests/integration/quaxed/test_lax.py`); `unxts.parametric` 103 src pass.

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)