### PR TITLE
♻️ refactor(unitsystems): single dimension→field mapping

### DIFF
--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -108,12 +108,16 @@ class AbstractUnitSystem:
     _dimension_to_field: ClassVar[Mapping[AbstractDimension, str]]
 
     @_classproperty
-    def _base_dimensions(cls) -> tuple["AbstractDimension", ...]:  # noqa: N805
+    def _base_dimensions(  # pylint: disable=no-self-argument
+        cls,  # noqa: N805
+    ) -> tuple["AbstractDimension", ...]:
         """Return the base dimensions, in declaration order."""
         return tuple(cls._dimension_to_field)
 
     @_classproperty
-    def _base_field_names(cls) -> tuple[str, ...]:  # noqa: N805
+    def _base_field_names(  # pylint: disable=no-self-argument
+        cls,  # noqa: N805
+    ) -> tuple[str, ...]:
         """Return the declared field names, in declaration order."""
         return tuple(cls._dimension_to_field.values())
 

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -5,7 +5,7 @@ __all__ = ("UNITSYSTEMS_REGISTRY", "AbstractUnitSystem")
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import ClassVar, get_args, get_type_hints
+from typing import Any, ClassVar, get_args, get_type_hints
 
 import jax.tree_util as jtu
 from astropy.units import PhysicalType, UnitBase as AstropyUnitBase
@@ -18,6 +18,23 @@ from unxt.dims import AbstractDimension, dimension
 from unxt.units import AbstractUnit, unit
 
 Unit = AstropyUnitBase
+
+
+class _classproperty:  # noqa: N801
+    """Read-only property that also works on the *class*.
+
+    ``AbstractUnitSystem`` subclasses expose ``_base_dimensions`` /
+    ``_base_field_names`` on the class (e.g. the unit-system registry keys off
+    ``cls._base_dimensions``), which a plain ``property`` cannot serve.
+    """
+
+    def __init__(self, fget: Any) -> None:
+        self.fget = fget
+        self.__doc__ = fget.__doc__
+
+    def __get__(self, obj: Any, owner: type | None = None) -> Any:
+        return self.fget(owner if owner is not None else type(obj))
+
 
 _UNITSYSTEMS_REGISTRY: dict[
     tuple[AbstractDimension, ...], type["AbstractUnitSystem"]
@@ -84,12 +101,21 @@ class AbstractUnitSystem:
     # ===============================================================
     # Class-level
 
-    _base_field_names: ClassVar[tuple[str, ...]]
-    _base_dimensions: ClassVar[tuple[AbstractDimension, ...]]
-    #: Base dimension -> declared field name. Built once at class creation so
-    #: ``__getitem__`` is an O(1) lookup with no scan and no exception on the
-    #: derived-dimension (miss) path.
+    #: The single source of truth: base dimension -> declared field name, in
+    #: declaration order. Built once at class creation, so ``__getitem__`` is an
+    #: O(1) lookup with no scan and no exception on the derived-dimension path.
+    #: ``_base_dimensions`` / ``_base_field_names`` are its keys / values.
     _dimension_to_field: ClassVar[Mapping[AbstractDimension, str]]
+
+    @_classproperty
+    def _base_dimensions(cls) -> tuple["AbstractDimension", ...]:  # noqa: N805
+        """Return the base dimensions, in declaration order."""
+        return tuple(cls._dimension_to_field)
+
+    @_classproperty
+    def _base_field_names(cls) -> tuple[str, ...]:  # noqa: N805
+        """Return the declared field names, in declaration order."""
+        return tuple(cls._dimension_to_field.values())
 
     def __init_subclass__(cls) -> None:
         # In Python 3.14+, annotations are stored via __annotate_func__ (PEP
@@ -118,9 +144,8 @@ class AbstractUnitSystem:
             msg = f"Unit system with dimensions {dims} already exists."
             raise ValueError(msg)
 
-        # Add attributes to the class
-        cls._base_field_names = tuple(field_names)
-        cls._base_dimensions = dims
+        # Store the single dimension -> field-name mapping; the
+        # ``_base_dimensions`` / ``_base_field_names`` tuples derive from it.
         cls._dimension_to_field = MappingProxyType(
             dict(zip(dims, field_names, strict=True))
         )


### PR DESCRIPTION
Follow-up to #728, per review discussion there.

## What

`_base_dimensions` and `_base_field_names` were stored `ClassVar` tuples sitting alongside `_dimension_to_field`, which already holds exactly the same pairing. This keeps **only the mapping** and derives the two tuples from its keys / values.

Both must stay readable on the **class** — the registry keys off `cls._base_dimensions`, and tests read `Cls._base_field_names` — which a plain `@property` cannot serve (it returns the descriptor). So a small `_classproperty` descriptor is added.

I did it symmetrically: removing only `_base_field_names` (the original suggestion) would have left the equally-derivable `_base_dimensions` stored, which reads arbitrary.

## On the performance question I raised

I initially pushed back on this, arguing it would regress a hot path. **I was wrong, and measurement refuted me** — worth recording:

| | per call |
|---|---|
| `_base_field_names` attribute access | 0.045 µs |
| `usys[derived dim]` (the caller) | 292 µs |

The attribute is ~0.015% of the call that uses it. Recomputing it is ~5.6× slower *in isolation*, which moves the real operation by ~0.07% — invisible. My objection was a microbenchmark artifact.

## Verification

Confirmed the interactions that actually put this at risk, since the class is a `@dataclass(frozen=True, slots=True)` that's also `jtu.register_static`:

- class-level **and** instance-level access of both attributes
- `base_units`, `__str__`, `__getitem__` (base and derived paths)
- pickle round-trip, hashability (JAX static-arg use), registry lookup via `cls._base_dimensions`

Full CI scope: **3497 passed** (the only failures are an untracked local scratch file and the pre-existing `test_version`, both unrelated). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)