### PR TITLE
🐛 fix(quantity): coerce astropy operands in //, %, ** and @

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -862,6 +862,18 @@ class AbstractQuantity(
     def __sub__(self, other: Any) -> Any:
         return super().__sub__(_coerce_foreign_quantity(other))
 
+    def __floordiv__(self, other: Any) -> Any:
+        return super().__floordiv__(_coerce_foreign_quantity(other))
+
+    def __mod__(self, other: Any) -> Any:
+        return super().__mod__(_coerce_foreign_quantity(other))
+
+    def __pow__(self, other: Any) -> Any:
+        return super().__pow__(_coerce_foreign_quantity(other))
+
+    def __matmul__(self, other: Any) -> Any:
+        return super().__matmul__(_coerce_foreign_quantity(other))
+
     def __pdoc__(
         self,
         *,

--- a/tests/integration/astropy/test_astropy_interop_quantity.py
+++ b/tests/integration/astropy/test_astropy_interop_quantity.py
@@ -5,6 +5,7 @@ mixed unxt/astropy arithmetic (eager and under ``jax.jit``), and the
 ``ustrip(AllowValue, ...)`` dispatches.
 """
 
+import operator
 from typing import Any
 
 import astropy.units as apyu
@@ -306,6 +307,49 @@ class TestMixedUnxtAstropyArithmetic:
         """Adding an incompatible astropy quantity still raises."""
         with pytest.raises(apyu.UnitConversionError, match="not convertible"):
             _ = u.Q(1.0, "m") + apyu.Quantity(2.0, "s")
+
+    @pytest.mark.parametrize(
+        ("name", "op", "lhs", "rhs"),
+        [
+            (
+                "floordiv",
+                operator.floordiv,
+                u.Q(6.0, ""),
+                apyu.Quantity(2.0, "percent"),
+            ),
+            ("mod", operator.mod, u.Q(6.0, ""), apyu.Quantity(2.0, "percent")),
+            ("pow", operator.pow, u.Q(3.0, "m"), apyu.Quantity(2.0, "percent")),
+            (
+                "matmul",
+                operator.matmul,
+                u.Q([1.0, 2.0], "m"),
+                apyu.Quantity([3.0, 4.0], "km"),
+            ),
+        ],
+    )
+    def test_operator_matches_explicitly_converted_operand(
+        self, name: str, op: Any, lhs: Any, rhs: Any
+    ) -> None:
+        """Every binary operator treats an astropy operand as a converted quantity.
+
+        Asserted as an invariant rather than a hand-computed "right answer":
+        whatever ``q <op> convert(apy_q, Quantity)`` gives, ``q <op> apy_q``
+        must give too. That is precisely what ``_coerce_foreign_quantity``
+        already guarantees for ``*``, ``/``, ``+`` and ``-``.
+
+        Regression: only those four dunders were overridden to coerce. ``//``,
+        ``%``, ``**`` and ``@`` were inherited unchanged, so quax materialised
+        the astropy operand via ``__array__`` -- stripping it to a bare array in
+        its own unit and silently dropping the unit. ``**`` was wrong in every
+        case (``Q(3, "m") ** apy(2, "percent")`` gave ``9 m2`` rather than
+        ``1.0222 m(1/50)``); ``@`` dropped the ``km``.
+        """
+        expected = op(lhs, convert(rhs, u.quantity.Quantity))
+        got = op(lhs, rhs)
+
+        assert got.unit == expected.unit, f"{name}: unit"
+        msg = f"{name}: value"
+        assert np.allclose(np.asarray(got.value), np.asarray(expected.value)), msg
 
     def test_plum_convert_astropy_to_unxt(self) -> None:
         """`plum.convert` from an astropy Quantity yields an ``unxt`` Quantity.


### PR DESCRIPTION
Follow-up to #750, which was incomplete. `_coerce_foreign_quantity` was wired
into `__mul__`, `__truediv__`, `__add__` and `__sub__` only — `__floordiv__`,
`__mod__`, `__pow__` and `__matmul__` were left inherited, so quax still
materialised an astropy operand via `__array__`, stripping it to a bare array
in its own unit and **silently dropping that unit**.

`**` was wrong in every case, not only for scaled units:

```python
u.Q(3.0, "m") ** apyu.Quantity(2.0, "percent")
#  was:  Quantity(9., unit='m2')
#  now:  Quantity(1.0222154, unit='m(1/50)')
```

`@` dropped the foreign unit outright (`m` instead of `km m`). `//` and `%`
were silently wrong whenever both operands were dimensionless-compatible, and
went loud with a misleading "not convertible" message otherwise.

## Tested as an invariant, not hand-computed answers

For every binary operator: `q <op> apy_q` must equal
`q <op> convert(apy_q, Quantity)`. That is precisely the guarantee the existing
four dunders already provide, so it encodes the intended contract rather than my
arithmetic. Confirmed failing first on all four.

This matters here because `//` is a case where the *value* happened to agree and
only the unit differed — a hand-written expected value could easily have been
written to match the buggy output.

## Enumerated rather than trusted

Rather than fixing the three operators that were reported, I swept all 19 binary
operators programmatically and compared each against its converted-operand
equivalent. That turned up **`__matmul__` as a fourth case** that no report
mentioned. The 8 arithmetic operators are now consistent.

Two deliberate exclusions, both verified:

- **Comparisons** (`<`, `<=`, `>`, `>=`) are *not* fixed here. They raise
  `EquinoxRuntimeError` on both the astropy path and the converted path, so they
  are already consistent — a separate, loud bug with a working workaround
  (`convert(apy_q, u.Quantity)`), better handled on its own.
- **`<<`** is astropy's unit-attachment operator, not arithmetic; coercing it
  would turn a currently-working call into a `TypeError`. Left alone, flagged
  here.

Full CI scope: 3579 passed, 49 skipped, 20 xfailed.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)