### PR TITLE
🐛 fix(quantity): truncate integer StaticQuantity division

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -1842,10 +1842,11 @@ def div_p_sqsq(x: StaticQuantity, y: StaticQuantity, /) -> StaticQuantity:
     xv, yv = ustrip(x), ustrip(y)
     xv, yv = promote_dtypes_if_needed((x.dtype, y.dtype), xv, yv)
     # Integer division must *truncate toward zero* to match ``lax.div_p`` (and so
-    # the plain-``Quantity`` rule); ``np.floor_divide`` rounds toward -inf, which
+    # the plain-``Quantity`` rule); plain floor division rounds toward -inf, which
     # disagrees for negative operands. ``xv - np.fmod(xv, yv)`` is exactly
-    # divisible by ``yv``, so ``//`` there gives the truncated quotient without a
-    # float round-trip. Float dtypes use true division.
+    # divisible by ``yv``, so ``np.floor_divide`` there (floor == truncate on an
+    # exact quotient) gives the truncated result without a float round-trip.
+    # Float dtypes use true division.
     result = (
         np.floor_divide(xv - np.fmod(xv, yv), yv)
         if jnp.issubdtype(xv.dtype, jnp.integer)

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -1819,12 +1819,16 @@ def div_p_sqsq(x: StaticQuantity, y: StaticQuantity, /) -> StaticQuantity:
     >>> import unxt as u
     >>> import quaxed.lax as qlax
 
-    Integer division for integer dtypes:
+    Integer division for integer dtypes, truncating toward zero (like
+    ``lax.div``, so a negative operand does not floor):
 
     >>> q1 = u.StaticQuantity(6, "m")
     >>> q2 = u.StaticQuantity(2, "s")
     >>> qlax.div(q1, q2)
     StaticQuantity(array(3), unit='m / s')
+
+    >>> qlax.div(u.StaticQuantity(-7, "m"), u.StaticQuantity(2, "s"))
+    StaticQuantity(array(-3), unit='m / s')
 
     True division for float dtypes:
 
@@ -1837,9 +1841,13 @@ def div_p_sqsq(x: StaticQuantity, y: StaticQuantity, /) -> StaticQuantity:
     u = unit(x.unit / y.unit)
     xv, yv = ustrip(x), ustrip(y)
     xv, yv = promote_dtypes_if_needed((x.dtype, y.dtype), xv, yv)
-    # Use lax.div for integer division, Python / for float division
+    # Integer division must *truncate toward zero* to match ``lax.div_p`` (and so
+    # the plain-``Quantity`` rule); ``np.floor_divide`` rounds toward -inf, which
+    # disagrees for negative operands. ``xv - np.fmod(xv, yv)`` is exactly
+    # divisible by ``yv``, so ``//`` there gives the truncated quotient without a
+    # float round-trip. Float dtypes use true division.
     result = (
-        np.floor_divide(xv, yv)
+        np.floor_divide(xv - np.fmod(xv, yv), yv)
         if jnp.issubdtype(xv.dtype, jnp.integer)
         else np.divide(xv, yv)
     )

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -413,6 +413,7 @@ def test_static_quantity_lax_div_truncates_like_lax() -> None:
     plain-``Quantity`` rule -- for negative operands. Floor and truncate agree
     for positives, which is why the existing doctest (6 / 2) did not catch it.
     """
+    unit = u.unit("m / s")
     for a, b in [(-7, 2), (7, 2), (-7, -2), (7, -2)]:
         expected = int(jax.lax.div(jnp.asarray(a), jnp.asarray(b)))  # truncated
 
@@ -421,11 +422,19 @@ def test_static_quantity_lax_div_truncates_like_lax() -> None:
         got = qlax.div(sa, sb)
         assert isinstance(got, u.StaticQuantity)
         assert int(np.asarray(got.value)) == expected, (a, b)
+        # Integer division stays integer and keeps the divided unit -- not
+        # promoted to float or relabelled.
+        assert got.unit == unit
+        assert np.issubdtype(np.asarray(got.value).dtype, np.integer)
 
-        # ... and it agrees with the plain Quantity rule on the same inputs.
+        # ... and it agrees with the plain Quantity rule on the same inputs,
+        # likewise integer-typed with the divided unit.
         qa = u.Q(jnp.asarray(a), "m")
         qb = u.Q(jnp.asarray(b), "s")
-        assert int(np.asarray(qlax.div(qa, qb).value)) == expected, (a, b)
+        qgot = qlax.div(qa, qb)
+        assert int(np.asarray(qgot.value)) == expected, (a, b)
+        assert qgot.unit == unit
+        assert np.issubdtype(np.asarray(qgot.value).dtype, np.integer)
 
 
 def test_static_quantity_modulo_with_quantity() -> None:

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -14,6 +14,7 @@ from hypothesis import given, strategies as st
 from hypothesis.extra.numpy import arrays as np_arrays
 from plum import promote
 
+import quaxed.lax as qlax
 import quaxed.numpy as qnp
 
 import unxt as u
@@ -402,6 +403,29 @@ def test_static_quantity_division_integer_inputs() -> None:
     assert result.value.dtype == np.float32
     assert np.allclose(result.value, 3.0)
     assert result.unit == u.unit("m / s")
+
+
+def test_static_quantity_lax_div_truncates_like_lax() -> None:
+    """``qlax.div`` on integer StaticQuantities truncates toward zero.
+
+    Regression: the rule used ``np.floor_divide`` (rounds toward -inf), which
+    disagrees with ``lax.div_p`` -- and hence with both raw ``lax.div`` and the
+    plain-``Quantity`` rule -- for negative operands. Floor and truncate agree
+    for positives, which is why the existing doctest (6 / 2) did not catch it.
+    """
+    for a, b in [(-7, 2), (7, 2), (-7, -2), (7, -2)]:
+        expected = int(jax.lax.div(jnp.asarray(a), jnp.asarray(b)))  # truncated
+
+        sa = u.StaticQuantity(np.asarray(a), "m")
+        sb = u.StaticQuantity(np.asarray(b), "s")
+        got = qlax.div(sa, sb)
+        assert isinstance(got, u.StaticQuantity)
+        assert int(np.asarray(got.value)) == expected, (a, b)
+
+        # ... and it agrees with the plain Quantity rule on the same inputs.
+        qa = u.Q(jnp.asarray(a), "m")
+        qb = u.Q(jnp.asarray(b), "s")
+        assert int(np.asarray(qlax.div(qa, qb).value)) == expected, (a, b)
 
 
 def test_static_quantity_modulo_with_quantity() -> None:


### PR DESCRIPTION
`qlax.div` (i.e. `lax.div_p`) on integer `StaticQuantity` operands used
`np.floor_divide`, which rounds toward -∞. But `lax.div_p` **truncates toward
zero** — so a `StaticQuantity` silently disagreed with both raw `lax.div` and
the plain-`Quantity` rule for negative operands:

```python
qlax.div(u.StaticQuantity(-7, "m"), u.StaticQuantity(2, "s"))  # was -4  (floor)
qlax.div(u.Q(-7, "m"),              u.Q(2, "s"))                #     -3  (truncate)
```

Floor and truncate agree for positive operands, which is exactly why the
existing `6 / 2` doctest never caught it.

## Fix

Truncate via `(xv - np.fmod(xv, yv)) // yv`. The numerator is exactly divisible
by `yv`, so `//` there yields the truncated quotient with no float round-trip
(integer-exact, unlike `np.trunc(xv / yv)`). Verified to match `lax.div` across
**all four sign combinations**.

This mirrors the `rem` fix (#740), which likewise moved `StaticQuantity` onto
truncating `np.fmod` semantics to agree with the JAX primitive.

## Tests

`test_static_quantity_lax_div_truncates_like_lax` sweeps the four sign combos and
asserts the `StaticQuantity` result equals both `lax.div` and the plain
`Quantity` rule. Confirmed failing first; mutation-verified (reverting to
`np.floor_divide` fails it). A negative-operand doctest pins the semantics.

Full CI scope: **3637 passed**, 49 skipped, 20 xfailed.

Found in the pre-v2.0 release-gate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)