### PR TITLE
🐛 fix: disable the hypothesis deadline suite-wide

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 from pathlib import Path
 from typing import Any
 
+import hypothesis
 from sybil import Document, Region, Sybil
 from sybil.evaluators.doctest import DocTestEvaluator
 from sybil.evaluators.python import PythonEvaluator
@@ -17,6 +18,15 @@ from sybil.parsers.abstract.doctest import DocTestStringParser
 from optional_dependencies import OptionalDependencyEnum, auto
 
 optionflags = ELLIPSIS | NORMALIZE_WHITESPACE
+
+# Hypothesis' 200ms per-example deadline is meaningless for tests that call into
+# jax: an example that trips a fresh trace/compile, or just lands on a busy CPU
+# during a full-suite run, blows past it. The deadline failure then does not
+# reproduce on replay, so it surfaces as an unactionable `FlakyFailure`
+# ("unreliable results: Falsified on the first call but did not on a subsequent
+# one"). Turn it off globally; per-test `@settings` still override this.
+hypothesis.settings.register_profile("unxt", deadline=None)
+hypothesis.settings.load_profile("unxt")
 
 
 class PlainDocTestParser:


### PR DESCRIPTION
## Problem

`tests/unit/test_quantity.py::TestQuantityProperties::test_negation_involutive` was intermittently failing under the full CI-scope suite run (~1 in 3), and could **not** be reproduced in isolation, by sweeping `--hypothesis-seed` 1-8, or by repeating its own file six times.

## Root cause

Hypothesis' 200 ms per-example deadline — **not** a numerical bug.

- **Numerics ruled out.** Negation is a bit-exact IEEE-754 sign flip. A 100k-case sweep across shapes 1-5, including ±0.0 and denormals, produced zero mismatches; the strategy bounds exclude NaN/inf.
- **The timing is marginal.** Under the full suite, examples run ~30-42 ms against a 200 ms deadline. One outlier — a fresh jax trace/compile, or just a busy CPU — is enough.
- **The signature matches.** Reproduced by running the identical test body with the deadline tightened to 20 ms:
  ```
  FlakyFailure: ... produces unreliable results:
  Falsified on the first call but did not on a subsequent one
  ```
  Hypothesis re-runs a deadline failure; when the replay is fast it reports `FlakyFailure` instead of `DeadlineExceeded`. That is *inherently* non-reproducible in isolation — exactly why every targeted reproduction attempt came back clean.

**Why this test specifically:** it is one of only 9 `@given` tests in the file missing `@settings(...)`, while its immediate neighbours all carry `@settings(max_examples=20, deadline=None)`. So it runs **100** examples where siblings run 20 — 5× the chances to hit a timing outlier.

## Fix

Register a suite-wide profile in `conftest.py` rather than patching the one test — the other 8 carry the same latent flake, and the deadline provides no value for tests that call into jax. Per-test `@settings` still override it.

## Verification

- Profile confirmed active inside the repo tree **and** under `packages/` (probe asserting `settings.default.deadline is None` passes in both).
- Negative control: a test with one deliberately 1 s example fails with the exact `FlakyFailure`/`DeadlineExceeded` pair at a 200 ms deadline, and passes under the fix.
- Full CI-scope suite: `3544 passed, 49 skipped, 12 xfailed` on this branch; 4 consecutive clean runs on an earlier base.
- `pre-commit run --files conftest.py`: all hooks pass.

## Caveat

The original failure was never caught in the wild during this investigation — the pre-fix full-suite runs were all clean. Given the ~1-in-3 base rate, a handful of clean post-fix runs is weak evidence on its own. Confidence rests on the mechanism reproduction and the ruled-out numerics, not on the run loop.

Targeting v2. Backport to `versions/v1.11.x` to be decided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)