### PR TITLE
🐛 fix(ci): import hypothesis defensively in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,6 @@ from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 from pathlib import Path
 from typing import Any
 
-import hypothesis
 from sybil import Document, Region, Sybil
 from sybil.evaluators.doctest import DocTestEvaluator
 from sybil.evaluators.python import PythonEvaluator
@@ -25,8 +24,18 @@ optionflags = ELLIPSIS | NORMALIZE_WHITESPACE
 # reproduce on replay, so it surfaces as an unactionable `FlakyFailure`
 # ("unreliable results: Falsified on the first call but did not on a subsequent
 # one"). Turn it off globally; per-test `@settings` still override this.
-hypothesis.settings.register_profile("unxt", deadline=None)
-hypothesis.settings.load_profile("unxt")
+#
+# Imported defensively: `hypothesis` is declared only by the two `*hypothesis`
+# packages and the root dev env, while each per-package CI job installs a
+# minimal env (`uv sync --package <pkg>`) without it. An unconditional import
+# here makes *loading this conftest* fail, which pytest reports as a usage
+# error (exit code 4) before any test runs -- so it takes down every sibling
+# package job, not just the hypothesis-using ones.
+if importlib.util.find_spec("hypothesis") is not None:
+    import hypothesis
+
+    hypothesis.settings.register_profile("unxt", deadline=None)
+    hypothesis.settings.load_profile("unxt")
 
 
 class PlainDocTestParser:


### PR DESCRIPTION
**Regression on `main` from #753 — currently breaking every per-package CI job.**

#753 added a module-level `import hypothesis` to the root `conftest.py`. But
only the two `*hypothesis` packages declare hypothesis; each per-package CI job
installs a minimal env (`uv sync --no-default-groups --group test --package
<pkg>`) that does not have it:

| package test group | declares hypothesis |
| --- | --- |
| `unxt-hypothesis`, `unxts.hypothesis` | ✅ |
| `unxt-api`, `unxts.api`, `unxts.linalg`, `unxts.parametric`, `unxts.interop.{gala,matplotlib,xarray}` | ❌ |

An unconditional import there makes **loading the conftest** fail, which pytest
reports as a usage error (exit code 4) *before any test runs*. So it takes down
all seven non-hypothesis sibling jobs — not just the ones that use hypothesis:

```
ImportError while loading conftest '/home/runner/work/unxt/unxt/conftest.py'.
conftest.py:10: in <module>
    import hypothesis
E   ModuleNotFoundError: No module named 'hypothesis'
##[error]Process completed with exit code 4.
```

## Fix

Guard the import with `importlib.util.find_spec`, matching the optional-dependency
handling already used in this file (`_is_installed`, `OptDeps`). The deadline
profile still registers and loads wherever hypothesis is installed, so #753's
actual fix is unaffected.

## Verified in a real minimal env

Not just "tests pass on my machine" — reproduced the CI failure and the fix in
the same hypothesis-free env the CI job builds:

```
$ uv sync --no-default-groups --group test --package unxts-interop-xarray
$ python -c "import importlib.util; print(importlib.util.find_spec('hypothesis'))"
None

# main's unguarded import:
ImportError while loading conftest ... ModuleNotFoundError: No module named 'hypothesis'

# with this fix:
3 passed
```

Also checked the other direction: with hypothesis installed, the profile still
loads (`hypothesis.settings.default.deadline is None`), so the flaky-deadline
fix keeps working.

## How this surfaced

Spotted on #748, whose `unxts-interop-xarray` jobs went red on all four Python
versions. Worth noting *why* it only appeared then: that job is gated behind the
`🧩 unxts-interop-xarray` label, and — exactly as analysed in #752 — the label
lands too late to affect the run that applies it, so the job first executed on
the *next* push. Several other PRs are likely to go red the same way as their
labels catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)