### PR TITLE
🐛 fix(quantity): give lax.rem_p on quantities truncated-remainder semantics

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4261,8 +4261,9 @@ def rem_p_aa(x: AbstractAngle, y: ABCQ, /) -> AbstractAngle:
     Angle(Array([1, 2, 3], dtype=int32), unit='deg')
 
     """
-    # Don't promote - preserve the Angle type
-    return replace(x, value=ustrip(x) % ustrip(x.unit, y))
+    # Don't promote - preserve the Angle type. Use lax.rem (truncated
+    # remainder) to match lax.rem_p, unlike ``%`` which is floor-mod.
+    return replace(x, value=lax.rem(ustrip(x), ustrip(x.unit, y)))
 
 
 @quax.register(lax.rem_p)
@@ -4285,8 +4286,18 @@ def rem_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
 
     """
     x, y = promote(x, y)
-    # Use % to preserve numpy arrays for StaticQuantity
-    return replace(x, value=ustrip(x) % ustrip(x.unit, y))
+    xv = ustrip(x)
+    yv = ustrip(x.unit, y)
+    # ``lax.rem_p`` is C-style *truncated* remainder (result takes the
+    # dividend's sign); ``%`` is floor-mod (divisor's sign), which disagrees
+    # whenever the operands' signs differ. Use ``lax.rem`` to match the
+    # primitive, and ``np.fmod`` (also truncated) for a StaticQuantity so it
+    # stays static instead of materialising to a JAX array.
+    if isinstance(x.value, StaticValue):
+        value = np.fmod(np.asarray(xv), np.asarray(yv))
+    else:
+        value = lax.rem(xv, yv)
+    return replace(x, value=value)
 
 
 @quax.register(lax.rem_p)

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -16,6 +16,7 @@ from jax.dtypes import canonicalize_dtype
 from jaxtyping import TypeCheckError
 from plum import convert
 
+import quaxed.lax as qlax
 import quaxed.numpy as jnp
 
 import unxt as u
@@ -1370,3 +1371,26 @@ def test_remainder_bare_quantity_dimensionful_raises():
     q = u.Quantity(jnp.asarray([5.0, 7.0]), "m")
     with pytest.raises(UnitConversionError):
         _ = jnp.remainder(q, jnp.asarray(3.0))
+
+
+@pytest.mark.parametrize(("xv", "yv"), [(-10, 3), (-10, -3), (10, 3), (10, -3)])
+def test_rem_p_matches_lax_rem_truncated_semantics(xv, yv):
+    """`lax.rem_p` on a Quantity is truncated remainder, like raw `lax.rem`.
+
+    Regression: the rule used the ``%`` operator (numpy floor-mod, result takes
+    the divisor's sign), but ``lax.rem_p`` is C-style truncated remainder
+    (result takes the dividend's sign). The two disagree whenever the operands
+    have opposite signs.
+    """
+    got = float(u.ustrip("m", qlax.rem(u.Q(float(xv), "m"), u.Q(float(yv), "m"))))
+    expected = float(jax.lax.rem(jnp.asarray(float(xv)), jnp.asarray(float(yv))))
+    assert got == expected
+
+
+def test_rem_p_preserves_staticness_and_truncated_semantics():
+    """`rem` on a StaticQuantity stays static and uses truncated semantics."""
+    got = qlax.rem(
+        u.StaticQuantity(np.array(-10.0), "m"), u.StaticQuantity(np.array(3.0), "m")
+    )
+    assert isinstance(got, u.StaticQuantity)
+    assert float(np.asarray(got.value)) == -1.0  # truncated, not 2.0 (floor-mod)


### PR DESCRIPTION
## The bug

`qlax.rem` (i.e. `lax.rem_p`) on a `Quantity` gives a different answer than the identical bare-array call whenever the operands' signs differ:

```python
>>> import unxt as u, quaxed.lax as qlax, jax, jax.numpy as jnp
>>> float(u.ustrip("m", qlax.rem(u.Q(-10.0, "m"), u.Q(3.0, "m"))))
2.0                                     # floor-mod
>>> float(jax.lax.rem(jnp.asarray(-10.0), jnp.asarray(3.0)))
-1.0                                    # truncated (what lax.rem_p means)
```

Over the four sign combinations, `(-10, 3)` and `(10, -3)` disagreed.

## Root cause

`rem_p_qq` and `rem_p_aa` implemented `lax.rem_p` with the `%` operator. On both JAX and NumPy arrays `%` is **floor-mod** (result takes the divisor's sign), but `lax.rem_p` is C-style **truncated** remainder (result takes the dividend's sign). The rule gave the primitive the wrong semantics.

## The fix

Use `lax.rem` (truncated) to match the primitive. For a `StaticQuantity`, use `np.fmod` (also truncated) so the result stays static rather than materialising to a JAX array — the reason `%` was originally chosen.

The `%` **operator** is unchanged: it routes through `jnp.remainder` and stays floor-mod, exactly as for raw JAX arrays. So unxt now mirrors JAX's own `lax.rem` (truncated) vs `%` (floor-mod) distinction, for `Quantity`, `Angle` and `StaticQuantity` alike.

## Verification

New regressions: `test_rem_p_matches_lax_rem_truncated_semantics` (parametrized over all four sign combos, compared against `jax.lax.rem`) and `test_rem_p_preserves_staticness_and_truncated_semantics` (both fail on `main`). Full run: **1437 passed** (`test_quantity.py` + `register_primitives` doctests + `tests/integration/quaxed/test_lax.py`); `unxts.parametric` 73 pass.

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)