### PR TITLE
✨ feat(experimental): add unit-checked where()

### DIFF
--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -98,8 +98,10 @@ def where(condition: ArrayLike, x: R, y: AbstractQuantity, /) -> R:
             "wrap a raw array as unxt.Quantity(arr, unit)."
         )
         raise TypeError(msg)
-    # ``y`` -> ``x``'s unit (raises if not convertible); result in ``x``'s unit.
-    xv = ustrip(x.unit, x)
+    # Strip ``x`` in its own unit (no conversion); convert only ``y`` to
+    # ``x``'s unit (raises if not convertible). Converting ``x`` to its own unit
+    # would be needless work and can promote integer dtypes. Result in x's unit.
+    xv = ustrip(x)
     yv = ustrip(x.unit, y)
     return replace(x, value=jax.numpy.where(condition, xv, yv))
 

--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -20,10 +20,11 @@ To import this experimental module
 """
 # pylint: disable=import-error
 
-__all__ = ("grad", "hessian", "jacfwd")
+__all__ = ("grad", "hessian", "jacfwd", "where")
 
 import functools as ft
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any, TypeVar, TypeVarTuple
 from typing_extensions import Unpack
 
@@ -42,6 +43,64 @@ R = TypeVar("R", bound=AbstractQuantity)
 
 def unit_or_none(obj: Any) -> AbstractUnit | None:
     return obj if obj is None else unit(obj)
+
+
+def where(condition: ArrayLike, x: AbstractQuantity, y: AbstractQuantity, /) -> R:
+    """Unit-checked ``where``: both branches must be quantities (experimental).
+
+    A strict alternative to :func:`jax.numpy.where`. Both ``x`` and ``y`` must be
+    quantities (a dimensionless ``Quantity`` is fine). ``y`` is converted to
+    ``x``'s unit -- raising if they are not convertible -- and the result is
+    returned in ``x``'s unit.
+
+    Unlike ``jnp.where``, this will **not** silently reinterpret a raw array as
+    being in the quantity's unit (see the "``jnp.where`` adopts the quantity's
+    unit for a raw-array branch" sharp bit): a raw-array branch is rejected, so
+    wrap it as ``u.Q(arr, unit)`` first. ``jnp.where`` cannot itself be made
+    strict, because JAX lowers masking ops (``triu``/``tril``/``trace``,
+    ``where(mask, q, 0)``) to the same primitive and relies on the raw zero-fill
+    adopting the unit.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt import experimental
+
+    >>> cond = jnp.asarray([True, False])
+
+    ``y`` is converted to ``x``'s unit; the result is in ``x``'s unit:
+
+    >>> experimental.where(cond, u.Q([1.0, 2.0], "m"), u.Q([0.003, 0.004], "km"))
+    Quantity(Array([1., 4.], dtype=float32), unit='m')
+
+    Incompatible units raise:
+
+    >>> try:
+    ...     experimental.where(cond, u.Q([1.0, 2.0], "m"), u.Q([1.0, 2.0], "s"))
+    ... except Exception as e:
+    ...     print(type(e).__name__)
+    UnitConversionError
+
+    A raw-array branch is rejected rather than silently adopting the unit:
+
+    >>> try:
+    ...     experimental.where(cond, u.Q([1.0, 2.0], "m"), jnp.asarray([3.0, 4.0]))
+    ... except TypeError as e:
+    ...     print(e)
+    unxt.experimental.where requires both branches to be Quantities; ...
+
+    """
+    if not isinstance(x, AbstractQuantity) or not isinstance(y, AbstractQuantity):
+        msg = (
+            "unxt.experimental.where requires both branches to be Quantities; "
+            "wrap a raw array as u.Q(arr, unit)."
+        )
+        raise TypeError(msg)
+    # ``y`` -> ``x``'s unit (raises if not convertible); result in ``x``'s unit.
+    xv = ustrip(x.unit, x)
+    yv = ustrip(x.unit, y)
+    return replace(x, value=jax.numpy.where(condition, xv, yv))
 
 
 def grad(

--- a/src/unxt/_src/experimental.py
+++ b/src/unxt/_src/experimental.py
@@ -45,19 +45,20 @@ def unit_or_none(obj: Any) -> AbstractUnit | None:
     return obj if obj is None else unit(obj)
 
 
-def where(condition: ArrayLike, x: AbstractQuantity, y: AbstractQuantity, /) -> R:
+def where(condition: ArrayLike, x: R, y: AbstractQuantity, /) -> R:
     """Unit-checked ``where``: both branches must be quantities (experimental).
 
     A strict alternative to :func:`jax.numpy.where`. Both ``x`` and ``y`` must be
     quantities (a dimensionless ``Quantity`` is fine). ``y`` is converted to
     ``x``'s unit -- raising if they are not convertible -- and the result is
-    returned in ``x``'s unit.
+    returned in ``x``'s unit and concrete type (``x`` typed as ``R`` so a checker
+    sees, e.g., ``Angle`` in -> ``Angle`` out).
 
     Unlike ``jnp.where``, this will **not** silently reinterpret a raw array as
     being in the quantity's unit (see the "``jnp.where`` adopts the quantity's
     unit for a raw-array branch" sharp bit): a raw-array branch is rejected, so
-    wrap it as ``u.Q(arr, unit)`` first. ``jnp.where`` cannot itself be made
-    strict, because JAX lowers masking ops (``triu``/``tril``/``trace``,
+    wrap it as ``unxt.Quantity(arr, unit)`` first. ``jnp.where`` cannot itself be
+    made strict, because JAX lowers masking ops (``triu``/``tril``/``trace``,
     ``where(mask, q, 0)``) to the same primitive and relies on the raw zero-fill
     adopting the unit.
 
@@ -94,7 +95,7 @@ def where(condition: ArrayLike, x: AbstractQuantity, y: AbstractQuantity, /) -> 
     if not isinstance(x, AbstractQuantity) or not isinstance(y, AbstractQuantity):
         msg = (
             "unxt.experimental.where requires both branches to be Quantities; "
-            "wrap a raw array as u.Q(arr, unit)."
+            "wrap a raw array as unxt.Quantity(arr, unit)."
         )
         raise TypeError(msg)
     # ``y`` -> ``x``'s unit (raises if not convertible); result in ``x``'s unit.

--- a/tests/unit/test_experimental_where.py
+++ b/tests/unit/test_experimental_where.py
@@ -1,0 +1,64 @@
+"""Tests for the experimental unit-checked ``where``."""
+
+import astropy.units as apyu
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import unxt as u
+from unxt import experimental
+
+_COND = jnp.asarray([True, False])
+
+
+def test_where_converts_second_branch_to_first_unit() -> None:
+    """``y`` is converted to ``x``'s unit; the result is in ``x``'s unit."""
+    got = experimental.where(_COND, u.Q([1.0, 2.0], "m"), u.Q([0.003, 0.004], "km"))
+    assert got.unit == u.unit("m")
+    assert np.allclose(np.asarray(got.value), [1.0, 4.0])
+
+
+def test_where_incompatible_units_raise() -> None:
+    """Selecting between non-convertible units raises, like ``concat``."""
+    with pytest.raises(apyu.UnitConversionError):
+        experimental.where(_COND, u.Q([1.0, 2.0], "m"), u.Q([1.0, 2.0], "s"))
+
+
+@pytest.mark.parametrize("raw_side", ["x", "y"])
+def test_where_rejects_a_raw_array_branch(raw_side: str) -> None:
+    """A raw-array branch is rejected -- no silent unit adoption.
+
+    This is the whole point of the helper: unlike ``jnp.where`` (which must
+    adopt the unit so JAX masking keeps working), this refuses the ambiguous mix
+    and tells the caller to wrap the array.
+    """
+    q = u.Q([1.0, 2.0], "m")
+    raw = jnp.asarray([3.0, 4.0])
+    x, y = (raw, q) if raw_side == "x" else (q, raw)
+    with pytest.raises(TypeError, match="both branches to be Quantities"):
+        experimental.where(_COND, x, y)
+
+
+def test_where_works_under_jit() -> None:
+    """The unit conversion and selection survive ``jax.jit``."""
+    fn = jax.jit(lambda a, b: experimental.where(_COND, a, b))
+    got = fn(u.Q([1.0, 2.0], "m"), u.Q([0.003, 0.004], "km"))
+    assert got.unit == u.unit("m")
+    assert np.allclose(np.asarray(got.value), [1.0, 4.0])
+
+
+def test_where_preserves_angle_type() -> None:
+    """The result keeps the first branch's concrete type (e.g. ``Angle``)."""
+    x = u.Angle([10.0, 20.0], "deg")
+    y = u.Angle([1.0, 2.0], "rad")
+    got = experimental.where(_COND, x, y)
+    assert isinstance(got, u.Angle)
+    assert got.unit == u.unit("deg")
+
+
+def test_where_dimensionless_branches() -> None:
+    """Two dimensionless quantities select without conversion."""
+    got = experimental.where(_COND, u.Q([1.0, 2.0], ""), u.Q([3.0, 4.0], ""))
+    assert got.unit == u.unit("")
+    assert np.allclose(np.asarray(got.value), [1.0, 4.0])


### PR DESCRIPTION
Adds `unxt.experimental.where` — a strict, opt-in alternative to `jnp.where`
that unit-checks both branches. This is the safe path pointed to by the
`jnp.where` sharp bit (#763).

## Why

`jnp.where(cond, quantity, raw_array)` silently reinterprets the raw array as
being in the quantity's unit, and **it cannot be made strict**: JAX lowers
masking ops (`triu`/`tril`/`trace`, `where(mask, q, 0)`) to the same `select_n`
primitive and relies on the raw zero-fill adopting the unit. At that level a
masking fill is indistinguishable from user data — the operand is always a
tracer, so there's no value or structural signal to split on (established while
investigating #763).

So rather than change the shared primitive, this gives users who want unit
safety an explicit checked function, leaving `jnp.where` (and masking) untouched.

## Behaviour

```python
from unxt import experimental

experimental.where(cond, u.Q([1.,2.], "m"), u.Q([0.003, 0.004], "km"))
# -> Quantity([1., 4.], unit='m')     # y converted to x's unit; result in x's unit

experimental.where(cond, u.Q([1.,2.], "m"), u.Q([1.,2.], "s"))
# -> UnitConversionError               # incompatible, like concat

experimental.where(cond, u.Q([1.,2.], "m"), jnp.asarray([3., 4.]))
# -> TypeError: ... both branches to be Quantities; wrap a raw array as u.Q(arr, unit)
```

- Both branches must be quantities (a dimensionless `Quantity` is fine).
- `y` is converted to `x`'s unit; the result is in `x`'s unit — matching
  `concat`'s "first operand's unit" convention.
- A raw-array branch (either side) is rejected with a clear message.
- Works under `jax.jit`; preserves the first branch's concrete type (e.g.
  `Angle`, verified).

## Scope

In `unxt.experimental` (documented as 🧪 — "may change or be removed"), so it
carries no stability guarantee yet. Auto-documented via the existing
`experimental` automodule (added to `__all__`).

7 tests (conversion, incompatible-raise, raw-array reject on both sides, jit,
Angle-type preservation, dimensionless) + doctests. Full CI scope: **3659
passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)