### PR TITLE
⚡️ perf(interop): identity fast path in uconvert

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/quantity.py
+++ b/src/unxt/_interop/unxt_interop_astropy/quantity.py
@@ -248,8 +248,15 @@ def uconvert(u: APYUnits, x: AbstractQuantity, /) -> AbstractQuantity:
     # NB: astropy treats physically-equal units as ``==`` (e.g. ``J == m2 kg /
     # s2``), so ``x.unit == u`` alone would silently return ``x`` without
     # relabeling to the requested (equal but differently-named) unit. Require
-    # the string forms to match too so the relabel still happens; the cheap
-    # ``==`` check short-circuits the common (unequal) case before formatting.
+    # the string forms to match too so the relabel still happens.
+    #
+    # Check identity first: astropy interns named units, so the common
+    # "convert to the unit it already has" case hits ``is`` and skips two
+    # ``to_string()`` calls (~116x the cost of the identity test). Identity
+    # implies identical string forms, so this cannot skip a needed relabel --
+    # the ``J`` vs ``m2 kg / s2`` case is ``==`` but *not* ``is``.
+    if x.unit is u:
+        return x
     if x.unit == u and x.unit.to_string() == u.to_string():
         return x
 

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -249,8 +249,19 @@ def test_uconvert_identity_fastpath_still_relabels() -> None:
     j, comp = u.unit("J"), u.unit("m2 kg / s2")
     assert j == comp
     assert j is not comp
-    assert u.uconvert(comp, u.Q(1.0, "J")).unit == comp
-    assert u.uconvert(j, u.Q(1.0, "m2 kg / s2")).unit == j
+
+    # NB: assert on the *label*, not ``==``. astropy considers ``J == m2 kg/s2``,
+    # so an ``== comp`` assertion would pass even if uconvert wrongly
+    # short-circuited and handed back the original ``J``-labelled quantity --
+    # i.e. it could not fail for the bug it guards. ``to_string()`` distinguishes
+    # them ("J" vs "m2 kg / s2").
+    got = u.uconvert(comp, u.Q(1.0, "J"))
+    assert got.unit.to_string() == comp.to_string()
+    assert got.unit.to_string() != j.to_string()
+
+    back = u.uconvert(j, u.Q(1.0, "m2 kg / s2"))
+    assert back.unit.to_string() == j.to_string()
+    assert back.unit.to_string() != comp.to_string()
 
     # is: returns the same object untouched.
     q = u.Q(2.0, "m")

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -237,6 +237,29 @@ def test_scalar_weak_type_preserved():
     assert not arr.value.weak_type
 
 
+def test_uconvert_identity_fastpath_still_relabels() -> None:
+    """The identity fast path must not skip an equal-but-differently-named unit.
+
+    ``uconvert`` short-circuits on ``x.unit is u`` (astropy interns named units,
+    so "convert to the unit it already has" is the common case). Identity implies
+    identical string forms, so the relabel for units that are ``==`` but not
+    ``is`` -- e.g. ``J`` vs ``m2 kg / s2`` -- must still happen.
+    """
+    # == but NOT is: must relabel, not short-circuit.
+    j, comp = u.unit("J"), u.unit("m2 kg / s2")
+    assert j == comp
+    assert j is not comp
+    assert u.uconvert(comp, u.Q(1.0, "J")).unit == comp
+    assert u.uconvert(j, u.Q(1.0, "m2 kg / s2")).unit == j
+
+    # is: returns the same object untouched.
+    q = u.Q(2.0, "m")
+    assert u.uconvert(u.unit("m"), q) is q
+
+    # a genuine conversion is unaffected.
+    assert jnp.isclose(u.uconvert(u.unit("km"), u.Q(1000.0, "m")).value, 1.0)
+
+
 def test_uconvert_value_preserves_dtype():
     """Test that uconvert_value preserves input dtype."""
     # Float32 input


### PR DESCRIPTION
Found while reviewing v2 for performance wins.

## The problem

`uconvert`'s no-op guard is:

```python
if x.unit == u and x.unit.to_string() == u.to_string():
    return x
```

The `to_string()` pair exists for a good reason — astropy treats `J == m2 kg / s2`, so `==` alone would silently skip a needed *relabel*. But it means the **same-unit case — precisely what the fast path is for — pays two `to_string()` calls.**

Profiling a same-unit workload showed exactly **2 `to_string()` per `uconvert`** (16 000 calls for 8 000 conversions), ~12% of the sampled time.

## The fix

Check identity first:

```python
if x.unit is u:
    return x
```

astropy **interns named units** (`unit("m") is unit("m")` → `True`), so "convert to the unit it already has" hits identity and skips both format calls.

**This is safe, not a heuristic:** identity implies identical string forms, so it can never skip a needed relabel. The awkward case is exactly the one that still takes the slow path — `J` and `m2 kg / s2` are `==` but **not** `is`.

| | cost |
|---|---|
| `unit is unit` | 31 ns |
| `to_string()` ×2 | 3 646 ns (**116×**) |

## Measured

| | before | after |
|---|---|---|
| same-unit `uconvert` | 9.96 µs | **5.20 µs** (1.9×) |
| cross-unit `uconvert` | 345.8 µs | 341.8 µs (unchanged) |

## Verification

New regression `test_uconvert_identity_fastpath_still_relabels` pins the property that matters — `J` ↔ `m2 kg / s2` still relabels in both directions, `is` returns the same object, and a genuine conversion is unaffected. Full CI scope: **3498 passed**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)