### PR TITLE
Backport PR #732 on branch versions/v1.11.x (🐛 fix: keep true units for min/max/clamp of scaled-dimensionless quantities)

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -44,6 +44,22 @@ def _to_val_rad_or_one(q: ABCQ) -> ArrayLike:
     return ustrip(radian if is_unit_convertible(q.unit, radian) else one, q)
 
 
+def _as_dimensionless_like(q: ABCQ, value: ArrayLike) -> ABCQ:
+    """Wrap a value as a dimensionless quantity like ``q``.
+
+    When a bare array is combined with a quantity (e.g. ``maximum(0.0, q)``) the
+    quantity operand is stripped to *true* dimensionless units, so the result
+    must be labelled dimensionless too — not with ``q``'s own (possibly scaled,
+    e.g. ``percent``) unit. Some quantity subtypes (e.g. ``Angle``,
+    ``StaticQuantity``) constrain their units and cannot be dimensionless; for
+    those we fall back to a plain dimensionless :class:`Quantity`.
+    """
+    try:
+        return type_np(q)(value, unit=one)
+    except (ValueError, TypeError):
+        return Q(value, unit=one)
+
+
 ################################################################################
 # Registering Primitives
 
@@ -898,8 +914,13 @@ def clamp_p_vaqaq(min: ArrayLike, x: ABCQ, max: ABCQ) -> ABCQ:
     >>> lax.clamp(min, q, max)
     Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is clamped in true units, not its own:
+
+    >>> lax.clamp(jnp.asarray(0.0), u.Q(100.0, "percent"), u.Q(0.5, ""))
+    Quantity(Array(0.5, dtype=float32...), unit='')
+
     """
-    return replace(x, value=lax.clamp(min, ustrip(one, x), ustrip(one, max)))
+    return _as_dimensionless_like(x, lax.clamp(min, ustrip(one, x), ustrip(one, max)))
 
 
 # ---------------------------
@@ -966,7 +987,7 @@ def clamp_p_aqaqv(min: ABCQ, x: ABCQ, max: ArrayLike) -> ABCQ:
     BareQuantity(Array([0, 1, 2], dtype=int32), unit='')
 
     """
-    return replace(x, value=lax.clamp(ustrip(one, min), ustrip(one, x), max))
+    return _as_dimensionless_like(x, lax.clamp(ustrip(one, min), ustrip(one, x), max))
 
 
 @quax.register(lax.clamp_p)
@@ -986,8 +1007,13 @@ def clamp_p_qqv(
     >>> lax.clamp(min, q, max)
     Quantity(Array([0, 1, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is clamped in true units, not its own:
+
+    >>> lax.clamp(u.Q(0.0, ""), u.Q(100.0, "percent"), jnp.asarray(0.5))
+    Quantity(Array(0.5, dtype=float32...), unit='')
+
     """
-    return replace(x, value=lax.clamp(ustrip(one, min), ustrip(one, x), max))
+    return _as_dimensionless_like(x, lax.clamp(ustrip(one, min), ustrip(one, x), max))
 
 
 # ==============================================================================
@@ -3359,9 +3385,14 @@ def max_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
     >>> jnp.maximum(x, q2)
     Quantity(Array([2.], dtype=float32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.maximum(x, u.Q(100.0, "percent"))
+    Quantity(Array([1.], dtype=float32), unit='')
+
     """
     yv = ustrip(one, y)
-    return replace(y, value=lax.max(x, yv))
+    return _as_dimensionless_like(y, lax.max(x, yv))
 
 
 @quax.register(lax.max_p)
@@ -3381,9 +3412,14 @@ def max_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> jnp.maximum(q1, y)
     Quantity(Array([2.], dtype=float32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.maximum(u.Q(100.0, "percent"), y)
+    Quantity(Array([1.], dtype=float32), unit='')
+
     """
     xv = ustrip(one, x)
-    return replace(x, value=lax.max(xv, y))
+    return _as_dimensionless_like(x, lax.max(xv, y))
 
 
 @quax.register(lax.max_p)
@@ -3454,8 +3490,13 @@ def min_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
     >>> jnp.minimum(x, q)
     Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.minimum(jnp.array([0.5]), u.Q(100.0, "percent"))
+    Quantity(Array([0.5], dtype=float32), unit='')
+
     """
-    return replace(y, value=lax.min(x, ustrip(one, y)))
+    return _as_dimensionless_like(y, lax.min(x, ustrip(one, y)))
 
 
 @quax.register(lax.min_p)
@@ -3476,8 +3517,13 @@ def min_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     >>> jnp.minimum(q, x)
     Quantity(Array([1, 2, 2], dtype=int32), unit='')
 
+    A scaled-dimensionless quantity is compared in true units, not its own:
+
+    >>> jnp.minimum(u.Q(100.0, "percent"), jnp.array([0.5]))
+    Quantity(Array([0.5], dtype=float32), unit='')
+
     """
-    return replace(x, value=lax.min(ustrip(one, x), y))
+    return _as_dimensionless_like(x, lax.min(ustrip(one, x), y))
 
 
 # ==============================================================================

--- a/tests/integration/quaxed/test_numpy.py
+++ b/tests/integration/quaxed/test_numpy.py
@@ -14,6 +14,7 @@ from jax._src.numpy.setops import (
 from jax.numpy import iinfo as IInfo  # noqa: N812
 from numpy import finfo as FInfo  # noqa: N812
 
+import quaxed.lax as qlax
 import quaxed.numpy as jnp
 
 import unxt as u
@@ -1499,6 +1500,53 @@ def test_min():
     assert isinstance(got, u.Q)
     assert got.unit == exp.unit
     assert jnp.array_equal(got.value, exp.value)
+
+
+def test_clip_scaled_dimensionless():
+    """Bare bounds on a scaled-dimensionless quantity keep true units.
+
+    ``jnp.clip`` lowers to ``maximum``/``minimum``, so bare bounds must be
+    compared against ``q`` in true-dimensionless units and the result must not
+    inherit ``q``'s scaled ('%') unit.
+    """
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    got = jnp.clip(q, 0.0, 0.5)
+
+    assert got.unit == u.unit("")
+    assert u.ustrip("", got) == 0.5
+
+
+def test_maximum_scaled_dimensionless():
+    """``maximum`` with a bare bound on a scaled-dimensionless quantity."""
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    for got in (jnp.maximum(0.0, q), jnp.maximum(q, 0.0)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 1.0
+
+
+def test_minimum_scaled_dimensionless():
+    """``minimum`` with a bare bound on a scaled-dimensionless quantity."""
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    for got in (jnp.minimum(0.5, q), jnp.minimum(q, 0.5)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 0.5
+
+
+def test_clamp_scaled_dimensionless():
+    """``lax.clamp`` with a bare bound on a scaled-dimensionless quantity.
+
+    The mixed array/quantity ``clamp`` rules share the min/max defect: a bound
+    given as a bare array must clamp ``q`` in true-dimensionless units, and the
+    result must not inherit ``q``'s scaled ('%') unit.
+    """
+    q = u.Q(100.0, "percent")  # == 1.0 dimensionless
+
+    for got in (qlax.clamp(0.0, q, u.Q(0.5, "")), qlax.clamp(u.Q(0.0, ""), q, 0.5)):
+        assert got.unit == u.unit("")
+        assert u.ustrip("", got) == 0.5
 
 
 @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")  # TODO: Why?


### PR DESCRIPTION
Backport of #732 to `versions/v1.11.x` (targeting the next v1.11.x patch).

## The bug

`jnp.clip` lowers to `maximum`/`minimum`, and the mixed array/quantity `max_p`/`min_p` rules stripped the quantity operand to **true** dimensionless units (`ustrip(one, q)`) but re-wrapped the result with `replace(q, …)`, preserving `q`'s own *scaled* unit. For a scaled-dimensionless quantity such as `percent`:

```python
>>> import unxt as u, quaxed.numpy as jnp
>>> jnp.clip(u.Q(100.0, "percent"), 0.0, 0.5)
Quantity(0.01, unit='%')   # == 1e-4, should be Quantity(0.5, unit='')
```

The mixed `clamp_p` rules (`vaqaq`, `aqaqv`, and the parametric-dimensionless `qqv`) share the identical defect, reachable via `lax.clamp` with bare bounds.

Confirmed reproducing on `versions/v1.11.x` before the fix (`ustrip("", …) == 1e-4`).

## The fix

`_as_dimensionless_like` (introduced upstream in #729, which is **not** on this branch, so it is backported here as a small self-contained helper) wraps the result as a truly dimensionless quantity in `q`'s namespace. All six mixed min/max/clamp rules now route through it.

This branch has a finer-grained `clamp` registration set than `main`, so the backport fixes **three** clamp rules (`clamp_p_vaqaq`, `clamp_p_aqaqv`, and the parametric `clamp_p_qqv`) — the latter is the one actually dispatched for a parametric dimensionless `u.Q(…, "percent")`. The `aqvaq`/`qvq` rules return bare arrays and are unaffected.

## Tests

- New regressions covering `clip`/`maximum`/`minimum`/`clamp` with a scaled-dimensionless quantity, asserting both the stripped value **and** the truly-dimensionless unit.
- Doctest examples on each fixed rule.
- Full `register_primitives` doctests, `tests/integration/quaxed/`, and `tests/unit/test_quantity.py` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)