### PR TITLE
🏷️ types(quantity): make Quantity(1, "m") type-check under pyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,26 @@ jobs:
       - name: Lint
         run: uv run --frozen nox -s lint
 
+  # Static type-checking, scoped to the tests/typing fixture (see
+  # [tool.pyright]). Guards the `Quantity(1, "m")` constructor typing, which
+  # pyright — the only checker that reads equinox's converter field-specifier —
+  # would otherwise silently regress. Pyright-scoped by design; not mypy/ty.
+  pyright:
+    name: Pyright
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install
+        run: uv sync --no-default-groups --group nox --locked
+
+      - name: Type-check
+        run: uv run --frozen nox -s pyright
+
   # Documentation build
   #
   # Nothing previously gated Sphinx output: there was no docs job here, and the
@@ -640,6 +660,7 @@ jobs:
         setup,
         format,
         docs,
+        pyright,
         tests-unxt,
         tests-unxt-api,
         tests-unxt-hypothesis,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,20 @@ repos:
       - id: taplo-format
       # - id: taplo-lint
 
+  # Pyright, scoped to the `tests/typing` fixture (see [tool.pyright]). Runs via
+  # `uv run` so it gets an env where `unxt` and its deps resolve -- a bare
+  # pyright could not import the package. Guards the `Quantity(1, "m")`
+  # constructor typing; runs when any Python / lock / config changes.
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright (typing guard)
+        entry: uv run --frozen --group typecheck --extra all pyright
+        language: system
+        pass_filenames: false
+        files: (\.py$|^pyproject\.toml$|^uv\.lock$)
+        require_serial: true
+
   # - repo: https://github.com/abravalheri/validate-pyproject
   #   rev: v0.23
   #   hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,6 +75,17 @@ def precommit(s: nox.Session, /) -> None:
     s.run("prek", "run", "--all-files", *s.posargs)
 
 
+@session(uv_groups=["typecheck"], uv_extras=["all"], reuse_venv=True)
+def pyright(s: nox.Session, /) -> None:
+    """Type-check the typing smoke fixture with pyright.
+
+    Scoped (via ``[tool.pyright]`` ``include``) to ``tests/typing`` -- the guard
+    for the ``Quantity(1, "m")`` constructor typing. Not the whole tree, which
+    is not yet pyright-clean.
+    """
+    s.run("pyright", *s.posargs)
+
+
 def _parse_pylint_paths(package: PackageEnum, /) -> list[str]:
     # Lint each package in isolation so the ``duplicate-code`` checker does not
     # flag the intentional similarity between a shim and its canonical package.

--- a/packages/unxts.api/src/unxts/api/_src/units.py
+++ b/packages/unxts.api/src/unxts/api/_src/units.py
@@ -5,14 +5,27 @@ Copyright (c) 2023 Galactic Dynamics. All rights reserved.
 
 __all__ = ("unit", "unit_of")
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import plum
 
+if TYPE_CHECKING:
+    # `unit` is liberal in what it accepts (Postel's law): a unit object, a
+    # string, ... -> a unit. Declared here as a plain callable so static
+    # checkers can read the `Any` parameter -- in particular so it works as an
+    # `equinox.field(converter=unit)`, making `Quantity(1, "m")` type-check.
+    # (`plum.dispatch.abstract` erases the signature to an opaque `Function`
+    # that the converter field-specifier cannot introspect.) The `raise` body
+    # keeps pylint from inferring a `None` return for callers (this branch is
+    # type-checking only; the runtime definition is dispatched by plum).
+    def unit(obj: Any, /) -> Any:
+        raise NotImplementedError
 
-@plum.dispatch.abstract
-def unit(obj: Any, /) -> Any:
-    """Construct the units from a units object."""
+else:
+
+    @plum.dispatch.abstract
+    def unit(obj: Any, /) -> Any:
+        """Construct the units from a units object."""
 
 
 @plum.dispatch.abstract

--- a/packages/unxts.parametric/src/unxts/parametric/_src/parametric.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/parametric.py
@@ -9,13 +9,15 @@ import equinox as eqx
 from jaxtyping import Array, Shaped
 from plum import add_promotion_rule, parametric
 
+import unxts.api as uapi
+
 from .base_parametric import AbstractParametricQuantity
 from unxt.quantity import (
     Quantity,
     StaticValue,
     convert_to_quantity_value,
 )
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 @final
@@ -123,7 +125,7 @@ class ParametricQuantity(AbstractParametricQuantity):
     )
     """The value of the `AbstractQuantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,12 @@ dependencies = [
   "packaging>=20.0",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
-  "quax>=0.4.0",
+  "quax>=0.4.2",
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",
   "unxt-api>=2.0.0",
+  "unxts.api>=2.0.0",
   "wadler-lindig>=0.1.5",
   "xmmutablemap>=0.1",
   "zeroth>=1.0.0",
@@ -116,7 +117,7 @@ docs = [
   # Runtime dependencies for notebook execution
   "jax[cpu]>=0.5.3",
   "jaxlib>=0.5.3",
-  "quax>=0.4.0",
+  "quax>=0.4.2",
 ]
 lint = ["prek>=0.3.9", "pylint>=3.3.8"]
 nox = ["nox>=2024.10.9", "nox-uv>=0.6.3"]
@@ -134,6 +135,9 @@ test = [
 ]
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]
 test-mpl = ["pytest-mpl>=0.17.0", "matplotlib>=3.8"]
+# Pinned so the `pyright` guard cannot drift as new pyright releases change
+# diagnostics. Scoped to the `tests/typing` fixture; see [tool.pyright].
+typecheck = ["pyright==1.1.411"]
 workspace = [
   "unxt-api",
   "unxt-hypothesis",
@@ -243,6 +247,16 @@ module = [
   "quaxed.*",
   "unxt.*",
 ]
+
+
+# Pyright is scoped to the typing smoke fixture only -- it guards the
+# `Quantity(1, "m")` constructor typing (see tests/typing/) without asking the
+# whole, not-yet-pyright-clean source tree to pass. Widen `include` when more of
+# the tree is type-checked.
+[tool.pyright]
+include          = ["tests/typing"]
+pythonVersion    = "3.12"           # match `requires-python = ">=3.12"`
+typeCheckingMode = "basic"
 
 
 [tool.pylint]

--- a/src/unxt/_src/quantity/angle.py
+++ b/src/unxt/_src/quantity/angle.py
@@ -5,9 +5,9 @@ __all__ = ("Angle",)
 from typing import final
 
 import equinox as eqx
+import unxts.api as uapi
 from jaxtyping import Array, Real
 
-import unxt_api as uapi
 from .base_angle import AbstractAngle
 from .value import StaticValue, convert_to_quantity_value
 from unxt.units import AbstractUnit

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -6,11 +6,12 @@ __all__ = ("Q", "Quantity")
 from typing import Any, ClassVar
 
 import equinox as eqx
+import unxts.api as uapi
 from jaxtyping import Array, Shaped
 
 from .base import AbstractQuantity
 from .value import StaticValue, convert_to_quantity_value
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 class Quantity(AbstractQuantity):
@@ -34,7 +35,7 @@ class Quantity(AbstractQuantity):
     )
     """The value of the `Quantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     short_name: ClassVar[str] = "Q"

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -9,6 +9,7 @@ from typing import Any, final
 
 import equinox as eqx
 import numpy as np
+import unxts.api as uapi
 import wadler_lindig as wl
 from jaxtyping import ArrayLike
 from plum import add_promotion_rule
@@ -16,7 +17,7 @@ from plum import add_promotion_rule
 from .base import AbstractQuantity, ArrayLikeSequence, same_unit_label
 from .quantity import Quantity
 from .value import StaticValue
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 @final
@@ -66,7 +67,7 @@ class StaticQuantity(AbstractQuantity):
     )
     """The static value of the `AbstractQuantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     def __hash__(self) -> int:

--- a/tests/typing/test_construction.py
+++ b/tests/typing/test_construction.py
@@ -1,0 +1,48 @@
+"""Static-typing smoke test: quantity constructors accept a unit string.
+
+Runs as a normal pytest (the constructors must not raise) AND under the
+`pyright` nox session (the string-unit argument must type-check). Regression
+guard for the `unit`-field converter: the quantity classes use the ``unit`` API
+function (liberal ``Any`` input, Postel's law) as their ``eqx.field`` converter,
+so ``Quantity(1, "m")`` type-checks while ``.unit`` still reads as a unit.
+
+Pyright-scoped: mypy / ty do not implement the `converter` field-specifier
+extension, so they will not validate this. A mypy/ty regression is the trigger
+to revisit a `.pyi` stub.
+"""
+
+from typing import assert_type
+
+import astropy.units as apyu
+
+import unxt as u
+
+
+def test_string_unit_constructors_typecheck_and_run() -> None:
+    """A unit string is accepted by the quantity constructors.
+
+    The ``assert_type`` calls are checked statically by pyright (the actual
+    guard); the runtime assertions make it a real behavioural test too -- the
+    string unit must be parsed to the expected unit.
+    """
+    # The README's first line -- and the bug this guards.
+    assert_type(u.Quantity(1, "m"), u.Quantity)
+
+    # ``Angle`` shares the same ``unit``-field converter. StaticQuantity does
+    # too, but its *value* field is separately opaque to pyright (it types
+    # ``value: StaticValue``, rejecting ``Literal[1]``), so a smoke line for it
+    # would fail pyright for a reason unrelated to this unit-field fix -- a
+    # separate follow-up. ParametricQuantity lives in the ``unxts.parametric``
+    # package and is guarded by that package's own suite.
+    assert_type(u.Angle(1, "rad"), u.Angle)
+
+    # Runtime: the string unit is parsed to the right unit on each constructor.
+    assert u.Quantity(1, "m").unit == apyu.Unit("m")
+    assert u.Q(1.0, "m").unit == apyu.Unit("m")
+    assert u.Angle(1, "rad").unit == apyu.Unit("rad")
+
+    # A real unit object is still accepted and round-trips.
+    assert u.Quantity(1, apyu.Unit("m")).unit == apyu.Unit("m")
+
+    # The ``unit`` field reads back as a unit, not ``str``.
+    assert_type(u.Quantity(1, "m").unit, u.AbstractUnit)

--- a/uv.lock
+++ b/uv.lock
@@ -1984,6 +1984,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "nox"
 version = "2026.4.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2731,6 +2740,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3005,7 +3027,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3014,9 +3036,9 @@ dependencies = [
     { name = "packaging" },
     { name = "plum-dispatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/88/af0d77ee4a7b8c29e6486d6684b5aa59251ae4e37c2b3a029df623e8a818/quax-0.4.2.tar.gz", hash = "sha256:80047bb81db74e330e988eb41a06265d982c20c27fe51c0ade8e3a0266998a15", size = 203720, upload-time = "2026-07-27T15:56:21.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/e9/391ffa7a3c58998f47aa21414d74d817d611e4ee54300d2f70977402ccac/quax-0.4.0-py3-none-any.whl", hash = "sha256:1fa3d9ae506f2404bb1de09ecbcbf12205ec8cfd918dfcb1f65f3a8ce1a396e8", size = 58510, upload-time = "2026-07-22T18:02:22.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fd/978ecf09a54a861cedcce949a2f2ff52b059ba14ab41ce7cb31b5da55784/quax-0.4.2-py3-none-any.whl", hash = "sha256:47f6da78b77222b8c849174969f1935433d0842e412e43dce92d96d587f49248", size = 59368, upload-time = "2026-07-27T15:56:20.243Z" },
 ]
 
 [[package]]
@@ -3753,6 +3775,7 @@ dependencies = [
     { name = "quaxed" },
     { name = "traitlets" },
     { name = "unxt-api" },
+    { name = "unxts-api" },
     { name = "wadler-lindig" },
     { name = "xmmutablemap" },
     { name = "zeroth" },
@@ -3926,6 +3949,9 @@ test-mpl = [
     { name = "matplotlib" },
     { name = "pytest-mpl" },
 ]
+typecheck = [
+    { name = "pyright" },
+]
 workspace = [
     { name = "unxt-api" },
     { name = "unxt-hypothesis" },
@@ -3958,11 +3984,12 @@ requires-dist = [
     { name = "packaging", specifier = ">=20.0" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "quax-blocks", specifier = ">=0.4.1" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "traitlets", specifier = ">=5.0.0" },
     { name = "unxt-api", editable = "packages/unxt-api" },
+    { name = "unxts-api", editable = "packages/unxts.api" },
     { name = "unxts-api", marker = "extra == 'all'", editable = "packages/unxts.api" },
     { name = "unxts-api", marker = "extra == 'workspace'", editable = "packages/unxts.api" },
     { name = "unxts-hypothesis", marker = "extra == 'all'", editable = "packages/unxts.hypothesis" },
@@ -4015,7 +4042,7 @@ dev = [
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },
@@ -4047,7 +4074,7 @@ docs = [
     { name = "myst-nb", specifier = ">=1.1.2" },
     { name = "myst-parser", specifier = ">=0.13" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },
@@ -4098,6 +4125,7 @@ test-mpl = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
 ]
+typecheck = [{ name = "pyright", specifier = "==1.1.411" }]
 workspace = [
     { name = "unxt-api", editable = "packages/unxt-api" },
     { name = "unxt-hypothesis", editable = "packages/unxt-hypothesis" },


### PR DESCRIPTION
`u.Quantity(1, "m")` — the constructor call on the **first line of the README**
and throughout the docs — was a pyright error:

```
error: Argument of type "Literal['m']" cannot be assigned to parameter "unit"
  of type "AbstractUnit" in function "__init__" (reportArgumentType)
```

It works at runtime (a converter parses the string), but any user with pyright
enabled saw an error immediately.

## Root cause

The `unit` field is `unit: AbstractUnit = eqx.field(converter=<unit>)`. Pyright's
`dataclass_transform` support types the generated `__init__` parameter from the
**converter's** signature — but the converter was a `plum` dispatch, which pyright
reads as an opaque `Function`. With no readable call signature it falls back to
the declared field type `AbstractUnit`, which excludes `str`.

## Fix

Use the canonical **`unxts.api.unit`** function directly as the
`eqx.field(converter=...)` on all four `unit` fields — **Quantity,
StaticQuantity, Angle, ParametricQuantity** — and give it a signature pyright can
read: `unxts.api._src.units` declares `unit` as a plain `(obj: Any) -> Any`
callable under `TYPE_CHECKING`, while the runtime definition stays
`@plum.dispatch.abstract`.

`unit` is liberal in what it accepts (Postel's law: a unit object, a string, …
→ a unit), so the generated `__init__` accepts the string and `Quantity(1, "m")`
type-checks — while `q.unit` still reads back as `AbstractUnit` (the field type).
**No runtime change**, and no converter wrapper/shim: the converter *is* the
public API function.

> An earlier revision used a `parse_unit(obj: AbstractUnit | str) -> AbstractUnit`
> wrapper (a `cast` over the dispatch). That was dropped in favour of this
> single-source approach — the API function is the one true converter, so there's
> nothing to keep in sync.

### Trade-off: `unit()`'s own return type

Because the `unxts.api` layer is backend-agnostic (it cannot name astropy's
`AbstractUnit` without inverting the dependency), the `TYPE_CHECKING` signature
is `Any -> Any`, so `u.unit("m")` now reads as `Any` to checkers (it was the
opaque `Function`'s `object` before). The **field** `q.unit` is unaffected — it
reads as `AbstractUnit`. Narrowing `u.unit()`'s public return to `AbstractUnit`
is a possible follow-up (a `unxt.units`-level typed re-export), independent of
this constructor fix.

## Dependencies

- **Requires `quax>=0.4.2`.** quax's `_FastModuleMeta.__call__` was typed
  `-> Any`, which erased construction typing for *every* `quax.Value` subclass
  (incl. `AbstractQuantity`), so `Quantity(...)` inferred `Any` regardless of the
  converter. Fixed upstream in
  [nstarman/quax#198](https://github.com/nstarman/quax/pull/198) (returns the
  concrete type), released in v0.4.2.
- Adds **`unxts.api`** to `dependencies` — core `unxt` now imports it directly.
- Sets `[tool.pyright] pythonVersion = "3.12"` to match `requires-python`
  (the tree uses `from typing import override`, 3.12-only).

## Guard — nothing type-checked in CI before this

No type checker ran in CI or pre-commit, so this fix (and future regressions)
would be invisible. Added:

- **`tests/typing/test_construction.py`** — `assert_type` for `Quantity`/`Angle`
  **plus runtime `assert`s** that each string-unit constructor parses to the
  expected unit (so it validates under pytest too). *StaticQuantity* is omitted
  deliberately (pyright flags its `value` arg — a separate value-field opacity,
  not this unit-field fix); *ParametricQuantity* is guarded in the
  `unxts.parametric` package's own suite rather than coupling unxt's tests to a
  downstream package.
- **A pinned `pyright==1.1.411`** nox session, scoped via `[tool.pyright]`
  `include = ["tests/typing"]` — the tree isn't pyright-clean yet, so this guards
  the constructor typing without gating on the whole source.
- **A pre-commit hook** and a **CI `Pyright` job** in the CI-Pass `needs` gate.

Verified the guard **bites** (errors on the fixture without the fix, 0 with it)
and that `Quantity(1, "m")` reveals as `Quantity` (not `Any`) under quax 0.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
