### PR TITLE
🐛 fix(unxts-linalg): add (Quantity, QuantityMatrix) dot_general rule

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -761,7 +761,8 @@ def dot_general_qty_qm(
     a uniform-unit :class:`QuantityMatrix` and delegated to
     :func:`dot_general_qm_qm`. Without this rule a plain Quantity on the left
     fell through to unxt's generic ``AbstractQuantity`` dot_general, which built
-    a `~unxt.Quantity` whose ``.unit`` was a `UnitsMatrix` -- a malformed object.
+    a :class:`~unxt.Quantity` whose ``.unit`` was a
+    :class:`~unxts.linalg.UnitsMatrix` -- a malformed object.
 
     (:class:`QuantityMatrix` is itself an :class:`~unxt.AbstractQuantity`
     subtype, so :func:`dot_general_qm_qm` still takes precedence when both sides

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -744,6 +744,62 @@ def dot_general_qm_qty(
 
 
 @quax.register(lax.dot_general_p)
+def dot_general_qty_qm(
+    lhs: u.AbstractQuantity,
+    rhs: QuantityMatrix,
+    /,
+    *,
+    dimension_numbers: lax.DotDimensionNumbers,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    **kw: Any,
+) -> "QuantityMatrix | u.Q":
+    """Dot product of a :class:`~unxt.AbstractQuantity` with a :class:`QuantityMatrix`.
+
+    The mirror of :func:`dot_general_qm_qty`. The ``lhs`` Quantity carries a
+    single scalar unit that applies uniformly to all elements; it is wrapped as
+    a uniform-unit :class:`QuantityMatrix` and delegated to
+    :func:`dot_general_qm_qm`. Without this rule a plain Quantity on the left
+    fell through to unxt's generic ``AbstractQuantity`` dot_general, which built
+    a `~unxt.Quantity` whose ``.unit`` was a `UnitsMatrix` -- a malformed object.
+
+    (:class:`QuantityMatrix` is itself an :class:`~unxt.AbstractQuantity`
+    subtype, so :func:`dot_general_qm_qm` still takes precedence when both sides
+    are :class:`QuantityMatrix`.)
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import quaxed.numpy as qnp
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+
+    Uniform-unit Quantity vector @ 2D metric with units:
+
+    >>> v = u.Q(jnp.array([1.0, 1.0]), "rad")
+    >>> g = QuantityMatrix(
+    ...     jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+    ...     unit=UnitsMatrix((("m2 / rad2", "m2 / rad2"), ("m2 / rad2", "m2 / rad2"))),
+    ... )
+    >>> w = qnp.matmul(v, g)
+    >>> isinstance(w, QuantityMatrix)
+    True
+    >>> w.value
+    Array([2., 3.], dtype=float32)
+
+    """
+    lhs_unit = u.unit_of(lhs)
+    lhs_val = cast("jax.Array", u.ustrip(AllowValue, lhs_unit, lhs))
+    lhs_qm = _wrap_operand(lhs_val, lhs_unit, dimension_numbers[1][0])
+    return dot_general_qm_qm(
+        lhs_qm,
+        rhs,
+        dimension_numbers=dimension_numbers,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+        **kw,
+    )
+
+
+@quax.register(lax.dot_general_p)
 def dot_general_arr_qm(
     lhs: jax.Array,
     rhs: QuantityMatrix,

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -926,13 +926,18 @@ class TestDotProduct:
         got = _matmul(q_mat, vec)
         assert isinstance(got, QMat)
         assert isinstance(got.unit, UnitsMatrix)
-        assert got.unit[0] == _kg * _m
+        # Every element's unit, not just the first, so a partial/batched
+        # unit-propagation bug can't slip through.
+        assert tuple(got.unit) == (_kg * _m, _kg * _m)
+        assert jnp.allclose(got.value, jnp.array([2.0, 3.0]))
 
         # Consistent with the already-working reverse order.
         mat = QMat(jnp.eye(2), unit=((_kg, _kg), (_kg, _kg)))
         rev = _matmul(mat, u.Q(jnp.array([2.0, 3.0]), "s"))
         assert isinstance(rev, QMat)
         assert isinstance(rev.unit, UnitsMatrix)
+        assert tuple(rev.unit) == (_kg * _s, _kg * _s)
+        assert jnp.allclose(rev.value, jnp.array([2.0, 3.0]))
 
     def test_batched_matmul_2x2(self):
         """Leading batch axis: (B, 2, 2) @ (B, 2, 2) contracts per batch element.

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -909,6 +909,31 @@ class TestDotProduct:
         assert jnp.isclose(result.value[0, 0], 21)
         assert result.unit == ((_m * _s,),)
 
+    def test_matmul_quantity_left_quantitymatrix_right(self):
+        """`Quantity @ QuantityMatrix` yields a well-formed QuantityMatrix.
+
+        Regression: with a plain Quantity on the left there was no
+        ``(Quantity, QuantityMatrix)`` dot_general rule, so unxt's generic
+        ``AbstractQuantity`` rule won and built a `Quantity` whose ``.unit`` was
+        a `UnitsMatrix` -- a malformed object. Both operand orders must give a
+        `QuantityMatrix` with a `UnitsMatrix` unit.
+        """
+        # Uniform units along the contraction so the dot product is
+        # dimensionally valid; the bug was about the result *type*.
+        q_mat = u.Q(jnp.eye(2), "kg")  # plain Quantity, single unit
+        vec = QMat(jnp.array([2.0, 3.0]), unit=(_m, _m))
+
+        got = _matmul(q_mat, vec)
+        assert isinstance(got, QMat)
+        assert isinstance(got.unit, UnitsMatrix)
+        assert got.unit[0] == _kg * _m
+
+        # Consistent with the already-working reverse order.
+        mat = QMat(jnp.eye(2), unit=((_kg, _kg), (_kg, _kg)))
+        rev = _matmul(mat, u.Q(jnp.array([2.0, 3.0]), "s"))
+        assert isinstance(rev, QMat)
+        assert isinstance(rev.unit, UnitsMatrix)
+
     def test_batched_matmul_2x2(self):
         """Leading batch axis: (B, 2, 2) @ (B, 2, 2) contracts per batch element.
 


### PR DESCRIPTION
## The bug

`Quantity @ QuantityMatrix` returns a malformed `Quantity` whose `.unit` is a `UnitsMatrix`:

```python
>>> import jax.numpy as jnp, quaxed.numpy as qnp, unxt as u
>>> from unxts.linalg import QuantityMatrix
>>> A = u.Q(jnp.eye(2), "kg")
>>> v = QuantityMatrix(jnp.array([2., 3.]), unit=("m", "m"))
>>> r = qnp.matmul(A, v)
>>> type(r).__name__, type(r.unit).__name__
('Quantity', 'UnitsMatrix')       # a Quantity should never wrap a UnitsMatrix
```

## Root cause

`dot_general_p` was registered for `(QuantityMatrix, Quantity)`, `(QuantityMatrix, Array)` and `(Array, QuantityMatrix)` — but **not** `(Quantity, QuantityMatrix)`. With a plain `Quantity` on the left, unxt's generic `AbstractQuantity` dot_general rule won (a `QuantityMatrix` *is* an `AbstractQuantity`) and built the **left** operand's type, slapping the `QuantityMatrix`'s `UnitsMatrix` on as the unit of a plain `Quantity`.

## The fix

Add `dot_general_qty_qm`, the exact mirror of the existing `dot_general_qm_qty`: wrap the uniform-unit `Quantity` as a `QuantityMatrix` via `_wrap_operand` and delegate to `dot_general_qm_qm`. Because the new rule's `rhs` is the more specific `QuantityMatrix`, it wins over the generic `AbstractQuantity` rule; and `QuantityMatrix @ QuantityMatrix` still resolves to the even-more-specific `dot_general_qm_qm`.

## Verification

New regression `test_matmul_quantity_left_quantitymatrix_right` asserts a well-formed `QuantityMatrix`/`UnitsMatrix` result for both operand orders (fails on `main`). Run separately per CI: `unxts.linalg` **254 tests + 317 src doctests** pass. ruff clean.

(Note: the finding's original example used incompatible per-element units — `kg` matrix contracted against a `(m, s)` vector — which now correctly raises a `UnitsError` from the `qm_qm` path rather than silently producing a malformed object; the test uses uniform units so the contraction is dimensionally valid.)

Found in the v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)