### PR TITLE
🐛 fix: return multiple outputs from top_k/approx_top_k dispatches (JAX 0.11.0)

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -428,7 +428,7 @@ def and_p_vq(x1: ArrayLike, x2: ABCQ, /) -> ABCQ:
 
 
 @quax.register(lax.approx_top_k_p)
-def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
+def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> tuple[ABCQ, Array]:
     """Approximate top-k of a quantity.
 
     Examples
@@ -439,10 +439,16 @@ def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> ABCQ:
     >>> x = u.quantity.Quantity([1.0, 2, 3], "m")
     >>> qlax.approx_max_k(x, k=2)
     [Quantity(Array([3., 2.], dtype=float32), unit='m'),
-     Quantity(Array([2., 1.], dtype=float32), unit='m')]
+     Array([2, 1], dtype=int32)]
 
     """
-    return replace(x, value=lax.approx_top_k_p.bind(ustrip(x), **kwargs))  # type: ignore[no-untyped-call]
+    # `approx_top_k_p` is a multiple-results primitive returning (values,
+    # indices). quax requires the dispatch to return a sequence of outputs (one
+    # per result). The values keep the operand's unit; the indices are
+    # positional integers, so they pass through as a raw array -- matching
+    # `argmax`/`argmin`/`argsort`.
+    values, indices = lax.approx_top_k_p.bind(ustrip(x), **kwargs)  # type: ignore[no-untyped-call]
+    return replace(x, value=values), indices
 
 
 # ==============================================================================
@@ -5140,7 +5146,7 @@ def tanh_p(x: ABCQ, /, **kw: Any) -> ABCQ:
 
 
 @quax.register(lax.top_k_p)
-def top_k_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
+def top_k_p(operand: ABCQ, /, **kw: Any) -> tuple[ABCQ, Array]:
     """Top k elements of a quantity.
 
     Examples
@@ -5151,15 +5157,21 @@ def top_k_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
     >>> q = u.quantity.Quantity([1, 2, 3], "m")
     >>> qlax.top_k(q, k=2)
     [Quantity(Array([3, 2], dtype=int32), unit='m'),
-     Quantity(Array([2, 1], dtype=int32), unit='m')]
+     Array([2, 1], dtype=int32)]
 
     >>> q = u.Q([1, 2, 3], "m")
     >>> qlax.top_k(q, k=2)
     [Quantity(Array([3, 2], dtype=int32), unit='m'),
-     Quantity(Array([2, 1], dtype=int32), unit='m')]
+     Array([2, 1], dtype=int32)]
 
     """
-    return replace(operand, value=lax.top_k_p.bind(ustrip(operand), **kw))  # type: ignore[no-untyped-call]
+    # `top_k_p` is a multiple-results primitive returning (values, indices).
+    # quax requires the dispatch to return a sequence of outputs (one per
+    # result). The values keep the operand's unit; the indices are positional
+    # integers, so they pass through as a raw array -- matching
+    # `argmax`/`argmin`/`argsort`.
+    values, indices = lax.top_k_p.bind(ustrip(operand), **kw)  # type: ignore[no-untyped-call]
+    return replace(operand, value=values), indices
 
 
 # ==============================================================================

--- a/tests/integration/quaxed/test_lax.py
+++ b/tests/integration/quaxed/test_lax.py
@@ -59,7 +59,7 @@ xround = u.Q(xround_val, unit="m")
             "approx_max_k",
             (x_L,),
             {"k": 2},
-            [u.Q([[2.0, 1], [4, 3]], unit="m"), u.Q([[1.0, 0], [1, 0]], unit="m")],
+            [u.Q([[2.0, 1], [4, 3]], unit="m"), jnp.array([[1, 0], [1, 0]])],
         ),
         (
             "approx_min_k",
@@ -67,7 +67,7 @@ xround = u.Q(xround_val, unit="m")
             {"k": 2},
             [
                 u.Q([[1.0, 2.0], [3.0, 4.0]], unit="m"),
-                u.Q([[0.0, 1.0], [0.0, 1.0]], unit="m"),
+                jnp.array([[0, 1], [0, 1]]),
             ],
         ),
         ("argmax", (x_L,), {"axis": 0, "index_dtype": int}, jnp.array([1, 1])),
@@ -340,7 +340,7 @@ xround = u.Q(xround_val, unit="m")
         ("sub", (x_L, y_L), {}, u.Q(lax.sub(x_val, y_val), "m")),
         ("tan", (x_ND,), {}, u.Q(lax.tan(x_val), "")),
         ("tanh", (x_ND,), {}, u.Q(lax.tanh(x_val), "")),
-        ("top_k", (x_L, 1), {}, [u.Q([[2.0], [4.0]], "m"), u.Q([[1.0], [1.0]], "m")]),
+        ("top_k", (x_L, 1), {}, [u.Q([[2.0], [4.0]], "m"), jnp.array([[1], [1]])]),
         (
             "transpose",
             (x_L, (1, 0)),


### PR DESCRIPTION
## Problem

The **Newest supported deps** CI job started failing once **JAX 0.11.0** was released ([run 29627929341](https://github.com/GalacticDynamics/unxt/actions/runs/29627929341/job/88035998308)). Six tests fail with:

```
AttributeError: 'NoneType' object has no attribute 'process_primitive'
```

- doctests: `register_primitives.py` (`approx_max_k`, `top_k` ×2)
- integration: `test_lax_functions[approx_max_k…]`, `[approx_min_k…]`, `[top_k…]`

## Root cause

`top_k` (`top_k_p`) and `approx_max_k`/`approx_min_k` (`approx_top_k_p`) are **multiple-results** primitives — each returns `(values, indices)`. The dispatches returned a single `Quantity` wrapping the whole `[values, indices]` list:

```python
return replace(operand, value=lax.top_k_p.bind(ustrip(operand), **kw))
```

quax knows these primitives are `multiple_results`, so it iterates the rule's return value (one element per result: `[_QuaxTracer(self, _wrap_if_array(x)) for x in out]`). Iterating a single `Quantity` triggers `Quantity.__iter__` → element slicing outside an active JAX trace → the crash. JAX 0.10.1 happened not to crash (it silently produced two `Quantity`s); 0.11.0 exposed the latent bug.

## Fix

Unpack the two results and return a proper 2-tuple. Values keep the operand's unit; **indices pass through as a raw array**, matching the established convention for index-returning primitives (`argmax_p`/`argmin_p` → `-> Array`; `sort_p` passes the `argsort` `iota` payload through unwrapped).

## Verification

- The 6 originally-failing tests pass under JAX 0.11.0.
- `register_primitives.py` doctests + full `test_lax.py`: **1347 passed** on both JAX 0.11.0 and 0.10.1.
- `ruff check` / pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)