### PR TITLE
🐛 fix(quantity): make a 0-d Quantity non-iterable (np.iterable parity)

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -494,7 +494,10 @@ class AbstractQuantity(
         # runs on the first ``next()``), so ``np.iterable(0-d q)`` returned True
         # -- unlike numpy/jax/astropy -- breaking scalar plotting in matplotlib.
         # Validate eagerly and return the iterator.
-        if self.value.ndim == 0:
+        # ``np.ndim`` rather than ``self.value.ndim``: during a ``jax.tree`` map
+        # the value can transiently be a plain list (which has no ``.ndim``),
+        # and it also handles tracers, NumPy/JAX arrays and ``StaticValue``.
+        if np.ndim(self.value) == 0:
             msg = "iteration over a 0-d array"
             raise TypeError(msg)
         return (self[i] for i in range(len(self.value)))

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -489,7 +489,15 @@ class AbstractQuantity(
          Quantity(Array(3, dtype=int32), unit='m')]
 
         """
-        yield from (self[i] for i in range(len(self.value)))
+        # NB: this is deliberately *not* a generator function. A generator
+        # would make ``iter(q)`` succeed even for a 0-d quantity (the body only
+        # runs on the first ``next()``), so ``np.iterable(0-d q)`` returned True
+        # -- unlike numpy/jax/astropy -- breaking scalar plotting in matplotlib.
+        # Validate eagerly and return the iterator.
+        if self.value.ndim == 0:
+            msg = "iteration over a 0-d array"
+            raise TypeError(msg)
+        return (self[i] for i in range(len(self.value)))
 
     def argmax(self, *args: Any, **kwargs: Any) -> Array:
         """Return the indices of the maximum value.

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -1447,3 +1447,21 @@ def test_angle_products_degrade_to_quantity():
     assert type(prod) is u.Quantity
     assert prod.unit == u.unit("rad") ** 2
     assert math.isclose(float(prod.value), 6.0, rel_tol=1e-6)
+
+
+def test_zero_d_quantity_is_not_iterable():
+    """A 0-d Quantity is not iterable, matching numpy / jax / astropy.
+
+    Regression: ``__iter__`` was a generator, so ``iter(q)`` succeeded even for
+    a 0-d quantity and the ``TypeError`` only surfaced on the first ``next()``.
+    ``np.iterable`` therefore reported a scalar quantity as iterable, which
+    broke e.g. ``matplotlib``'s ``ax.scatter`` / ``ax.axhline`` on scalars.
+    """
+    scalar = u.Q(3.0, "m")
+    assert np.iterable(scalar) is False
+    with pytest.raises(TypeError):
+        iter(scalar)  # must fail eagerly, not on first next()
+
+    vec = u.Q([1.0, 2.0, 3.0], "m")
+    assert np.iterable(vec) is True
+    assert [float(x.value) for x in vec] == [1.0, 2.0, 3.0]


### PR DESCRIPTION
## The bug

A 0-d `Quantity` reports as iterable, unlike numpy / jax / astropy:

```python
>>> import numpy as np, unxt as u
>>> np.iterable(u.Q(3.0, "m"))     # 0-d
True                                # numpy/jax/astropy all say False
```

`AbstractQuantity.__iter__` was a **generator function**, so its body (which calls `len(self.value)`) only runs on the first `next()`. `iter(q)` therefore succeeds even for a 0-d quantity, and `np.iterable` — which just calls `iter(...)` and catches `TypeError` — reports True.

## Relationship to #725 (merged)

#725 added a 0-d guard inside `UnxtConverter.convert`, which fixes `imshow(extent=...)`. **This PR is still required and is not redundant** — verified on current `main` with #725 merged:

```
np.iterable(0-d Q)        : True     <- core bug persists
ax.set_xlim(Q, Q)         : TypeError
ax.axhline(Q)             : TypeError
```

matplotlib's `_is_natively_supported` iterates the argument **directly**, never going through `UnxtConverter.convert`, so #725's local guard can't reach it. This PR fixes the root cause instead.

With this branch applied, all three pass — **including #725's own `imshow` case**, which continues to work:

```
np.iterable(0-d Q)        : False    <- matches numpy
ax.set_xlim(Q, Q)         : OK
ax.axhline(Q)             : OK
imshow(extent=Quantities) : OK       <- #725 unaffected
```

The two changes are complementary: #725 hardens the converter, this fixes the underlying iterability contract for every consumer (not just matplotlib).

## The fix

Make `__iter__` a non-generator that validates eagerly: raise `TypeError` for a 0-d value *before* returning, otherwise return the element iterator. Uses `np.ndim(self.value)` rather than `.ndim` because during a `jax.tree` map the value can transiently be a plain list.

## Verification

New regression `test_zero_d_quantity_is_not_iterable`. Rebased onto `main` (post-#725); full CI scope **3498 passed** (the only failures are an untracked local scratch file and the pre-existing `test_version`). `StaticQuantity` and `ParametricQuantity` inherit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)