### PR TITLE
🐛 fix(config): override(cfg) must not reset unmentioned traits

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -113,11 +113,18 @@ class _ParametricLocalConfig(LocalConfigurable):
 
         if cfg is not None:
             temp_instance = self.__class__(config=cfg)
-            overrides = {}
-            for trait_name in self.trait_names():
-                overrides[trait_name] = object.__getattribute__(
-                    temp_instance, trait_name
-                )
+            # Only override the traits the Config actually specifies. Iterating
+            # every trait would read the class default for traits absent from
+            # ``cfg`` and clobber any globally-configured value on entry.
+            specified: set[str] = set()
+            for klass in type(self).__mro__:
+                section = cfg.get(klass.__name__, None)
+                if section:
+                    specified |= set(section)
+            overrides = {
+                name: object.__getattribute__(temp_instance, name)
+                for name in specified & set(self.trait_names())
+            }
             kwargs = overrides
 
         return _NestedConfigContext(self, kwargs)

--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -121,9 +121,12 @@ class _ParametricLocalConfig(LocalConfigurable):
                 section = cfg.get(klass.__name__, None)
                 if section:
                     specified |= set(section)
+            # Intersect with the *override allowlist*, not all traits:
+            # ``__getattribute__`` only consults these keys, so an entry outside
+            # it could never be observed -- it would just be a dead push.
             overrides = {
                 name: object.__getattribute__(temp_instance, name)
-                for name in specified & set(self.trait_names())
+                for name in specified & set(self._config_keys)
             }
             kwargs = overrides
 

--- a/packages/unxts.parametric/tests/test_config.py
+++ b/packages/unxts.parametric/tests/test_config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import unxts.parametric as up
+from traitlets.config import Config
 
 import unxt as u
 
@@ -41,6 +42,24 @@ def test_nested_override() -> None:
         assert str(q).startswith("ParametricQuantity(")  # no ['length']
     # restored
     assert str(q).startswith("ParametricQuantity['length']")
+
+
+def test_override_with_config_preserves_unmentioned_traits() -> None:
+    """``override(cfg)`` must not reset traits the Config does not mention.
+
+    Regression: the ``cfg`` branch overrode every trait, reading the class
+    default for traits absent from the Config, so entering with an empty (or
+    unrelated) Config silently discarded a globally-set value.
+    """
+    original = up.config.quantity_repr.include_params
+    try:
+        up.config.quantity_repr.include_params = True
+        with up.config.quantity_repr.override(Config()):
+            # Empty Config mentions nothing -> the global value must survive.
+            assert up.config.quantity_repr.include_params is True
+        assert up.config.quantity_repr.include_params is True
+    finally:
+        up.config.quantity_repr.include_params = original
 
 
 def test_override_rejects_unknown_option() -> None:

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -249,11 +249,18 @@ class QuantityReprConfig(LocalConfigurable):
             # resolved trait values. This ensures LazyConfigValue objects are
             # properly resolved to their actual values.
             temp_instance = self.__class__(config=cfg)
-            overrides = {}
-            for trait_name in self.trait_names():
-                overrides[trait_name] = object.__getattribute__(
-                    temp_instance, trait_name
-                )
+            # Only override the traits the Config actually specifies. Iterating
+            # every trait would read the class default for traits absent from
+            # ``cfg`` and clobber any globally-configured value on entry.
+            specified: set[str] = set()
+            for klass in type(self).__mro__:
+                section = cfg.get(klass.__name__, None)
+                if section:
+                    specified |= set(section)
+            overrides = {
+                name: object.__getattribute__(temp_instance, name)
+                for name in specified & set(self.trait_names())
+            }
             kwargs = overrides
 
         return _NestedConfigContext(self, kwargs)
@@ -418,11 +425,18 @@ class QuantityStrConfig(LocalConfigurable):
             # resolved trait values. This ensures LazyConfigValue objects are
             # properly resolved to their actual values.
             temp_instance = self.__class__(config=cfg)
-            overrides = {}
-            for trait_name in self.trait_names():
-                overrides[trait_name] = object.__getattribute__(
-                    temp_instance, trait_name
-                )
+            # Only override the traits the Config actually specifies. Iterating
+            # every trait would read the class default for traits absent from
+            # ``cfg`` and clobber any globally-configured value on entry.
+            specified: set[str] = set()
+            for klass in type(self).__mro__:
+                section = cfg.get(klass.__name__, None)
+                if section:
+                    specified |= set(section)
+            overrides = {
+                name: object.__getattribute__(temp_instance, name)
+                for name in specified & set(self.trait_names())
+            }
             kwargs = overrides
 
         return _NestedConfigContext(self, kwargs)

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -257,9 +257,12 @@ class QuantityReprConfig(LocalConfigurable):
                 section = cfg.get(klass.__name__, None)
                 if section:
                     specified |= set(section)
+            # Intersect with the *override allowlist*, not all traits:
+            # ``__getattribute__`` only consults these keys, so an entry outside
+            # it could never be observed -- it would just be a dead push.
             overrides = {
                 name: object.__getattribute__(temp_instance, name)
-                for name in specified & set(self.trait_names())
+                for name in specified & QUANTITY_REPR_CONFIG_KEYS
             }
             kwargs = overrides
 
@@ -433,9 +436,12 @@ class QuantityStrConfig(LocalConfigurable):
                 section = cfg.get(klass.__name__, None)
                 if section:
                     specified |= set(section)
+            # Intersect with the *override allowlist*, not all traits:
+            # ``__getattribute__`` only consults these keys, so an entry outside
+            # it could never be observed -- it would just be a dead push.
             overrides = {
                 name: object.__getattribute__(temp_instance, name)
-                for name in specified & set(self.trait_names())
+                for name in specified & QUANTITY_STR_CONFIG_KEYS
             }
             kwargs = overrides
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -742,6 +742,37 @@ def test_nested_config_override() -> None:
         u.config.quantity_repr.use_short_name = original_use_short_name
 
 
+def test_override_with_config_preserves_unmentioned_traits() -> None:
+    """``override(cfg)`` must not reset traits the Config does not mention.
+
+    Regression: the ``cfg`` branch looped over every trait and pushed an
+    override for each, reading the class default for traits absent from the
+    Config -- so entering the context silently discarded any globally-set value
+    for those traits.
+    """
+    original_short_arrays = u.config.quantity_repr.short_arrays
+    original_use_short_name = u.config.quantity_repr.use_short_name
+
+    try:
+        # A globally-set value on a trait the Config does not mention.
+        u.config.quantity_repr.use_short_name = True
+
+        cfg = Config()
+        cfg.QuantityReprConfig.short_arrays = "compact"
+
+        with u.config.quantity_repr.override(cfg):
+            # The mentioned trait takes the Config value ...
+            assert u.config.quantity_repr.short_arrays == "compact"
+            # ... and the unmentioned one keeps its globally-set value.
+            assert u.config.quantity_repr.use_short_name is True
+
+        # After exit, the global value is still there.
+        assert u.config.quantity_repr.use_short_name is True
+    finally:
+        u.config.quantity_repr.short_arrays = original_short_arrays
+        u.config.quantity_repr.use_short_name = original_use_short_name
+
+
 def test_nested_str_config_override() -> None:
     """Test that QuantityStrConfig override() is applied and restored."""
     original_short_arrays = u.config.quantity_str.short_arrays


### PR DESCRIPTION
## The bug

`config.override(cfg)` with a `Config` that sets one trait silently resets *every other* trait to its class default on context entry:

```python
>>> import unxt as u
>>> from traitlets.config import Config
>>> u.config.quantity_repr.use_short_name = True   # global value
>>> cfg = Config()
>>> cfg.QuantityReprConfig.short_arrays = "compact"  # mentions only short_arrays
>>> with u.config.quantity_repr.override(cfg):
...     u.config.quantity_repr.use_short_name        # unmentioned trait
False                                                 # should still be True!
```

Any value configured via attribute assignment, `update_config`, or a `[tool.unxts.unxt]` pyproject section is silently discarded for the duration of the context.

## Root cause

The `cfg` branch of `override` looped over **all** `self.trait_names()` and pushed an override for each, reading the value off a fresh `self.__class__(config=cfg)` instance. Traits absent from `cfg` resolve to the class default on that temp instance, so they all got overridden — clobbering the live global values.

## The fix

Only push overrides for the traits the `Config` actually specifies: the union of the config sections named after this class and its bases (traitlets applies config by MRO), intersected with the trait names. An empty or unrelated `Config` now leaves globally-set values untouched.

Applied identically to `QuantityReprConfig` / `QuantityStrConfig` (core) and the `_ParametricLocalConfig` mirror in `unxts.parametric`, which had the same code.

## Verification

New regressions: `test_override_with_config_preserves_unmentioned_traits` (core) and its parametric counterpart (both fail on `main`). Full runs: core config **54 passed**, `unxts.parametric` **103 src + 74 tests** pass.

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)