### PR TITLE
🐛 fix(quantity): compare unit labels in static equality

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -87,7 +87,7 @@ def _coerce_foreign_quantity(other: Any) -> Any:
     return other
 
 
-def same_unit_label(a: Any, b: Any, /) -> bool:
+def same_unit_label(a: AbstractUnit, b: AbstractUnit, /) -> bool:
     """Return whether two units carry the same *label*.
 
     The static-value equality path must not use ``a == b``: astropy's unit

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -87,6 +87,23 @@ def _coerce_foreign_quantity(other: Any) -> Any:
     return other
 
 
+def same_unit_label(a: Any, b: Any, /) -> bool:
+    """Return whether two units carry the same *label*.
+
+    The static-value equality path must not use ``a == b``: astropy's unit
+    equality is *physical*, so ``Unit("J") == Unit("m2 kg / s2")`` is `True`,
+    whereas astropy hashes the label, so those two hash *differently*. Using
+    ``==`` there therefore broke the ``__eq__``/``__hash__`` contract -- equal
+    objects that hash apart, so ``{a, b}`` held two elements.
+
+    Comparing ``str`` keeps equality consistent with ``__hash__`` (which hashes
+    the unit itself), and preserves the property a `StaticQuantity` exists for:
+    distinct unit labels stay distinct ``jax.jit`` compilation cache keys. Use
+    `unxt.equivalent` for the unit-aware comparison.
+    """
+    return str(a) == str(b)
+
+
 class AbstractQuantity(
     AstropyQuantityCompatMixin,
     NumPyCompatMixin,
@@ -754,7 +771,7 @@ class AbstractQuantity(
         """
         if self._is_static_backed(other):
             return bool(
-                self.unit == other.unit
+                same_unit_label(self.unit, other.unit)
                 and np.array_equal(self.value.array, other.value.array)
             )
 

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -13,7 +13,7 @@ import wadler_lindig as wl
 from jaxtyping import ArrayLike
 from plum import add_promotion_rule
 
-from .base import AbstractQuantity, ArrayLikeSequence
+from .base import AbstractQuantity, ArrayLikeSequence, same_unit_label
 from .quantity import Quantity
 from .value import StaticValue
 from unxt.units import AbstractUnit, unit as parse_unit
@@ -76,7 +76,8 @@ class StaticQuantity(AbstractQuantity):
     def __eq__(self, other: Any, /) -> bool | np.ndarray:  # type: ignore[override]
         """Return structural equality for static quantities."""
         if isinstance(other, StaticQuantity):
-            return self.unit == other.unit and self.value == other.value
+            # Label, not physical, equality -- see `same_unit_label`.
+            return same_unit_label(self.unit, other.unit) and self.value == other.value
         return super().__eq__(other)
 
     def __pdoc__(self, *, show_wrapper: bool = False, **kwargs: Any) -> wl.AbstractDoc:

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -628,14 +628,27 @@ def test_static_backed_eq_is_label_based_not_physical(lhs, rhs) -> None:
     assert u.unit(lhs) == u.unit(rhs)
 
     assert a != b
-    assert hash(a) != hash(b)
+    # Collision-safe: a set falls back to ``__eq__`` when hashes collide, so
+    # two unequal objects always occupy two slots regardless of hashing.
     assert len({a, b}) == 2
+
+    # They are unequal *because the labels differ* -- that is the semantics
+    # under test. (Asserting ``hash(a) != hash(b)`` would be asserting more
+    # than Python guarantees: unequal objects are permitted to collide.)
+    assert str(a.unit) != str(b.unit)
+
+    # The eq/hash contract, in the direction Python actually requires:
+    # equal objects must hash equal. This is what the bug violated.
+    same = u.StaticQuantity(value, lhs)
+    assert a == same
+    assert hash(a) == hash(same)
 
     # ... and the same holds for a StaticValue-backed plain Quantity.
     qa = u.Q(StaticValue(value), lhs)
     qb = u.Q(StaticValue(value), rhs)
     assert qa != qb
-    assert hash(qa) != hash(qb)
+    assert str(qa.unit) != str(qb.unit)
+    assert qa == u.Q(StaticValue(value), lhs)
 
 
 def test_static_quantity_jit_distinguishes_units() -> None:

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -599,6 +599,45 @@ def test_static_backed_eq_hash_contract() -> None:
     assert (a != c) is True
 
 
+@pytest.mark.parametrize(
+    ("lhs", "rhs"),
+    [
+        ("J", "m2 kg / s2"),  # energy
+        ("N", "kg m / s2"),  # force
+        ("W", "J / s"),  # power
+    ],
+)
+def test_static_backed_eq_is_label_based_not_physical(lhs, rhs) -> None:
+    """Physically-equal but differently-spelled units compare unequal.
+
+    Regression: the static path compared units with ``self.unit == other.unit``,
+    which is astropy's *physical* equality (``Unit('J') == Unit('m2 kg / s2')``
+    is True), while ``__hash__`` hashes the unit *label* (those two hash
+    differently). So ``a == b`` was True while ``hash(a) != hash(b)`` -- the
+    eq/hash contract broken, and ``{a, b}`` held two elements.
+
+    The existing contract test above cannot catch this: it uses ``1000 m`` vs
+    ``1 km``, whose *values* also differ, so it passes under either semantics.
+    Here the values are identical and only the unit spelling differs.
+    """
+    value = np.array([1.0])
+    a = u.StaticQuantity(value, lhs)
+    b = u.StaticQuantity(value, rhs)
+
+    # The units really are physically equal -- this is the trap.
+    assert u.unit(lhs) == u.unit(rhs)
+
+    assert a != b
+    assert hash(a) != hash(b)
+    assert len({a, b}) == 2
+
+    # ... and the same holds for a StaticValue-backed plain Quantity.
+    qa = u.Q(StaticValue(value), lhs)
+    qb = u.Q(StaticValue(value), rhs)
+    assert qa != qb
+    assert hash(qa) != hash(qb)
+
+
 def test_static_quantity_jit_distinguishes_units() -> None:
     """Different-unit static args must not collapse to one jit compilation."""
 

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -643,12 +643,19 @@ def test_static_backed_eq_is_label_based_not_physical(lhs, rhs) -> None:
     assert a == same
     assert hash(a) == hash(same)
 
-    # ... and the same holds for a StaticValue-backed plain Quantity.
+    # ... and the same holds for a StaticValue-backed plain Quantity, which
+    # goes through the `AbstractQuantity.__eq__` static path rather than
+    # `StaticQuantity.__eq__`. The bug was present on both, so assert the
+    # contract on both -- including the hash direction.
     qa = u.Q(StaticValue(value), lhs)
     qb = u.Q(StaticValue(value), rhs)
     assert qa != qb
     assert str(qa.unit) != str(qb.unit)
-    assert qa == u.Q(StaticValue(value), lhs)
+    assert len({qa, qb}) == 2
+
+    qsame = u.Q(StaticValue(value), lhs)
+    assert qa == qsame
+    assert hash(qa) == hash(qsame)
 
 
 def test_static_quantity_jit_distinguishes_units() -> None:


### PR DESCRIPTION
The `StaticValue`-backed `__eq__` used `self.unit == other.unit` — astropy's
*physical* equality — while `__hash__` hashes the unit *label*. Those disagree:

```python
a = u.StaticQuantity(np.array([1.0]), "J")
b = u.StaticQuantity(np.array([1.0]), "m2 kg / s2")

a == b            # True
hash(a) == hash(b)  # False
len({a, b})         # 2
```

Equal objects that hash apart — the `__eq__`/`__hash__` contract broken. Same
for `N` vs `kg m / s2`, `W` vs `J / s`, and for `StaticValue`-backed plain
`Quantity`.

**The docstring already specified the correct behaviour** — "they are equal only
when their unit labels match", and it even warns that unit-aware equality "would
break the `__eq__`/`__hash__` contract, since the hash is unit-label sensitive".
Only the code disagreed. This aligns the code with its documented intent.

**Fix:** compare `str(unit)` via a shared `same_unit_label` helper used by both
call sites (`base.py` and `static_quantity.py`) so they cannot drift. Verified
empirically that `str`-equality implies astropy hash-equality across the unit
sample (no str-equal-but-hash-differ pairs), so equality is now provably
consistent with `__hash__`.

This also preserves the property `StaticQuantity` exists for: distinct unit
labels stay distinct `jax.jit` compilation cache keys. `unxt.equivalent` remains
the unit-aware comparison.

**Why the existing test missed it:** `test_static_backed_eq_hash_contract` uses
`1000 m` vs `1 km`, whose *values* also differ — so it passes under either
semantics. The new test holds the value fixed at `1.0` and varies only the unit
spelling, parametrized over three physically-equal pairs, asserting the trap
condition (`u.unit(lhs) == u.unit(rhs)`) explicitly so it cannot pass for the
wrong reason.

Confirmed failing first (3 failed), then green. Full CI scope: 3523 passed, 49
skipped, 12 xfailed.

Semantics choice (label-based `==` vs canonicalising `__hash__`) confirmed with
@nstarman before implementing — label-based is the smaller change, matches the
docstring, and keeps label-distinct jit cache keys.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)