### PR TITLE
💚 ci: add a weekly ecosystem run for per-package jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,8 +591,10 @@ jobs:
           # skip instead of treating it as a failure.
           #
           # `tests-unxts-parametric` is deliberately NOT listed: it has no `if:`
-          # gate and must run on every PR, so a skip there is a real failure
-          # (e.g. a malformed gate) and should fail this check loudly.
+          # gate and must run on every PR, so a skip there is a real failure --
+          # e.g. an `if:` gate reintroduced on the job, or its `needs:`
+          # (`setup`/`format`) failing -- and should fail this check loudly
+          # rather than pass silently.
           allowed-skips:
             tests-unxt-api, tests-unxt-hypothesis, tests-unxts-api,
             tests-unxts-hypothesis, tests-unxts-interop-gala,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ on:
     - cron: "0 0 * * 1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Keyed on the event as well as the ref. A `schedule` run reports the default
+  # branch as `github.ref`, which is the same value a `push` to main reports --
+  # so without `event_name` the weekly ecosystem run and a Monday-morning push
+  # to main would share a group and, with `cancel-in-progress`, cancel each
+  # other. Including it keeps them independent while still collapsing repeated
+  # pushes to the same branch or PR.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Weekly, Mondays at midnight UTC. This is the ecosystem check: the
+    # per-package jobs below are gated off on ordinary PRs, so this run is what
+    # exercises every sibling package against current upstream releases and
+    # catches breakage that lands without any change to this repo.
+    - cron: "0 0 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,6 +99,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxt-api') ||
       startsWith(github.head_ref, 'unxt-api/')
@@ -132,6 +139,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxt-hypothesis') ||
       startsWith(github.head_ref, 'unxt-hypothesis/')
@@ -169,6 +177,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-api') ||
       startsWith(github.head_ref, 'unxts-api/')
@@ -209,6 +218,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-hypothesis') ||
       startsWith(github.head_ref, 'unxts-hypothesis/')
@@ -253,6 +263,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-interop-gala') ||
       startsWith(github.head_ref, 'unxts-interop-gala/')
@@ -295,6 +306,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-interop-matplotlib') ||
       startsWith(github.head_ref, 'unxts-interop-matplotlib/')
@@ -334,6 +346,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-interop-xarray') ||
       startsWith(github.head_ref, 'unxts-interop-xarray/')
@@ -369,24 +382,26 @@ jobs:
 
   # unxts-parametric package tests
   #
-  # Unlike its sibling package jobs, this one has NO `if:` gate: it runs on
-  # every event the workflow fires on, including ordinary pull requests.
-  # `unxts.parametric` depends on core `unxt` and is the migration target for
-  # every v1 user, so a core change that breaks it must fail the PR rather than
-  # be discovered after merge.
-  #
-  # The label/branch-prefix gate the siblings use cannot close this gap: the
-  # `🧩 unxts-parametric` label is applied by the `Auto-label PRs` workflow,
-  # which runs on `workflow_run` *after* `Collect PR labels` completes, while
-  # CI evaluates `github.event.pull_request.labels` from the original
-  # `pull_request` payload. The label therefore lands too late to affect the
-  # run it would need to gate, and CI does not trigger on `types: [labeled]`.
+  # NB: the label clause below is weaker than it looks. The `🧩 unxts-parametric`
+  # label is applied by the `Auto-label PRs` workflow, which runs on
+  # `workflow_run` *after* `Collect PR labels` completes, while CI evaluates
+  # `github.event.pull_request.labels` from the original `pull_request` payload.
+  # The label therefore lands too late to gate the run it would need to gate,
+  # and CI does not trigger on `types: [labeled]` -- so in practice it only
+  # takes effect on the *next* push to the PR. Coverage for core changes that
+  # break this package comes from the push-to-main and weekly `schedule` runs.
   tests-unxts-parametric:
     name:
       unxts-parametric Python ${{ matrix.python-version }} on ${{ matrix.runs-on
       }}
     runs-on: ${{ matrix.runs-on }}
     needs: [setup, format]
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, '🧩 unxts-parametric') ||
+      startsWith(github.head_ref, 'unxts-parametric/')
     strategy:
       fail-fast: false
       matrix:
@@ -426,6 +441,7 @@ jobs:
     needs: [setup, format]
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, '🧩 unxts-linalg') ||
       startsWith(github.head_ref, 'unxts-linalg/')
@@ -585,18 +601,13 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          # These per-package jobs only run on push / workflow_dispatch / a
-          # package label / `unxt-api|unxt-hypothesis/*` branches (see their
+          # These per-package jobs only run on push / schedule /
+          # workflow_dispatch / a package label / `<pkg>/*` branches (see their
           # `if:`), so on a normal PR they are intentionally skipped. Allow the
-          # skip instead of treating it as a failure.
-          #
-          # `tests-unxts-parametric` is deliberately NOT listed: it has no `if:`
-          # gate and must run on every PR, so a skip there is a real failure --
-          # e.g. an `if:` gate reintroduced on the job, or its `needs:`
-          # (`setup`/`format`) failing -- and should fail this check loudly
-          # rather than pass silently.
+          # skip instead of treating it as a failure. On the weekly `schedule`
+          # run they all execute, so nothing here is permanently unchecked.
           allowed-skips:
             tests-unxt-api, tests-unxt-hypothesis, tests-unxts-api,
             tests-unxts-hypothesis, tests-unxts-interop-gala,
             tests-unxts-interop-matplotlib, tests-unxts-interop-xarray,
-            tests-unxts-linalg
+            tests-unxts-linalg, tests-unxts-parametric

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,17 +368,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # unxts-parametric package tests
+  #
+  # Unlike its sibling package jobs, this one has NO `if:` gate: it runs on
+  # every event the workflow fires on, including ordinary pull requests.
+  # `unxts.parametric` depends on core `unxt` and is the migration target for
+  # every v1 user, so a core change that breaks it must fail the PR rather than
+  # be discovered after merge.
+  #
+  # The label/branch-prefix gate the siblings use cannot close this gap: the
+  # `🧩 unxts-parametric` label is applied by the `Auto-label PRs` workflow,
+  # which runs on `workflow_run` *after* `Collect PR labels` completes, while
+  # CI evaluates `github.event.pull_request.labels` from the original
+  # `pull_request` payload. The label therefore lands too late to affect the
+  # run it would need to gate, and CI does not trigger on `types: [labeled]`.
   tests-unxts-parametric:
     name:
       unxts-parametric Python ${{ matrix.python-version }} on ${{ matrix.runs-on
       }}
     runs-on: ${{ matrix.runs-on }}
     needs: [setup, format]
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, '🧩 unxts-parametric') ||
-      startsWith(github.head_ref, 'unxts-parametric/')
     strategy:
       fail-fast: false
       matrix:
@@ -581,8 +589,12 @@ jobs:
           # package label / `unxt-api|unxt-hypothesis/*` branches (see their
           # `if:`), so on a normal PR they are intentionally skipped. Allow the
           # skip instead of treating it as a failure.
+          #
+          # `tests-unxts-parametric` is deliberately NOT listed: it has no `if:`
+          # gate and must run on every PR, so a skip there is a real failure
+          # (e.g. a malformed gate) and should fail this check loudly.
           allowed-skips:
             tests-unxt-api, tests-unxt-hypothesis, tests-unxts-api,
             tests-unxts-hypothesis, tests-unxts-interop-gala,
             tests-unxts-interop-matplotlib, tests-unxts-interop-xarray,
-            tests-unxts-parametric, tests-unxts-linalg
+            tests-unxts-linalg


### PR DESCRIPTION
Per maintainer feedback, this no longer runs `tests-unxts-parametric` on every
PR. The per-package jobs stay gated off ordinary PRs; coverage comes from
push-to-main (already the case) plus a new weekly cron.

## What changed

- **`schedule:` trigger** on `ci.yml` — Mondays 00:00 UTC.
- **`github.event_name == 'schedule'`** added to **all nine** gated package
  jobs, not just parametric. The point of a weekly run is to catch upstream
  breakage that lands without any change to this repo, and that applies to
  `unxts.linalg`, `unxts.api`, `unxt-api`, `unxt-hypothesis`,
  `unxts.hypothesis` and the three interop packages just as much — so the
  weekly run exercises the whole ecosystem.
- `tests-unxts-parametric` restored to `allowed-skips`, since it is gated again.

## Net effect on PRs: none

The parametric job's `if:` is now identical in shape to its siblings
(`push || schedule || workflow_dispatch || label || branch-prefix`), and
`allowed-skips` is back to the same set as before — only reordered. The sole
behavioural change is the new weekly run.

## Verified

- `check-github-workflows` (check-jsonschema) and `check-yaml` pass.
- Asserted programmatically that all 9 gated jobs include the `schedule`
  clause, and that **the `allowed-skips` set equals the gated-jobs set** (9 ==
  9) — so no job is both skippable and unlisted, or listed but always-running.
- Confirmed the parametric gate now matches the sibling pattern exactly.

*(Gotcha for anyone scripting against this file: PyYAML parses the bare `on:`
key as boolean `True`, not the string `"on"`.)*

## Retained finding: the label gate is weaker than it looks

Left the note in place, because it still holds and explains why `push` and
`schedule` are load-bearing. The `🧩 <pkg>` label is applied by `Auto-label
PRs`, which runs on `workflow_run` *after* `Collect PR labels` completes, while
CI evaluates `github.event.pull_request.labels` from the original
`pull_request` payload. The label lands too late to gate its own run, and CI
does not trigger on `types: [labeled]` — so it only takes effect on the *next*
push to the PR. Worth fixing separately if the label gates are meant to be
relied on.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)