### PR TITLE
🐛 fix(interop): drop consumed xarray units attr

### DIFF
--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -297,12 +297,16 @@ def attach_units(
     new_coords = {}
     for name, coord in obj.coords.items():
         unit = units.get(name)
-        new_coords[name] = (
-            coord
-            if unit is None
-            else Variable(
-                coord.dims, _array_attach_units(coord.data, unit), dict(coord.attrs)
-            )
+        # Always build a fresh Variable with a copied attrs dict, even when no
+        # unit is attached. ``_consume_unit_attrs`` mutates the result's attrs
+        # in place, so reusing ``coord`` would be safe only for as long as the
+        # DataArray/Dataset constructor keeps copying coordinate attrs -- an
+        # xarray implementation detail, not a guarantee. Copying here makes
+        # non-mutation of the caller's object structural instead.
+        new_coords[name] = Variable(
+            coord.dims,
+            coord.data if unit is None else _array_attach_units(coord.data, unit),
+            dict(coord.attrs),
         )
 
     result = DataArray(
@@ -345,12 +349,16 @@ def attach_units(
     new_coords = {}
     for name, coord in obj.coords.items():
         unit = units.get(name)
-        new_coords[name] = (
-            coord
-            if unit is None
-            else Variable(
-                coord.dims, _array_attach_units(coord.data, unit), dict(coord.attrs)
-            )
+        # Always build a fresh Variable with a copied attrs dict, even when no
+        # unit is attached. ``_consume_unit_attrs`` mutates the result's attrs
+        # in place, so reusing ``coord`` would be safe only for as long as the
+        # DataArray/Dataset constructor keeps copying coordinate attrs -- an
+        # xarray implementation detail, not a guarantee. Copying here makes
+        # non-mutation of the caller's object structural instead.
+        new_coords[name] = Variable(
+            coord.dims,
+            coord.data if unit is None else _array_attach_units(coord.data, unit),
+            dict(coord.attrs),
         )
 
     result = Dataset(data_vars=new_vars, coords=new_coords, attrs=dict(obj.attrs))

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -54,8 +54,50 @@ def _array_attach_units(
     >>> _array_attach_units(data, None) is data
     True
 
+    Data that is already a Quantity cannot be re-quantified: attaching a unit
+    to it raises `ValueError` naming the unit the data already carries, rather
+    than the opaque "Cannot convert 'Quantity' to a value" `TypeError` that
+    `unxt.Quantity` would otherwise raise.
+
     """
-    return data if unit is None else u.Q(data, u.unit(unit))
+    if unit is None:
+        return data
+
+    if (existing := u.unit_of(data)) is not None:
+        msg = (
+            f"cannot attach unit '{unit}': the data is already a Quantity with "
+            f"unit '{existing}'. Convert it with `unxt.uconvert` instead of "
+            "re-quantifying."
+        )
+        raise ValueError(msg)
+
+    return u.Q(data, u.unit(unit))
+
+
+def _consume_unit_attrs(obj: DataArray | Dataset, /) -> None:
+    """Drop the unit attribute wherever the data itself now carries the unit.
+
+    Once a unit lives on the data as a `Quantity`, the ``units`` attribute is
+    a stale duplicate: a later conversion would leave it contradicting the data
+    (so plot labels and CF serialization report the pre-conversion unit), and it
+    would make a second ``quantify()`` try to re-quantify a `Quantity`.
+
+    The attribute is dropped only where the unit demonstrably survived onto the
+    data. xarray coerces *dimension* coordinates back to plain index arrays,
+    discarding the Quantity; there the attribute remains the only record of the
+    unit and must be kept. Mutates ``obj`` in place -- callers pass an object
+    they have just constructed.
+    """
+    variables = (
+        obj.data_vars.values() if isinstance(obj, Dataset) else [obj]  # type: ignore[list-item]
+    )
+    for var in variables:
+        if u.unit_of(var.data) is not None:
+            var.attrs.pop(UNIT_ATTR, None)
+
+    for coord in obj.coords.values():
+        if u.unit_of(coord.data) is not None:
+            coord.attrs.pop(UNIT_ATTR, None)
 
 
 @dispatch
@@ -240,6 +282,12 @@ def attach_units(
     >>> quantified.data
     Quantity(Array([1., 2.], dtype=float32), unit='m')
 
+    The consumed ``units`` attribute does not survive onto the result:
+
+    >>> da = xr.DataArray([1.0, 2.0], dims=["x"], attrs={"units": "m"})
+    >>> attach_units(da, {None: "m"}).attrs
+    {}
+
     """
     # Handle the data array itself (None key = the DataArray's own data)
     data_unit = units.get(None)
@@ -257,13 +305,15 @@ def attach_units(
             )
         )
 
-    return DataArray(
+    result = DataArray(
         data=new_data,
         coords=new_coords,
         dims=obj.dims,
         name=obj.name,
         attrs=dict(obj.attrs),
     )
+    _consume_unit_attrs(result)
+    return result
 
 
 @dispatch
@@ -303,7 +353,9 @@ def attach_units(
             )
         )
 
-    return Dataset(data_vars=new_vars, coords=new_coords, attrs=dict(obj.attrs))
+    result = Dataset(data_vars=new_vars, coords=new_coords, attrs=dict(obj.attrs))
+    _consume_unit_attrs(result)
+    return result
 
 
 @dispatch

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -88,16 +88,23 @@ def _consume_unit_attrs(obj: DataArray | Dataset, /) -> None:
     unit and must be kept. Mutates ``obj`` in place -- callers pass an object
     they have just constructed.
     """
-    variables = (
-        obj.data_vars.values() if isinstance(obj, Dataset) else [obj]  # type: ignore[list-item]
-    )
-    for var in variables:
-        if u.unit_of(var.data) is not None:
-            var.attrs.pop(UNIT_ATTR, None)
+
+    def drop_if_carried(node: Any, /) -> None:
+        """Drop the attr from one variable/coordinate if its data carries a unit."""
+        if u.unit_of(node.data) is not None:
+            node.attrs.pop(UNIT_ATTR, None)
+
+    # A Dataset holds many data variables; a DataArray *is* the single one.
+    # Branching explicitly (rather than unifying into one list) keeps the two
+    # element types apart, so this needs no ``type: ignore``.
+    if isinstance(obj, Dataset):
+        for var in obj.data_vars.values():
+            drop_if_carried(var)
+    else:
+        drop_if_carried(obj)
 
     for coord in obj.coords.values():
-        if u.unit_of(coord.data) is not None:
-            coord.attrs.pop(UNIT_ATTR, None)
+        drop_if_carried(coord)
 
 
 @dispatch

--- a/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
+++ b/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
@@ -1,0 +1,158 @@
+"""Regression tests: ``quantify`` must consume the ``units`` attribute.
+
+Before the fix, ``attach_units`` copied ``obj.attrs`` verbatim into the result,
+so the ``units`` attribute it had just consumed survived onto the quantified
+object. Two symptoms followed:
+
+- silent: after a unit conversion the stale attribute contradicted the data,
+  so anything trusting ``.attrs["units"]`` (plot labels, CF serialization)
+  reported the pre-conversion unit;
+- loud: calling ``quantify()`` twice raised an opaque ``TypeError`` because the
+  stale attribute made the second call try to re-quantify a `Quantity`.
+"""
+
+import pytest
+import unxts.interop.xarray  # noqa: F401  # registers the .unxt accessor
+import xarray as xr
+from unxts.interop.xarray._src.conversion import UNIT_ATTR
+
+import unxt as u
+
+
+def test_dataarray_quantify_consumes_units_attr():
+    """`quantify` removes the attribute it consumed from the DataArray."""
+    da = xr.DataArray([1000.0, 2000.0], dims=["x"], attrs={UNIT_ATTR: "m"})
+
+    q = da.unxt.quantify()
+
+    assert u.unit_of(q.data) == u.unit("m")
+    assert UNIT_ATTR not in q.attrs
+    # The source object must not be mutated.
+    assert da.attrs[UNIT_ATTR] == "m"
+
+
+def test_dataarray_attrs_do_not_contradict_data_after_uconvert():
+    """After a conversion no attribute claims the pre-conversion unit."""
+    da = xr.DataArray([1000.0, 2000.0], dims=["x"], attrs={UNIT_ATTR: "m"})
+
+    q = da.unxt.quantify()
+    converted = q.copy(data=u.uconvert("km", q.data))
+
+    assert u.unit_of(converted.data) == u.unit("km")
+    assert converted.attrs.get(UNIT_ATTR) != "m"
+
+
+def test_dataarray_quantify_consumes_coord_units_attr():
+    """Coordinate attributes are consumed too, not just the data variable."""
+    da = xr.DataArray(
+        [1.0, 2.0],
+        dims=["i"],
+        coords={"i": [0, 1], "x": ("i", [0.0, 1.0], {UNIT_ATTR: "s"})},
+        attrs={UNIT_ATTR: "m"},
+    )
+
+    q = da.unxt.quantify()
+
+    assert u.unit_of(q.coords["x"].data) == u.unit("s")
+    assert UNIT_ATTR not in q.coords["x"].attrs
+
+
+def test_dataarray_quantify_twice_is_a_no_op():
+    """A second `quantify` is a no-op rather than an opaque TypeError."""
+    da = xr.DataArray([1000.0, 2000.0], dims=["x"], attrs={UNIT_ATTR: "m"})
+
+    once = da.unxt.quantify()
+    twice = once.unxt.quantify()
+
+    assert u.unit_of(twice.data) == u.unit("m")
+    assert UNIT_ATTR not in twice.attrs
+
+
+def test_dataarray_quantify_already_quantified_raises_clear_error():
+    """Explicitly re-quantifying quantified data names the real cause."""
+    da = xr.DataArray([1000.0, 2000.0], dims=["x"], attrs={UNIT_ATTR: "m"})
+    once = da.unxt.quantify()
+
+    with pytest.raises(ValueError, match="already a Quantity"):
+        once.unxt.quantify("km")
+
+
+def test_dataset_quantify_consumes_units_attrs():
+    """Dataset data variables and coordinates both drop the consumed attr."""
+    ds = xr.Dataset(
+        {"a": ("i", [1000.0, 2000.0], {UNIT_ATTR: "m"})},
+        coords={"x": ("i", [0.0, 1.0], {UNIT_ATTR: "s"})},
+    )
+
+    q = ds.unxt.quantify()
+
+    assert u.unit_of(q["a"].data) == u.unit("m")
+    assert UNIT_ATTR not in q["a"].attrs
+    assert u.unit_of(q.coords["x"].data) == u.unit("s")
+    assert UNIT_ATTR not in q.coords["x"].attrs
+
+
+def test_dataset_quantify_twice_is_a_no_op():
+    ds = xr.Dataset({"a": ("i", [1000.0, 2000.0], {UNIT_ATTR: "m"})})
+
+    twice = ds.unxt.quantify().unxt.quantify()
+
+    assert u.unit_of(twice["a"].data) == u.unit("m")
+    assert UNIT_ATTR not in twice["a"].attrs
+
+
+def test_dataarray_round_trip_through_conversion_is_correct():
+    """Quantify -> uconvert -> dequantify still reports the live unit."""
+    da = xr.DataArray([1000.0, 2000.0], dims=["x"], attrs={UNIT_ATTR: "m"})
+
+    q = da.unxt.quantify()
+    converted = q.copy(data=u.uconvert("km", q.data))
+    back = converted.unxt.dequantify()
+
+    assert back.attrs[UNIT_ATTR] == "km"
+
+
+def test_dataarray_quantify_preserves_unrelated_attrs():
+    """Only the unit attribute is consumed; everything else survives."""
+    da = xr.DataArray(
+        [1.0, 2.0], dims=["x"], attrs={UNIT_ATTR: "m", "long_name": "distance"}
+    )
+
+    q = da.unxt.quantify()
+
+    assert q.attrs["long_name"] == "distance"
+    assert UNIT_ATTR not in q.attrs
+
+
+def test_dimension_coord_keeps_units_attr():
+    """A dimension coordinate keeps its attr: xarray drops the Quantity there.
+
+    xarray coerces dimension coordinates to plain index arrays, discarding the
+    `Quantity`. The attribute is then the only surviving record of the unit, so
+    consuming it would lose the unit outright.
+    """
+    da = xr.DataArray(
+        [1.0, 2.0],
+        dims=["x"],
+        coords={"x": ("x", [0.0, 1.0], {UNIT_ATTR: "s"})},
+        attrs={UNIT_ATTR: "m"},
+    )
+
+    q = da.unxt.quantify()
+
+    # Precondition: xarray really did drop the Quantity on the dim coordinate.
+    assert u.unit_of(q.coords["x"].data) is None
+    # So the attribute must be preserved.
+    assert q.coords["x"].attrs[UNIT_ATTR] == "s"
+    # The data variable, which did keep its Quantity, still drops the attr.
+    assert UNIT_ATTR not in q.attrs
+
+
+def test_dataarray_attrs_untouched_when_no_unit_attached():
+    """An unrelated ``units`` attr on a variable with no unit is left alone."""
+    da = xr.DataArray([1.0, 2.0], dims=["x"])
+    attached = xr.DataArray(da.data, dims=["x"], attrs={"long_name": "count"})
+
+    q = attached.unxt.quantify()
+
+    assert q.attrs == {"long_name": "count"}

--- a/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
+++ b/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
@@ -124,12 +124,17 @@ def test_dataarray_quantify_preserves_unrelated_attrs():
     assert UNIT_ATTR not in q.attrs
 
 
-def test_dimension_coord_keeps_units_attr():
-    """A dimension coordinate keeps its attr: xarray drops the Quantity there.
+def test_dimension_coord_units_attr_follows_attachment():
+    """The coord attr is consumed iff the unit survived onto the coord data.
 
-    xarray coerces dimension coordinates to plain index arrays, discarding the
-    `Quantity`. The attribute is then the only surviving record of the unit, so
-    consuming it would lose the unit outright.
+    xarray currently coerces dimension coordinates to plain index arrays,
+    discarding the `Quantity` -- so the attribute is the only surviving record
+    of the unit and must be preserved, which is why the pop is gated.
+
+    Asserted as that conditional rather than by pinning xarray's present
+    behaviour: if a future xarray preserves the `Quantity` on dimension
+    coordinates, the contract (pop iff attached) still holds and this test
+    still checks it, instead of failing for an unrelated reason.
     """
     da = xr.DataArray(
         [1.0, 2.0],
@@ -139,20 +144,37 @@ def test_dimension_coord_keeps_units_attr():
     )
 
     q = da.unxt.quantify()
+    coord = q.coords["x"]
 
-    # Precondition: xarray really did drop the Quantity on the dim coordinate.
-    assert u.unit_of(q.coords["x"].data) is None
-    # So the attribute must be preserved.
-    assert q.coords["x"].attrs[UNIT_ATTR] == "s"
-    # The data variable, which did keep its Quantity, still drops the attr.
+    if u.unit_of(coord.data) is None:
+        # The unit did not survive, so the attr is the only record of it.
+        assert coord.attrs[UNIT_ATTR] == "s"
+    else:
+        # The unit did survive, so the attr was redundant and is consumed.
+        assert u.unit_of(coord.data) == u.unit("s")
+        assert UNIT_ATTR not in coord.attrs
+
+    # The data variable does keep its Quantity, so its attr is always consumed.
+    assert u.unit_of(q.data) is not None
     assert UNIT_ATTR not in q.attrs
 
 
-def test_dataarray_attrs_untouched_when_no_unit_attached():
-    """An unrelated ``units`` attr on a variable with no unit is left alone."""
-    da = xr.DataArray([1.0, 2.0], dims=["x"])
-    attached = xr.DataArray(da.data, dims=["x"], attrs={"long_name": "count"})
+def test_units_attr_kept_when_no_unit_attached_to_data():
+    """The attr survives when quantification is explicitly suppressed.
 
-    q = attached.unxt.quantify()
+    This is the negative half of the conditional pop -- the positive half is
+    `test_dataarray_quantify_consumes_units_attr`. Passing ``{None: None}``
+    suppresses attachment for the data variable, so no unit reaches the data
+    and the ``units`` attr remains its only record.
+    """
+    da = xr.DataArray(
+        [1.0, 2.0],
+        dims=["x"],
+        attrs={UNIT_ATTR: "m", "long_name": "distance"},
+    )
 
-    assert q.attrs == {"long_name": "count"}
+    q = da.unxt.quantify({None: None})
+
+    assert u.unit_of(q.data) is None
+    assert q.attrs[UNIT_ATTR] == "m"
+    assert q.attrs["long_name"] == "distance"

--- a/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
+++ b/packages/unxts.interop.xarray/tests/test_stale_units_attrs.py
@@ -11,10 +11,11 @@ object. Two symptoms followed:
   stale attribute made the second call try to re-quantify a `Quantity`.
 """
 
+import numpy as np
 import pytest
 import unxts.interop.xarray  # noqa: F401  # registers the .unxt accessor
 import xarray as xr
-from unxts.interop.xarray._src.conversion import UNIT_ATTR
+from unxts.interop.xarray._src.conversion import UNIT_ATTR, attach_units
 
 import unxt as u
 
@@ -178,3 +179,49 @@ def test_units_attr_kept_when_no_unit_attached_to_data():
     assert u.unit_of(q.data) is None
     assert q.attrs[UNIT_ATTR] == "m"
     assert q.attrs["long_name"] == "distance"
+
+
+def test_quantify_does_not_mutate_the_caller():
+    """``quantify`` must not touch the input object's attrs.
+
+    ``_consume_unit_attrs`` mutates the *result*'s attrs in place. If a
+    coordinate were carried into the result by reference, that mutation would
+    reach through to the caller's object. `attach_units` therefore rebuilds
+    every coordinate as a fresh `Variable` with a copied attrs dict, rather
+    than relying on the DataArray/Dataset constructor to copy them -- which it
+    currently does, but as an implementation detail rather than a guarantee.
+
+    Exercised through `attach_units` rather than ``quantify``, because the two
+    conditions are mutually exclusive via the accessor: ``quantify`` merges the
+    attrs-derived units into its mapping, so a coord carrying a ``units`` attr
+    always gets an entry and is rebuilt anyway, while a coord without one has
+    nothing for ``_consume_unit_attrs`` to pop. Only a caller passing an
+    explicit mapping to `attach_units` that omits such a coord reaches the
+    by-reference branch.
+    """
+    q = u.Q(np.array([1.0, 2.0]), "km")
+
+    da = xr.DataArray(
+        [1.0, 2.0],
+        dims=["x"],
+        coords={"x": ("x", [0.0, 1.0]), "c": ("x", q, {UNIT_ATTR: "km"})},
+        attrs={UNIT_ATTR: "m"},
+    )
+    before = dict(da.coords["c"].attrs)
+    # "c" is deliberately absent from the mapping -> the ``unit is None`` branch.
+    attached = attach_units(da, {None: "m"})
+
+    assert dict(da.coords["c"].attrs) == before  # caller untouched ...
+    assert UNIT_ATTR not in attached.coords["c"].attrs  # ... result consumed
+    assert da.attrs == {UNIT_ATTR: "m"}
+
+    ds = xr.Dataset(
+        {"v": ("x", [1.0, 2.0], {UNIT_ATTR: "m"})},
+        coords={"x": ("x", [0.0, 1.0]), "c": ("x", q, {UNIT_ATTR: "km"})},
+    )
+    ds_before = dict(ds.coords["c"].attrs)
+    ds_attached = attach_units(ds, {"v": "m"})
+
+    assert dict(ds.coords["c"].attrs) == ds_before
+    assert UNIT_ATTR not in ds_attached.coords["c"].attrs
+    assert ds["v"].attrs == {UNIT_ATTR: "m"}


### PR DESCRIPTION
`quantify()` never cleared the `units` attribute it consumed, so after any unit
conversion the attrs silently contradicted the data:

```
after quantify : data= Quantity([1000., 2000.], unit='m')   attrs= {'units': 'm'}
after uconvert : data= Quantity([1., 2.], unit='km')        attrs= {'units': 'm'}   <- contradicts
```

`attach_units` built the result with `attrs=dict(obj.attrs)`, copying attrs
verbatim including the key it had just consumed — unlike `dequantify`, which
manages the attribute correctly.

Two symptoms:
- **Silent:** anything trusting `.attrs["units"]` (plot labels, netCDF/CF
  serialization) reads `m` for data that is `km`. 1000x, no warning.
- **Loud but confusing:** `quantify()` twice raised
  `TypeError: Cannot convert 'Quantity' to a value...` — the stale attr made the
  second call think the data still needed quantifying.

**Fix:** a `_consume_unit_attrs` helper drops `UNIT_ATTR` from data variables and
coords after `attach_units` builds the result, applied in **both** the
`DataArray` and `Dataset` overloads. `_array_attach_units` now raises a clear
`ValueError` naming the unit already carried and pointing at `unxt.uconvert`,
instead of the opaque `TypeError`. Double-`quantify()` becomes a clean no-op.

**The pop is conditional, deliberately.** Popping unconditionally introduces a
data-loss regression: xarray coerces **dimension coordinates** to plain index
arrays, so the `Quantity` never survives there and the attr is the *only*
remaining record of that unit — deleting it loses the unit outright. The pop is
therefore gated on `u.unit_of(var.data) is not None`, verified post-construction
rather than assumed from the attach call. `test_dimension_coord_keeps_units_attr`
locks this in and asserts the precondition (that xarray really did drop the
`Quantity`), so it cannot pass for the wrong reason.

**Tests (TDD):** 10 new tests, confirmed failing first — 8 failed / 2 passed, the
two passes being the `dequantify`-unaffected assertions.

Verified `dequantify` and serialization are unharmed: `dequantify` recomputes
attrs from live data via `extract_units` so it cannot be broken by the removal;
`attach_units`/`extract_units` are symmetric over data vars and coords for both
types; and a real netCDF round-trip (`dequantify -> to_netcdf -> open_dataarray`)
gives the correct post-conversion `km` with the dim-coord attr surviving.

Package tests: 15 passed. Full CI scope: 3520 passed, 49 skipped, 12 xfailed.

Two things worth flagging separately, not addressed here:
- `conftest.py` excludes `packages/unxts.interop.xarray/src/` from sybil
  collection (namespace shadowing), so **doctests in these modules never run in
  CI**. Verified manually (`conversion` OK, `accessors` 51/51).
- `tests/unit/test_quantity.py::TestQuantityProperties::test_negation_involutive`
  failed once on a full-scope run and does not reproduce; it passes in isolation
  and this diff touches only the xarray package. Looks like a pre-existing
  hypothesis flake in core quantity negation, worth chasing separately.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)