### PR TITLE
🐛 fix(interop): register 2-arg ustrip(AllowValue, astropy Quantity)

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -305,3 +305,27 @@ def ustrip(flag: type[AllowValue], u: Any, x: AstropyQuantity, /) -> Any:
 
     """
     return uapi.ustrip(u, x)
+
+
+@plum.dispatch
+def ustrip(flag: type[AllowValue], x: AstropyQuantity, /) -> Any:
+    """Strip the units from an astropy quantity, allowing bare values through.
+
+    The two-argument :class:`~unxt.quantity.AllowValue` form takes no target
+    unit, so it returns the value in the quantity's own unit. This dispatch
+    disambiguates ``ustrip(AllowValue, <astropy Quantity>)``, which otherwise
+    matched both ``ustrip(type[AllowValue], Any)`` and
+    ``ustrip(Any, AstropyQuantity)`` with neither dominating. It mirrors the
+    ``(type[AllowValue], AbstractQuantity)`` form for unxt quantities.
+
+    Examples
+    --------
+    >>> import astropy.units as apyu
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+    >>> q = apyu.Quantity(1000, "m")
+    >>> float(u.ustrip(AllowValue, q))
+    1000.0
+
+    """
+    return x.value

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -8,7 +8,7 @@ import pytest
 from plum import convert
 
 import unxt as u
-from unxt.quantity import AbstractQuantity
+from unxt.quantity import AbstractQuantity, AllowValue
 
 
 class TestUconvertValueWithAstropyUnits:
@@ -314,3 +314,23 @@ class TestMixedUnxtAstropyArithmetic:
             assert isinstance(got, u.quantity.Quantity)
             assert got.unit == u.unit("km")
             assert np.isclose(np.asarray(got.value), 2.0)
+
+
+class TestUstripAllowValueAstropy:
+    """``ustrip(AllowValue, <astropy Quantity>)`` -- the 2-arg AllowValue form."""
+
+    def test_two_arg_allowvalue_strips_astropy_quantity(self) -> None:
+        """Two-arg ``ustrip(AllowValue, aq)`` returns the value, not an error.
+
+        Regression: no 2-arg ``(type[AllowValue], AstropyQuantity)`` dispatch
+        existed, so the call was ambiguous between the generic
+        ``ustrip(type[AllowValue], Any)`` and ``ustrip(Any, AstropyQuantity)``.
+        """
+        aq = apyu.Quantity(2.0, "km")
+        got = u.ustrip(AllowValue, aq)
+        assert not isinstance(got, apyu.Quantity)
+        assert np.isclose(np.asarray(got), 2.0)
+
+    def test_two_arg_allowvalue_passes_through_bare_value(self) -> None:
+        """A bare (non-quantity) value still passes through unchanged."""
+        assert u.ustrip(AllowValue, 5.0) == 5.0


### PR DESCRIPTION
## The bug

```python
>>> import unxt as u, astropy.units as apyu
>>> from unxt.quantity import AllowValue
>>> u.ustrip(AllowValue, apyu.Quantity(2.0, "km"))
plum.resolver.AmbiguousLookupError: `ustrip(AllowValue, <Quantity 2. km>)` is ambiguous
```

The two-argument `AllowValue` form works for unxt quantities (`u.ustrip(AllowValue, u.Q(...))`) but raises for astropy ones.

## Root cause

Two methods match `ustrip(AllowValue, <astropy Quantity>)` and neither dominates:

- `ustrip(flag: type[AllowValue], x: Any)` — narrower in position 0
- `ustrip(u: Any, x: AstropyQuantity)` — narrower in position 1

unxt quantities avoid this via the more-specific `ustrip(type[AllowValue], AbstractQuantity)` method, but an astropy `Quantity` isn't an `AbstractQuantity`, so it falls into the ambiguity.

## The fix

Register the missing disambiguator next to the existing 3-arg astropy `AllowValue` method, mirroring the `(type[AllowValue], AbstractQuantity)` form. The 2-arg version takes no target unit, so it returns the value in the quantity's own unit (`x.value`).

## Verification

New `TestUstripAllowValueAstropy` (2-arg on an astropy quantity + bare-value pass-through; the first fails on `main`). Full astropy interop suite + interop doctests: **87 passed**. ruff clean.

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)