### PR TITLE
💥 boom(unitsystems): no-arg unitsystem() is now dimensionless

### DIFF
--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -91,7 +91,20 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
     >>> unitsystem("kpc", "Myr", "Msun", "radian")
     unitsystem(kpc, Myr, solMass, rad)
 
+    With no arguments it is the dimensionless system, agreeing with
+    ``unitsystem(None)`` and ``unitsystem([])``:
+
+    >>> unitsystem()
+    DimensionlessUnitSystem()
+
     """
+    # No units -> the dimensionless system. Building an empty ``UnitSystem()``
+    # here would be a distinct, non-``dimensionless`` class that then answers
+    # every derived-dimension lookup with a silent SI default. Mirror the empty
+    # ``Sequence`` dispatch, which already returns ``dimensionless``.
+    if not args:
+        return dimensionless
+
     # Convert everything to a unit
     args = tuple(map(unit, args))
 

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -48,6 +48,34 @@ def test_unitsystem_from_() -> None:
     assert np.isclose((8 * apyu.Myr).decompose(usys).value, 8 / 50)
 
 
+def test_no_arg_unitsystem_is_dimensionless() -> None:
+    """``unitsystem()`` with no arguments is the dimensionless system.
+
+    Previously it built a base-unit-less ``UnitSystem()`` that was **not**
+    ``dimensionless`` and, worse, answered every derived-dimension lookup with a
+    silent SI default (``unitsystem()["length"] == Unit("m")``). It now returns
+    the ``dimensionless`` singleton, matching ``unitsystem(None)`` and
+    ``unitsystem([])``, which already did.
+    """
+    usys = unitsystem()
+
+    assert usys is dimensionless
+    assert type(usys) is DimensionlessUnitSystem
+    assert usys == dimensionless
+    # Whatever ``dimensionless`` reports for base_units, the no-arg call agrees.
+    assert usys.base_units == dimensionless.base_units
+
+    # It must agree with the other empty spellings.
+    assert unitsystem() is unitsystem(None)
+    assert unitsystem() is unitsystem([])
+
+    # A derived-dimension lookup must NOT silently return an SI unit -- the empty
+    # system defines no length, so this raises just as ``dimensionless`` does
+    # (see ``TestDimensionlessUnitSystem.test_getitem``).
+    with pytest.raises(apyu.UnitConversionError):
+        _ = usys["length"]
+
+
 def test_compare() -> None:
     """Test the `unxt.AbstractUnitSystem.compare` method."""
     usys1 = unitsystem("kpc", "Myr", "radian", "Msun", "mas / yr")


### PR DESCRIPTION
**Breaking change, intentional, before the 2.0 freeze.**

`unitsystem()` with no arguments built a base-unit-less `UnitSystem()` that was
**not** the `dimensionless` singleton, and — worse — answered every
derived-dimension lookup with a silent SI default:

```python
>>> u.unitsystem() == u.unitsystems.dimensionless   # was False
>>> u.unitsystem()["length"]                         # was Unit("m")  ← silent SI
```

A system that defines no units confidently reporting metres for length is the
dangerous part: a forgotten argument produced a plausible-looking object instead
of an error.

## Fix

Both *other* spellings of the empty case already returned `dimensionless`:
`unitsystem(None)` (a dedicated dispatch) and `unitsystem([])` (the `Sequence`
dispatch guards `len(seq) > 0`). Only the variadic `unitsystem(*args)` fell
through to constructing an empty class. This guards it the same way — a
one-line early return mirroring the existing `Sequence` path.

After the fix:

```python
>>> u.unitsystem() is u.unitsystems.dimensionless      # True
>>> u.unitsystem()["length"]                            # raises UnitConversionError
```

`unitsystem()["length"]` now raises `UnitConversionError`, exactly like
`dimensionless["length"]` already does — no more silent SI.

## Breaking surface

`unitsystem()` returns `DimensionlessUnitSystem` rather than an empty
`UnitSystem()`; its `==` / `is` results and derived-dimension lookups change
accordingly. Shipping before 2.0 precisely because the return value and class
are frozen at the tag — deferring would make this a breaking change in 2.x.

## Verification

TDD — new `test_no_arg_unitsystem_is_dimensionless` confirmed failing first,
then green; mutation-verified (reverting the guard fails it). Full CI scope:
**3626 passed**, 49 skipped, 20 xfailed — nothing depended on the old empty
system.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)