### PR TITLE
💚 ci(docs): build docs and gate broken cross-references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,9 @@ jobs:
 
       - name: Fail on broken cross-references
         run: |
-          if grep -q 'myst.xref_missing' docs-build.log; then
+          if grep -qF 'myst.xref_missing' docs-build.log; then
             echo "::error::Broken cross-references in the docs:"
-            grep 'myst.xref_missing' docs-build.log
+            grep -F 'myst.xref_missing' docs-build.log
             echo
             echo "A relative link written with a '.md' suffix resolves through the"
             echo "filesystem, which follows the docs/packages/* symlinks out of the"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          # Pin to the version Read the Docs publishes on
+          # (.readthedocs.yaml build.tools.python), so this job builds the docs
+          # in the same environment they actually ship in -- rather than
+          # whatever ubuntu-latest happens to provide.
+          python-version: "3.12"
 
       - name: Install
         run: uv sync --no-default-groups --group nox --group docs --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,52 @@ jobs:
       - name: Lint
         run: uv run --frozen nox -s lint
 
+  # Documentation build
+  #
+  # Nothing previously gated Sphinx output: there was no docs job here, and the
+  # `docs` nox session builds with `--keep-going` and no `-W`, so it exits 0
+  # whatever it reports. (`.readthedocs.yaml` does set `sphinx.fail_on_warning`,
+  # but that key is ignored when `build.commands` is present -- and it is.) 43
+  # broken cross-references had accumulated on main, invisible to readers: a
+  # dropped MyST link still renders as styled text, just not clickable.
+  #
+  # This gates the category that means "navigation is broken" --
+  # `myst.xref_missing` -- rather than `-W`, which would also fail on ~120
+  # nitpicky `ref.*` warnings for unresolvable third-party type annotations.
+  # Those are curated in `nitpick_ignore` in docs/conf.py; ratcheting them to
+  # zero is worth doing, but blocking every PR on that first is not.
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install
+        run: uv sync --no-default-groups --group nox --group docs --locked
+
+      - name: Build docs
+        run: |
+          set -o pipefail
+          uv run --frozen nox -s docs -- --output-dir=_build 2>&1 | tee docs-build.log
+
+      - name: Fail on broken cross-references
+        run: |
+          if grep -q 'myst.xref_missing' docs-build.log; then
+            echo "::error::Broken cross-references in the docs:"
+            grep 'myst.xref_missing' docs-build.log
+            echo
+            echo "A relative link written with a '.md' suffix resolves through the"
+            echo "filesystem, which follows the docs/packages/* symlinks out of the"
+            echo "Sphinx srcdir and silently drops the link. Write the target"
+            echo "without the extension, e.g. '(../packages/x/index)'."
+            exit 1
+          fi
+          echo "No broken cross-references."
+
   # Main package tests
   tests-unxt:
     name: unxt Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
@@ -587,6 +633,7 @@ jobs:
       [
         setup,
         format,
+        docs,
         tests-unxt,
         tests-unxt-api,
         tests-unxt-hypothesis,

--- a/docs/guides/dimensions.md
+++ b/docs/guides/dimensions.md
@@ -170,7 +170,7 @@ PhysicalType('angle')
 
 ```
 
-The dimension-parametrized `ParametricQuantity` (from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package) encodes its dimension in the _class itself_, so `dimension_of` also works on a parametrized class — see [The dimension of a parametric class](../packages/unxts.parametric/dimensions.md).
+The dimension-parametrized `ParametricQuantity` (from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package) encodes its dimension in the _class itself_, so `dimension_of` also works on a parametrized class — see [The dimension of a parametric class](../packages/unxts.parametric/dimensions).
 
 ## Important Notes
 
@@ -190,6 +190,6 @@ The dimension-parametrized `ParametricQuantity` (from the separate [`unxts.param
 
 :::{seealso}
 
-[API Documentation for Dimensions](../api/dims.md)
+[API Documentation for Dimensions](../api/dims)
 
 :::

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -56,10 +56,10 @@ per-construction overhead. This is **not** about `jax.jit` cache misses — the
 about keeping a smaller, simpler type surface by default.
 
 `ParametricQuantity` moved to the separate
-[`unxts.parametric`](../packages/unxts.parametric/index.md) package in v2. Reach
+[`unxts.parametric`](../packages/unxts.parametric/index) package in v2. Reach
 for it when you need runtime dimension checking or dimension-specific `plum`
 dispatch; see the [parametric quantity
-guide](../packages/unxts.parametric/index.md) for details and the
+guide](../packages/unxts.parametric/index) for details and the
 {ref}`migration guide <migration-v2>` for the v1→v2 mapping. Everything else —
 arithmetic, unit conversion, JAX transforms, interop — works identically with
 either class.
@@ -81,7 +81,7 @@ List of 9 method(s):
     ...
 ```
 
-`Quantity.from_` assists with interfacing with other libraries, e.g. see [Interop with Astropy](../interop/astropy.md).
+`Quantity.from_` assists with interfacing with other libraries, e.g. see [Interop with Astropy](../interop/astropy).
 
 ## Converting to Different Units
 
@@ -417,7 +417,7 @@ Q([1, 2, 3], unit='m')
 
 ```
 
-(The `include_params=True` option adds a dimension parameter such as `['length']` to the representation. The default `Quantity` has no such parameter, so it only takes effect for a `ParametricQuantity`; see the [Configuration guide](../packages/unxts.parametric/configuration.md).)
+(The `include_params=True` option adds a dimension parameter such as `['length']` to the representation. The default `Quantity` has no such parameter, so it only takes effect for a `ParametricQuantity`; see the [Configuration guide](../packages/unxts.parametric/configuration).)
 
 See the [`wadler_lindig` documentation](https://docs.kidger.site/wadler_lindig) for more details on the pretty printing options.
 
@@ -620,7 +620,7 @@ distinction to live at the *value* level while keeping the `Quantity` type.
 
 :::{seealso}
 
-[API Documentation for Quantities](../api/quantity.md)
+[API Documentation for Quantities](../api/quantity)
 
 :::
 

--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -3,7 +3,7 @@
 This guide covers common pitfalls and surprising behaviors when working with `unxt` quantities in JAX. Like JAX itself, `unxt` has some "sharp bits" — behaviors that might surprise you if you're coming from NumPy or non-JAX Python scientific computing.
 
 ```{tip}
-If you're new to `unxt`, start with the [Quantity guide](quantity.md) first.
+If you're new to `unxt`, start with the [Quantity guide](./quantity) first.
 This guide assumes you're familiar with basic `unxt` usage.
 ```
 
@@ -273,7 +273,7 @@ result = add_lengths_m(u.Q(5.0, "m"), length_m_input)
 
 ### ℹ️ Note: `ParametricQuantity` multiplies pytree _types_ (not jit compilations)
 
-Feeding `ParametricQuantity` (from the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package) of different dimensions into a jitted function does **not** add a recompilation per dimension — recompilation is driven by the **unit**, a static field for both classes. What the parametric class adds is a new Python class and pytree type per dimension. See [Parametric types multiply pytree types](../packages/unxts.parametric/sharp-bits.md) in the parametric guide for the full explanation.
+Feeding `ParametricQuantity` (from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package) of different dimensions into a jitted function does **not** add a recompilation per dimension — recompilation is driven by the **unit**, a static field for both classes. What the parametric class adds is a new Python class and pytree type per dimension. See [Parametric types multiply pytree types](../packages/unxts.parametric/sharp-bits) in the parametric guide for the full explanation.
 
 ## Mixing Quantity Types
 
@@ -309,7 +309,7 @@ time = u.Q(2.0, "s")
 speed = length / time  # ✅ Fast; unit arithmetic without per-dimension classes
 ```
 
-**`ParametricQuantity`** — Opt in when you want the physical dimension carried in the type (for dimension-specific `plum` dispatch and runtime dimension checking). It lives in the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package (`up.PQ`); see its [guide](../packages/unxts.parametric/quantity.md).
+**`ParametricQuantity`** — Opt in when you want the physical dimension carried in the type (for dimension-specific `plum` dispatch and runtime dimension checking). It lives in the separate [`unxts.parametric`](../packages/unxts.parametric/index) package (`up.PQ`); see its [guide](../packages/unxts.parametric/quantity).
 
 **`StaticQuantity`** — For compile-time constants:
 
@@ -332,7 +332,7 @@ def function(x, *, constant=u.StaticQuantity(3.26, "lyr")):
 | `ParametricQuantity` | Dimension-parametrized dispatch / runtime checking | ✅ Yes | Good (a distinct type per dimension) |
 | `StaticQuantity` | Constants | ❌ None | Best (no tracer) |
 
-`ParametricQuantity` lives in the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package; see its [guide](../packages/unxts.parametric/quantity.md) for construction, dimension checking, and dispatch.
+`ParametricQuantity` lives in the separate [`unxts.parametric`](../packages/unxts.parametric/index) package; see its [guide](../packages/unxts.parametric/quantity) for construction, dimension checking, and dispatch.
 
 ## Mixing Astropy and `unxt` Quantities Under `jit`
 
@@ -429,7 +429,7 @@ os.environ["UNXT_ENABLE_RUNTIME_TYPECHECKING"] = "beartype.beartype"
 
 ## Quantity as a PyTree: JAX flattening overhead
 
-See the [Performance Guide](perf.md)
+See the [Performance Guide](perf)
 
 ### ❌ Problem: Quantity is slower than Array
 
@@ -470,11 +470,11 @@ This only applies to the outer-most function. Nesting jitted and quaxified funct
 
 ## `ParametricQuantity` Equality: Arrays vs. `StaticValue`
 
-A normal `ParametricQuantity` backed by a JAX array returns an element-wise boolean array from `==`, so it can't be a `jax.jit` `static_argnames` argument. Wrapping its value in a `StaticValue` makes `==` return a scalar `bool`, making the quantity hashable and usable as a static argument. This is a `ParametricQuantity` behavior (from the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package); see [Equality with `StaticValue`](../packages/unxts.parametric/sharp-bits.md#equality-with-staticvalue) in the parametric guide.
+A normal `ParametricQuantity` backed by a JAX array returns an element-wise boolean array from `==`, so it can't be a `jax.jit` `static_argnames` argument. Wrapping its value in a `StaticValue` makes `==` return a scalar `bool`, making the quantity hashable and usable as a static argument. This is a `ParametricQuantity` behavior (from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package); see [Equality with `StaticValue`](../packages/unxts.parametric/sharp-bits) in the parametric guide.
 
 ## See Also
 
 - [JAX Common Gotchas](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html)
-- [Quantity Guide](quantity.md)
-- [Type Checking Guide](type-checking.md)
-- [Testing Guide](../packages/unxt-hypothesis/testing-guide.md)
+- [Quantity Guide](./quantity)
+- [Type Checking Guide](./type-checking)
+- [Hypothesis strategies](../packages/unxts.hypothesis/index)

--- a/docs/guides/type-checking.md
+++ b/docs/guides/type-checking.md
@@ -9,7 +9,7 @@
 
 ## TL;DR
 
-You can annotate the **dtype** and **shape** of a `Quantity` — checked statically, and at runtime. To _also_ constrain the physical **dimension** of an argument, use the dimension-parametrized `ParametricQuantity` from the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package; see [Dimension annotations for type checking](../packages/unxts.parametric/type-checking.md).
+You can annotate the **dtype** and **shape** of a `Quantity` — checked statically, and at runtime. To _also_ constrain the physical **dimension** of an argument, use the dimension-parametrized `ParametricQuantity` from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package; see [Dimension annotations for type checking](../packages/unxts.parametric/type-checking).
 
 In the following example we define a function over two 1-D, equally-shaped float arrays and return their elementwise ratio:
 
@@ -98,4 +98,4 @@ Quantity(Array([2.], dtype=float32), unit='m / s')
 
 ## Dimension annotations
 
-The default {class}`unxt.quantity.Quantity` carries **dtype and shape** in its type, but no dimension — so `Quantity[<dimension>]` **does nothing** (it is informational only). To additionally check the physical **dimension** of an argument (e.g. `up.PQ["length"]`), use `ParametricQuantity` from the separate [`unxts.parametric`](../packages/unxts.parametric/index.md) package, which encodes the dimension in its _type_. For construction, dimension inference/checking, and the parametric-class theory, see [Dimension annotations for type checking](../packages/unxts.parametric/type-checking.md).
+The default {class}`unxt.quantity.Quantity` carries **dtype and shape** in its type, but no dimension — so `Quantity[<dimension>]` **does nothing** (it is informational only). To additionally check the physical **dimension** of an argument (e.g. `up.PQ["length"]`), use `ParametricQuantity` from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package, which encodes the dimension in its _type_. For construction, dimension inference/checking, and the parametric-class theory, see [Dimension annotations for type checking](../packages/unxts.parametric/type-checking).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,7 +2,7 @@
 
 # Migrating to v2
 
-This guide covers the breaking changes introduced in `unxt` v2: the rename of the quantity classes and the extraction of the parametric quantity into the separate `unxts.parametric` package. If you are starting fresh with `unxt`, you do not need this guide — consult the [Quantity guide](guides/quantity.md) and the [parametric quantity guide](packages/unxts.parametric/index.md) for the current API.
+This guide covers the breaking changes introduced in `unxt` v2: the rename of the quantity classes and the extraction of the parametric quantity into the separate `unxts.parametric` package. If you are starting fresh with `unxt`, you do not need this guide — consult the [Quantity guide](guides/quantity) and the [parametric quantity guide](packages/unxts.parametric/index) for the current API.
 
 ---
 
@@ -112,7 +112,7 @@ The `include_params` display option — whether `repr()`/`str()` show the `['len
 | `u.config.override(quantity_repr__include_params=True)` | `up.config.override(quantity_repr__include_params=True)` |
 | `[tool.unxt.quantity.repr]` → `include_params` | `[tool.unxts.parametric.quantity.repr]` → `include_params` |
 
-Defaults are unchanged (`repr` hides the parameter, `str` shows it). The other display settings (`short_arrays`, `use_short_name`, `named_unit`, `indent`) remain in `unxt.config`. See the [parametric quantity guide](packages/unxts.parametric/index.md#configuration).
+Defaults are unchanged (`repr` hides the parameter, `str` shows it). The other display settings (`short_arrays`, `use_short_name`, `named_unit`, `indent`) remain in `unxt.config`. See the [parametric quantity guide](packages/unxts.parametric/configuration).
 
 ### Config file section renamed to `[tool.unxts.unxt]`
 

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -66,11 +66,11 @@ Quantity(Array(1., dtype=float32), unit='m')
 
 ## Guides
 
-- [Quantity matrices](quantity-matrix.md) — constructing `QuantityMatrix`, indexing, unit conversion, and arithmetic.
-- [Units matrices](units-matrix.md) — the immutable, hashable `UnitsMatrix` unit structure.
-- [Linear algebra](linear-algebra.md) — matmul, transpose, `diag`, `det`, and `inv` with per-element unit tracking.
-- [Tutorial: a heterogeneous metric](tutorial-metric.md) — a worked end-to-end example.
-- [Sharp bits](sharp-bits.md) — the 1-D/2-D restriction and the uniform-unit requirements under `jax.jit`.
+- [Quantity matrices](quantity-matrix) — constructing `QuantityMatrix`, indexing, unit conversion, and arithmetic.
+- [Units matrices](units-matrix) — the immutable, hashable `UnitsMatrix` unit structure.
+- [Linear algebra](linear-algebra) — matmul, transpose, `diag`, `det`, and `inv` with per-element unit tracking.
+- [Tutorial: a heterogeneous metric](tutorial-metric) — a worked end-to-end example.
+- [Sharp bits](sharp-bits) — the 1-D/2-D restriction and the uniform-unit requirements under `jax.jit`.
 
 ## Public API
 

--- a/packages/unxts.linalg/docs/linear-algebra.md
+++ b/packages/unxts.linalg/docs/linear-algebra.md
@@ -42,6 +42,8 @@ Array([2001., 4003.], dtype=float32)
 
 A plain JAX array or an ordinary `unxt.Quantity` on one side is treated as dimensionless / uniform-unit respectively.
 
+(linalg-batches)=
+
 ### Batches
 
 A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and treats _leading_ axes of the value array as batch dimensions. All four products — and the `@` operator — broadcast those batch axes. The `@` operator dispatches on the _logical_ rank (matrix vs vector), so a batch of matrices applied to a batch of vectors "just works":

--- a/packages/unxts.linalg/docs/quantity-matrix.md
+++ b/packages/unxts.linalg/docs/quantity-matrix.md
@@ -1,6 +1,6 @@
 # Quantity matrices
 
-`QuantityMatrix` (alias `QM`) stores one numeric JAX array together with a static [`UnitsMatrix`](units-matrix.md) that gives the unit of **each** logical element. The shape of the unit structure decides whether the object behaves as a heterogeneous vector (1-D) or matrix (2-D).
+`QuantityMatrix` (alias `QM`) stores one numeric JAX array together with a static [`UnitsMatrix`](units-matrix) that gives the unit of **each** logical element. The shape of the unit structure decides whether the object behaves as a heterogeneous vector (1-D) or matrix (2-D).
 
 ```{code-block} python
 >>> import jax.numpy as jnp

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -53,8 +53,8 @@ By contrast `qnp.diag` lowers to a `gather`, whose indices are traced under `jit
 
 ## The `matmul` _function_ can't do a batched matrix-vector product
 
-A batched vector's value `(B, K)` is shape-indistinguishable from a matrix. The **`@` operator is fine** — `QuantityMatrix.__matmul__` dispatches on the logical rank, so `A @ v` correctly does a (batched) matrix-vector product. But the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` infer their contraction from the value shapes and so cannot; they silently succeed only when the sizes coincide and otherwise raise. `unxts.linalg.matmul` refuses a batched vector operand outright, pointing you at `matvec`. Prefer `@`, `ul.matvec`, or `ul.vecmat`. See [Linear algebra](linear-algebra.md#batches).
+A batched vector's value `(B, K)` is shape-indistinguishable from a matrix. The **`@` operator is fine** — `QuantityMatrix.__matmul__` dispatches on the logical rank, so `A @ v` correctly does a (batched) matrix-vector product. But the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` infer their contraction from the value shapes and so cannot; they silently succeed only when the sizes coincide and otherwise raise. `unxts.linalg.matmul` refuses a batched vector operand outright, pointing you at `matvec`. Prefer `@`, `ul.matvec`, or `ul.vecmat`. See [Linear algebra](linear-algebra).
 
 ## It is a Quax type, not a materialisable array
 
-`QuantityMatrix` is a `quax` array-ish value: it flows through `quax.quaxify`-ed functions but refuses to _materialise_ into a plain array (its elements have no single dtype-plus-unit), so use `.value` / `.unit` to inspect it, and `plum.convert(..., u.Q)` only when every unit is identical (see [Quantity matrices](quantity-matrix.md)).
+`QuantityMatrix` is a `quax` array-ish value: it flows through `quax.quaxify`-ed functions but refuses to _materialise_ into a plain array (its elements have no single dtype-plus-unit), so use `.value` / `.unit` to inspect it, and `plum.convert(..., u.Q)` only when every unit is identical (see [Quantity matrices](quantity-matrix)).

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -53,7 +53,7 @@ By contrast `qnp.diag` lowers to a `gather`, whose indices are traced under `jit
 
 ## The `matmul` _function_ can't do a batched matrix-vector product
 
-A batched vector's value `(B, K)` is shape-indistinguishable from a matrix. The **`@` operator is fine** — `QuantityMatrix.__matmul__` dispatches on the logical rank, so `A @ v` correctly does a (batched) matrix-vector product. But the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` infer their contraction from the value shapes and so cannot; they silently succeed only when the sizes coincide and otherwise raise. `unxts.linalg.matmul` refuses a batched vector operand outright, pointing you at `matvec`. Prefer `@`, `ul.matvec`, or `ul.vecmat`. See [Linear algebra](linear-algebra).
+A batched vector's value `(B, K)` is shape-indistinguishable from a matrix. The **`@` operator is fine** — `QuantityMatrix.__matmul__` dispatches on the logical rank, so `A @ v` correctly does a (batched) matrix-vector product. But the raw **function** forms `jnp.matmul` / `quaxed.numpy.matmul` infer their contraction from the value shapes and so cannot; they silently succeed only when the sizes coincide and otherwise raise. `unxts.linalg.matmul` refuses a batched vector operand outright, pointing you at `matvec`. Prefer `@`, `ul.matvec`, or `ul.vecmat`. See {ref}`Batches <linalg-batches>`.
 
 ## It is a Quax type, not a materialisable array
 

--- a/packages/unxts.linalg/docs/tutorial-metric.md
+++ b/packages/unxts.linalg/docs/tutorial-metric.md
@@ -70,7 +70,7 @@ For a uniform-unit metric the inverse carries the single reciprocal unit:
 ## Recap
 
 - A `QuantityMatrix` let us attach a distinct unit to every entry of the metric — impossible with a single-unit `unxt.Quantity`.
-- `.diag()` and `det` propagated those per-element units automatically; `inv` is defined for uniform units (see [Sharp bits](sharp-bits.md)).
+- `.diag()` and `det` propagated those per-element units automatically; `inv` is defined for uniform units (see [Sharp bits](sharp-bits)).
 - Everything is plain JAX underneath, so the same objects flow through `jax.jit`, `jax.grad`, and `jax.vmap`.
 
-See [Sharp bits](sharp-bits.md) for the current restrictions (1-D/2-D only, and the uniform-unit requirements of `inv` and of `diag` under `jax.jit`).
+See [Sharp bits](sharp-bits) for the current restrictions (1-D/2-D only, and the uniform-unit requirements of `inv` and of `diag` under `jax.jit`).

--- a/packages/unxts.linalg/docs/units-matrix.md
+++ b/packages/unxts.linalg/docs/units-matrix.md
@@ -1,6 +1,6 @@
 # Units matrices
 
-`UnitsMatrix` is the immutable, hashable unit structure carried by a [`QuantityMatrix`](quantity-matrix.md). It wraps a 1-D or 2-D structure of `unxt.AbstractUnit` objects and provides tuple-style indexing, transposition, and serialization. Because it is hashable and static, it lives in a `QuantityMatrix`'s pytree _aux data_, so it is available concretely even under `jax.jit`.
+`UnitsMatrix` is the immutable, hashable unit structure carried by a [`QuantityMatrix`](quantity-matrix). It wraps a 1-D or 2-D structure of `unxt.AbstractUnit` objects and provides tuple-style indexing, transposition, and serialization. Because it is hashable and static, it lives in a `QuantityMatrix`'s pytree _aux data_, so it is available concretely even under `jax.jit`.
 
 ```{code-block} python
 >>> import unxt as u

--- a/packages/unxts.parametric/docs/configuration.md
+++ b/packages/unxts.parametric/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-`unxts.parametric.config` — the parametric counterpart to `unxt.config`. It controls whether the dimension type parameter (e.g. `['length']`) appears in a `ParametricQuantity`'s `repr()` / `str()`. The other display settings (`short_arrays`, `use_short_name`, `named_unit`, `indent`) are shared with all quantities and remain in `unxt.config`; see the [unxt Configuration guide](../../guides/configuration.md).
+`unxts.parametric.config` — the parametric counterpart to `unxt.config`. It controls whether the dimension type parameter (e.g. `['length']`) appears in a `ParametricQuantity`'s `repr()` / `str()`. The other display settings (`short_arrays`, `use_short_name`, `named_unit`, `indent`) are shared with all quantities and remain in `unxt.config`; see the [unxt Configuration guide](../../guides/configuration).
 
 ```{code-block} python
 >>> import unxt as u

--- a/packages/unxts.parametric/docs/dimensions.md
+++ b/packages/unxts.parametric/docs/dimensions.md
@@ -1,6 +1,6 @@
 # Dimensions
 
-How `unxt.dimension_of` interacts with parametric quantities. For dimensions in general, see the [unxt Dimensions guide](../../guides/dimensions.md).
+How `unxt.dimension_of` interacts with parametric quantities. For dimensions in general, see the [unxt Dimensions guide](../../guides/dimensions).
 
 ```{code-block} python
 >>> import unxt as u
@@ -20,4 +20,4 @@ PhysicalType('length')
 can only get dimensions from parametrized ParametricQuantity -- ParametricQuantity[dim].
 ```
 
-The default `Quantity` carries no dimension, so `dimension_of` on the _class_ raises (only instances have a unit, and hence a dimension) — see the [unxt Dimensions guide](../../guides/dimensions.md).
+The default `Quantity` carries no dimension, so `dimension_of` on the _class_ raises (only instances have a unit, and hence a dimension) — see the [unxt Dimensions guide](../../guides/dimensions).

--- a/packages/unxts.parametric/docs/index.md
+++ b/packages/unxts.parametric/docs/index.md
@@ -13,7 +13,7 @@ sharp-bits
 
 `unxts.parametric` provides `ParametricQuantity` (alias `PQ`): a quantity that encodes its physical **dimension** in its _type_. It is the opt-in counterpart to the lightweight, non-parametric default `unxt.Quantity`.
 
-`ParametricQuantity` used to be the default `Quantity` in `unxt` v1. As of v2 the non-parametric class is the default and the parametric class lives here, in its own package. See the [migration guide](../../migration.md) for the full mapping.
+`ParametricQuantity` used to be the default `Quantity` in `unxt` v1. As of v2 the non-parametric class is the default and the parametric class lives here, in its own package. See the [migration guide](../../migration) for the full mapping.
 
 ## Install
 
@@ -69,11 +69,11 @@ Everything else — arithmetic, unit conversion, JAX transforms, interop — wor
 
 ## Guides
 
-- [Parametric Quantities](quantity.md) — construction, runtime dimension checking, dimension-specific dispatch.
-- [Dimensions](dimensions.md) — `dimension_of` on a parametric class.
-- [Type Checking](type-checking.md) — dimension annotations enforced at runtime.
-- [Configuration](configuration.md) — the `include_params` display option.
-- [Sharp Bits](sharp-bits.md) — pytree-type proliferation and `StaticValue` equality.
+- [Parametric Quantities](./quantity) — construction, runtime dimension checking, dimension-specific dispatch.
+- [Dimensions](dimensions) — `dimension_of` on a parametric class.
+- [Type Checking](type-checking) — dimension annotations enforced at runtime.
+- [Configuration](configuration) — the `include_params` display option.
+- [Sharp Bits](sharp-bits) — pytree-type proliferation and `StaticValue` equality.
 
 ## Public API
 
@@ -81,7 +81,7 @@ Everything else — arithmetic, unit conversion, JAX transforms, interop — wor
 
 - `ParametricQuantity` — the dimension-parametrized quantity (alias `PQ`).
 - `AbstractParametricQuantity` — its abstract base.
-- `config` — the `unxts.parametric.config` singleton (see [Configuration](configuration.md)).
+- `config` — the `unxts.parametric.config` singleton (see [Configuration](configuration)).
 
 Importing `unxts.parametric` also registers, as import side effects, the promotion rules, `plum` conversions, and JAX primitive rules that let `ParametricQuantity` interoperate with the rest of `unxt`.
 

--- a/packages/unxts.parametric/docs/quantity.md
+++ b/packages/unxts.parametric/docs/quantity.md
@@ -1,6 +1,6 @@
 # Parametric Quantities
 
-Constructing a `ParametricQuantity` and its runtime dimension checking. For the lightweight, non-parametric default, see the [unxt Quantity guide](../../guides/quantity.md).
+Constructing a `ParametricQuantity` and its runtime dimension checking. For the lightweight, non-parametric default, see the [unxt Quantity guide](../../guides/quantity).
 
 ```{code-block} python
 >>> import unxt as u

--- a/packages/unxts.parametric/docs/sharp-bits.md
+++ b/packages/unxts.parametric/docs/sharp-bits.md
@@ -1,6 +1,6 @@
 # Sharp Bits
 
-Gotchas specific to `ParametricQuantity`. For the core `unxt` sharp bits, see the [unxt Sharp Bits guide](../../guides/sharp-bits.md).
+Gotchas specific to `ParametricQuantity`. For the core `unxt` sharp bits, see the [unxt Sharp Bits guide](../../guides/sharp-bits).
 
 ```{code-block} python
 >>> import unxt as u

--- a/packages/unxts.parametric/docs/type-checking.md
+++ b/packages/unxts.parametric/docs/type-checking.md
@@ -1,6 +1,6 @@
 # Type Checking
 
-Annotating and checking the physical **dimension** of an argument. For enabling runtime type checking and for dtype/shape annotations on the default `Quantity`, see the [unxt Type Checking guide](../../guides/type-checking.md).
+Annotating and checking the physical **dimension** of an argument. For enabling runtime type checking and for dtype/shape annotations on the default `Quantity`, see the [unxt Type Checking guide](../../guides/type-checking).
 
 ```{code-block} python
 >>> import unxt as u


### PR DESCRIPTION
**Nothing gated Sphinx output.** There is no docs job in CI, and the `docs` nox
session builds with `--keep-going` and no `-W`, so it exits 0 no matter what it
reports. `.readthedocs.yaml` sets `sphinx.fail_on_warning`, but that key is
ignored when `build.commands` is present — and it is. So **43 broken
cross-references had accumulated on main**, invisible to readers: a dropped MyST
link still renders as styled text, just not clickable.

## Root cause

A relative link written with a `.md` suffix is resolved by MyST through the
*filesystem*, which follows the `docs/packages/*` symlinks out of the Sphinx
srcdir and drops the link. The extension-less form goes through the docname
registry and resolves. Same file, same line proves it — `dimensions.md` links to
the parametric package twice, and only the `.md`-suffixed one was dropped.

## Fixes

- **51 `.md`-suffixed relative links** de-suffixed across the core guides and
  the linalg/parametric package docs.
- One **dead target**: `sharp-bits.md` linked `../packages/unxt-hypothesis/testing-guide`,
  which does not exist and used the legacy shim name → the real hypothesis page.
- One **wrong target**: `migration.md` linked `parametric/index#configuration`,
  but that page has no Configuration heading → the configuration page.
- **3 `](quantity)` links disambiguated** (`./quantity`) — de-suffixing made them
  ambiguous with the `unxt.quantity` module. I checked the rebuild rather than
  assuming the suffix fix was side-effect-free; these were the side effect.

Docs build warnings: `myst.xref_missing` **43 → 0**, `myst.xref_ambiguous` **0**,
total **169 → 125**.

## The gate

A new `docs` job (in the CI Pass `needs` list, **not** `allowed-skips`) builds
the docs and greps the log for `myst.xref_missing`.

It gates **that one category** — the one that means navigation is broken — rather
than `-W`. Full `-W` would also fail on ~120 nitpicky `ref.*` warnings for
unresolvable third-party type annotations, which are curated separately via
`nitpick_ignore` in `docs/conf.py`. Ratcheting those to zero is worth doing, but
blocking every PR on it first is not; this can tighten to `-W` once they're
cleared.

Verified the gate actually bites: it fails on the pre-fix build log (43 broken)
and passes on the post-fix log (0). This is the check that would have caught the
symlink bug on day one.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)