### PR TITLE
🐛 fix(unxts-matplotlib): resolve axis unit from unxt's .unit, not pint's .units

### DIFF
--- a/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
+++ b/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
@@ -56,6 +56,8 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
 
     def axisinfo(self, unit: Any, _: Axes) -> matplotlib.units.AxisInfo:
         """Return axis information for this particular unit."""
+        if unit is None:
+            return matplotlib.units.AxisInfo()
         fmt = self.axisinfo_kw.get("format", "latex_inline")
         return matplotlib.units.AxisInfo(label=unit.to_string(fmt))
 
@@ -66,7 +68,10 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
             return x.unit
         if isinstance(x, Iterable) and isinstance(x, Sized):
             x = zeroth(x)
-        return getattr(x, "units", None)
+        # unxt quantities expose ``.unit`` (``.units`` is pint's attribute), so
+        # this is the branch that resolves the unit for a list/tuple of
+        # quantities passed to a plotting call.
+        return getattr(x, "unit", None)
 
 
 def setup_matplotlib_support_for_unxt(*, enable: bool = True) -> None:

--- a/packages/unxts.interop.matplotlib/tests/test_converter.py
+++ b/packages/unxts.interop.matplotlib/tests/test_converter.py
@@ -25,7 +25,10 @@ def test_default_units_for_iterable_of_quantities():
 
     Regression: the iterable branch probed pint's ``.units`` attribute, but
     unxt quantities expose ``.unit`` -- so it returned ``None`` and matplotlib
-    could not resolve the axis unit (crashing e.g. ``ax.set_xlim(Q, Q)``).
+    could not resolve the axis unit when plotting a sequence of quantities.
+
+    (Scalar plotting, e.g. ``ax.set_xlim(Q, Q)``, additionally needs the
+    separate 0-d non-iterable fix; it is not what this test covers.)
     """
     converter = uimpl.UnxtConverter()
     # Bare quantity already worked.

--- a/packages/unxts.interop.matplotlib/tests/test_converter.py
+++ b/packages/unxts.interop.matplotlib/tests/test_converter.py
@@ -18,3 +18,27 @@ def test_converter_strips_units():
     q = u.Q([1.0, 2.0, 3.0], "km")
     converted = list(converter.convert(q, u.unit("m"), axis=None))
     assert converted == [1000.0, 2000.0, 3000.0]
+
+
+def test_default_units_for_iterable_of_quantities():
+    """`default_units` reports the unit for a list/tuple of quantities.
+
+    Regression: the iterable branch probed pint's ``.units`` attribute, but
+    unxt quantities expose ``.unit`` -- so it returned ``None`` and matplotlib
+    could not resolve the axis unit (crashing e.g. ``ax.set_xlim(Q, Q)``).
+    """
+    converter = uimpl.UnxtConverter()
+    # Bare quantity already worked.
+    assert converter.default_units(u.Q(1.0, "m"), None) == u.unit("m")
+    # A list / tuple of quantities must resolve the same unit.
+    assert converter.default_units([u.Q(1.0, "m"), u.Q(2.0, "m")], None) == u.unit("m")
+    assert converter.default_units((u.Q(1.0, "m"),), None) == u.unit("m")
+    # A plain (unitless) value still yields None.
+    assert converter.default_units(5.0, None) is None
+
+
+def test_axisinfo_tolerates_none_unit():
+    """`axisinfo(None, ...)` returns a bare AxisInfo rather than dereferencing it."""
+    converter = uimpl.UnxtConverter()
+    info = converter.axisinfo(None, None)
+    assert isinstance(info, matplotlib.units.AxisInfo)


### PR DESCRIPTION
## The bug

`UnxtConverter.default_units` returns the axis unit for a bare quantity, but returns `None` for a **list/tuple** of quantities:

```python
>>> from unxts.interop.matplotlib._src.converter import UnxtConverter
>>> c = UnxtConverter()
>>> c.default_units(u.Q(1.0, "m"), None)            # bare quantity
Unit("m")
>>> c.default_units([u.Q(1.0, "m"), u.Q(2.0, "m")], None)   # list
None                                                 # should be Unit("m")
```

matplotlib then can't resolve the axis unit for the data and the plotting call fails.

## Root cause

The fallback branch for iterables did `getattr(x, "units", None)` — `units` is **pint's** attribute name; unxt quantities expose `.unit`. The branch was dead code that always returned `None`.

## The fix

- Probe `.unit` (unxt's attribute) so a list/tuple of quantities resolves its unit.
- Harden `axisinfo` to return a bare `AxisInfo()` when `unit is None`, instead of dereferencing `None.to_string`.

## Verification

New regressions `test_default_units_for_iterable_of_quantities` and `test_axisinfo_tolerates_none_unit` (both fail on `main`). Full `unxts.interop.matplotlib` suite: **4 passed**. End-to-end, plotting a 1-d array quantity now resolves the axis unit and sets limits correctly.

### Note on scalar plotting

Scalar `ax.set_xlim(Q, Q)` / `ax.axhline(Q)` need **both** this fix *and* #738 (the 0-d `__iter__` fix): matplotlib iterates the argument in `_is_natively_supported`, which crashes on a 0-d quantity until #738 lands. I verified the two together make scalar `set_xlim`/`axhline` work end-to-end. This PR is scoped to the `default_units`/`axisinfo` converter bug (#26); #738 is the complementary core fix.

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)