### PR TITLE
✨ feat(units): accept astropy function units (mag/dex/dB)

### DIFF
--- a/src/unxt/_src/units.py
+++ b/src/unxt/_src/units.py
@@ -13,19 +13,9 @@ from plum import dispatch
 import unxt_api as uapi
 from unxt.dims import AbstractDimension
 
-# ``Unit`` and ``CompositeUnit`` are subclasses of ``UnitBase``, so the first
-# member already covers them (the previous alias listed all three redundantly).
-# ``FunctionUnitBase`` -- the base of ``mag`` / ``dex`` / ``dB`` -- is a
-# *separate* astropy hierarchy that does not subclass ``UnitBase``, so it must be
-# listed explicitly for ``unit()`` to accept and return it. Function units flow
-# through the rest of the machinery (``dimension_of``, ``Quantity``,
-# ``uconvert``, ``ustrip``) unchanged.
-#
-# ``StructuredUnit`` is deliberately NOT included yet: it is also outside
-# ``UnitBase``, but unlike function units it has no single physical dimension, so
-# ``dimension_of`` has no meaningful answer for it -- accepting it here would
-# build a ``Quantity`` that then raises deeper down. Supporting it is a separate
-# change (it needs a ``dimension_of`` design for structured dimensions).
+# ``FunctionUnitBase`` (mag/dex/dB) is a separate hierarchy from ``UnitBase``, so
+# it is listed explicitly. ``StructuredUnit`` is intentionally excluded: it has
+# no single dimension, so ``dimension_of`` cannot handle it.
 AbstractUnit: TypeAlias = apyu.UnitBase | apyu.FunctionUnitBase
 
 

--- a/src/unxt/_src/units.py
+++ b/src/unxt/_src/units.py
@@ -13,7 +13,20 @@ from plum import dispatch
 import unxt_api as uapi
 from unxt.dims import AbstractDimension
 
-AbstractUnit: TypeAlias = apyu.Unit | apyu.UnitBase | apyu.CompositeUnit
+# ``Unit`` and ``CompositeUnit`` are subclasses of ``UnitBase``, so the first
+# member already covers them (the previous alias listed all three redundantly).
+# ``FunctionUnitBase`` -- the base of ``mag`` / ``dex`` / ``dB`` -- is a
+# *separate* astropy hierarchy that does not subclass ``UnitBase``, so it must be
+# listed explicitly for ``unit()`` to accept and return it. Function units flow
+# through the rest of the machinery (``dimension_of``, ``Quantity``,
+# ``uconvert``, ``ustrip``) unchanged.
+#
+# ``StructuredUnit`` is deliberately NOT included yet: it is also outside
+# ``UnitBase``, but unlike function units it has no single physical dimension, so
+# ``dimension_of`` has no meaningful answer for it -- accepting it here would
+# build a ``Quantity`` that then raises deeper down. Supporting it is a separate
+# change (it needs a ``dimension_of`` design for structured dimensions).
+AbstractUnit: TypeAlias = apyu.UnitBase | apyu.FunctionUnitBase
 
 
 # ===================================================================
@@ -46,6 +59,14 @@ def unit(obj: str, /) -> AbstractUnit:
     >>> m = u.unit("m")
     >>> m
     Unit("m")
+
+    Astropy function units (magnitudes, dex, decibels) are also supported:
+
+    >>> u.unit("mag(AB)")
+    Unit("mag(AB)")
+
+    >>> u.unit("dex(cm/s2)")
+    Unit("dex(cm / s2)")
 
     """
     return apyu.Unit(obj)

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,0 +1,74 @@
+"""Tests for `unxt.units` -- the `unit` constructor and `AbstractUnit` alias."""
+
+import astropy.units as apyu
+import pytest
+from plum import NotFoundLookupError
+
+import unxt as u
+from unxt.units import AbstractUnit
+
+
+class TestUnitFunctionUnits:
+    """`unit()` accepts astropy function units (mag / dex / dB).
+
+    Regression: `AbstractUnit` was `Unit | UnitBase | CompositeUnit`, none of
+    which is a `FunctionUnitBase`. So `unit("mag(AB)")` built a `MagUnit` via
+    `apyu.Unit(...)` but failed its own `-> AbstractUnit` return annotation
+    (`TypeCheckError` under beartype, `TypeError` otherwise), and passing a
+    function-unit object raised `NotFoundLookupError`. The `APYUnits` interop
+    alias already listed `FunctionUnitBase`, so the type surface claimed a
+    support the constructor did not provide.
+    """
+
+    @pytest.mark.parametrize(
+        ("string", "expected"),
+        [
+            ("mag(AB)", "mag(AB)"),
+            ("dex(cm/s2)", "dex(cm / s2)"),
+            ("dB(mW)", "dB(mW)"),
+        ],
+    )
+    def test_from_string(self, string: str, expected: str) -> None:
+        """A function-unit string round-trips to the astropy function unit."""
+        got = u.unit(string)
+        assert isinstance(got, apyu.FunctionUnitBase)
+        assert got == apyu.Unit(expected)
+
+    def test_from_object_is_identity(self) -> None:
+        """A function-unit object passes straight through."""
+        mag = apyu.Unit("mag(AB)")
+        assert u.unit(mag) is mag
+
+    def test_is_abstract_unit(self) -> None:
+        """A function unit is an instance of the (widened) `AbstractUnit`."""
+        assert isinstance(u.unit("mag(AB)"), AbstractUnit)
+
+    def test_function_unit_flows_downstream(self) -> None:
+        """A function unit works end-to-end, not just in the constructor.
+
+        Widening the *type* would be hollow if the rest of the machinery choked
+        on it -- so pin the whole path: dimension, construction, and a
+        round-trip through ``ustrip``.
+        """
+        mag = u.unit("mag(AB)")
+        assert u.dimension_of(mag) is not None  # does not raise
+        q = u.Q(1.0, mag)
+        assert q.unit == mag
+        assert float(u.ustrip(mag, q)) == 1.0
+
+
+class TestUnitStructuredIsNotYetSupported:
+    """`StructuredUnit` is intentionally still rejected -- see the alias comment.
+
+    Unlike function units it has no single physical dimension, so accepting it
+    would build a ``Quantity`` whose ``dimension_of`` raises. Until that is
+    designed, ``unit()`` should reject it *cleanly* at the boundary rather than
+    return a half-usable object. This test pins that boundary so a future
+    widening is a deliberate, tested change.
+    """
+
+    def test_structured_unit_rejected(self) -> None:
+        """`unit()` has no dispatch for a `StructuredUnit`, so it raises."""
+        su = apyu.StructuredUnit((apyu.m, apyu.s))
+        with pytest.raises(NotFoundLookupError):
+            u.unit(su)

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -11,13 +11,8 @@ from unxt.units import AbstractUnit
 class TestUnitFunctionUnits:
     """`unit()` accepts astropy function units (mag / dex / dB).
 
-    Regression: `AbstractUnit` was `Unit | UnitBase | CompositeUnit`, none of
-    which is a `FunctionUnitBase`. So `unit("mag(AB)")` built a `MagUnit` via
-    `apyu.Unit(...)` but failed its own `-> AbstractUnit` return annotation
-    (`TypeCheckError` under beartype, `TypeError` otherwise), and passing a
-    function-unit object raised `NotFoundLookupError`. The `APYUnits` interop
-    alias already listed `FunctionUnitBase`, so the type surface claimed support
-    the constructor did not provide.
+    Regression: `AbstractUnit` excluded `FunctionUnitBase`, so `unit("mag(AB)")`
+    failed its own return annotation and a function-unit object was unmatched.
     """
 
     @pytest.mark.parametrize(
@@ -44,12 +39,7 @@ class TestUnitFunctionUnits:
         assert isinstance(u.unit("mag(AB)"), AbstractUnit)
 
     def test_function_unit_flows_downstream(self) -> None:
-        """A function unit works end-to-end, not just in the constructor.
-
-        Widening the *type* would be hollow if the rest of the machinery choked
-        on it -- so pin the whole path: dimension, construction, and a
-        round-trip through ``ustrip``.
-        """
+        """A function unit works end-to-end: dimension, construction, ustrip."""
         mag = u.unit("mag(AB)")
         assert u.dimension_of(mag) is not None  # does not raise
         q = u.Q(1.0, mag)
@@ -58,13 +48,10 @@ class TestUnitFunctionUnits:
 
 
 class TestUnitStructuredIsNotYetSupported:
-    """`StructuredUnit` is intentionally still rejected -- see the alias comment.
+    """`StructuredUnit` is intentionally rejected -- see the alias comment.
 
-    Unlike function units it has no single physical dimension, so accepting it
-    would build a ``Quantity`` whose ``dimension_of`` raises. Until that is
-    designed, ``unit()`` should reject it *cleanly* at the boundary rather than
-    return a half-usable object. This test pins that boundary so a future
-    widening is a deliberate, tested change.
+    It has no single dimension, so accepting it would build a `Quantity` whose
+    `dimension_of` raises. This pins the boundary until that is designed.
     """
 
     def test_structured_unit_rejected(self) -> None:

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -16,8 +16,8 @@ class TestUnitFunctionUnits:
     `apyu.Unit(...)` but failed its own `-> AbstractUnit` return annotation
     (`TypeCheckError` under beartype, `TypeError` otherwise), and passing a
     function-unit object raised `NotFoundLookupError`. The `APYUnits` interop
-    alias already listed `FunctionUnitBase`, so the type surface claimed a
-    support the constructor did not provide.
+    alias already listed `FunctionUnitBase`, so the type surface claimed support
+    the constructor did not provide.
     """
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
`u.unit()` could not construct astropy **function units** — `mag`, `dex`, `dB` —
despite the interop `APYUnits` alias advertising them, and despite this being a
routine astronomy need:

```python
>>> u.unit("mag(AB)")     # TypeCheckError (beartype) / TypeError
>>> u.unit(apyu.Unit("mag(AB)"))   # NotFoundLookupError
```

## Root cause

The public `AbstractUnit` alias was `Unit | UnitBase | CompositeUnit`. `Unit` and
`CompositeUnit` are both subclasses of `UnitBase`, so it was just `UnitBase`
written three ways. Function units (`MagUnit` / `DexUnit` / `DecibelUnit`) share
the base `FunctionUnitBase`, which is a **separate hierarchy that does not
subclass `UnitBase`** — so the `str` dispatch's `apyu.Unit("mag(AB)")` result
failed the function's own `-> AbstractUnit` return annotation, and the identity
dispatch didn't match a function-unit object.

## Fix

Widen the alias to `UnitBase | FunctionUnitBase` (dropping the two redundant
members). Nothing else changes — the existing dispatches then handle function
units. A downstream sweep confirms they flow through the rest of the machinery
unchanged:

| operation | mag/dex/dB |
|---|---|
| `dimension_of` | ✅ `spectral flux density` |
| `unit_of` | ✅ |
| `u.Q(1.0, mag)` / `.from_` | ✅ |
| `uconvert` | ✅ |
| `ustrip` | ✅ |

## StructuredUnit is deliberately excluded

The original finding lumped `StructuredUnit` in with function units, but the
sweep shows it's different: it's also outside `UnitBase`, but it has **no single
physical dimension**, so `dimension_of(structured)` raises `NotFoundLookupError`.
Including it in the alias would let `u.Q(1.0, structured)` *construct* an object
whose `dimension_of` then raises — strictly worse than today's clean rejection at
the boundary. This PR keeps that clean rejection and **pins it with a test**;
supporting structured units needs a `dimension_of` design for structured
dimensions and is a separate change.

## Verification

- New `tests/unit/test_units.py` (there was no dedicated units test file):
  function-unit construction from strings and objects, `isinstance(..., AbstractUnit)`,
  an **end-to-end** test (dimension → construct → `ustrip` round-trip), and the
  StructuredUnit-rejection boundary. Confirmed failing first (5 fails).
- pyright now accepts `u.unit("mag(AB)")` (was `reportArgumentType`).
- **No new mypy errors** — baseline 408 unchanged with and without the change.
- Full CI scope: **3633 passed**, 49 skipped, 20 xfailed.

## Note

Widening a public exported alias is itself an API-surface change, best made
before the 2.0 freeze — deferring it would make the widening breaking in 2.x.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)