### PR TITLE
🧹 chore(deps): raise the quax floor to >=0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "packaging>=20.0",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
-  "quax>=0.3.6",
+  "quax>=0.4.0",
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",
@@ -115,7 +115,7 @@ docs = [
   # Runtime dependencies for notebook execution
   "jax[cpu]>=0.5.3",
   "jaxlib>=0.5.3",
-  "quax>=0.3.1",
+  "quax>=0.4.0",
 ]
 lint = ["prek>=0.3.9", "pylint>=3.3.8"]
 nox = ["nox>=2024.10.9", "nox-uv>=0.6.3"]

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -245,7 +245,12 @@ class AbstractQuantity(
     def aval(self) -> jax.core.ShapedArray:
         value = self.value
         if isinstance(value, StaticValue):
-            value = jnp.asarray(value.array)
+            # Use the raw array: ``jax.typeof`` reads its shape/canonical dtype
+            # directly. ``jnp.asarray`` here would *stage* the array (jax >=0.11
+            # routes it through ``lax.stage``), which requires an active trace --
+            # but ``aval`` is called outside any trace (quax caches it at tracer
+            # construction), so staging raised ``'NoneType' has no stage_value``.
+            value = value.array
         return jax.typeof(value)
 
     def enable_materialise(self, _: bool = True) -> "Self":  # noqa: FBT001, FBT002

--- a/uv.lock
+++ b/uv.lock
@@ -3006,7 +3006,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.3.6"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3015,9 +3015,9 @@ dependencies = [
     { name = "packaging" },
     { name = "plum-dispatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/09/7d59f59e558f2fb573abef5a15d107f845d59f2b42cf9c40d7d92f7b13cf/quax-0.3.6.tar.gz", hash = "sha256:f879f9c9945393281cf219b76d4e531ef3b50e88b864041ab159c95305eef451", size = 175831, upload-time = "2026-06-29T20:22:28.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl", hash = "sha256:dbe08ddca8d6df4383feffa5943f7bceaa4d273fd588901d2a5819e36ffce815", size = 40887, upload-time = "2026-06-29T20:22:27.473Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e9/391ffa7a3c58998f47aa21414d74d817d611e4ee54300d2f70977402ccac/quax-0.4.0-py3-none-any.whl", hash = "sha256:1fa3d9ae506f2404bb1de09ecbcbf12205ec8cfd918dfcb1f65f3a8ce1a396e8", size = 58510, upload-time = "2026-07-22T18:02:22.807Z" },
 ]
 
 [[package]]
@@ -3956,7 +3956,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=20.0" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.3.6" },
+    { name = "quax", specifier = ">=0.4.0" },
     { name = "quax-blocks", specifier = ">=0.4.1" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "traitlets", specifier = ">=5.0.0" },
@@ -4012,7 +4012,7 @@ dev = [
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.3.1" },
+    { name = "quax", specifier = ">=0.4.0" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },
@@ -4044,7 +4044,7 @@ docs = [
     { name = "myst-nb", specifier = ">=1.1.2" },
     { name = "myst-parser", specifier = ">=0.13" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.3.1" },
+    { name = "quax", specifier = ">=0.4.0" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },


### PR DESCRIPTION
## What

Bump the declared `quax` minimum from `>=0.3.6` to `>=0.4.0` (and the stale `>=0.3.1` in the `docs` group to match), plus a lock refresh (`quax 0.3.6 → 0.4.0`).

## Why

**quax 0.4.0 is a performance release** — it substantially reduces Python-side dispatch, tracing, and `equinox.Module` construction overhead. unxt is dispatch-heavy, so the payoff on eager (non-jit) paths is large. Measured A/B on this stack (warmed-up `timeit`, min-of-5, only quax changed):

| operation | quax 0.3.7 | quax 0.4.0 | speedup |
|---|---|---|---|
| construct `Quantity(arr, "m")` | 79 µs | 41 µs | **1.9×** |
| eager `q + q2` | 700 µs | 277 µs | **2.5×** |
| eager `q * 2.0` | 697 µs | 251 µs | **2.8×** |
| eager `qnp.sqrt(q)` | 455 µs | 209 µs | **2.2×** |
| `uconvert("km", q)` (astropy-bound) | 342 µs | 302 µs | 1.1× |

Eager arithmetic/dispatch — the quax-dispatch-bound hot path — is ~2.5–2.8× faster; conversion is astropy-bound so gains there are small. JIT-execute paths are XLA-bound and unaffected (expected).

0.4.0 also satisfies the upcoming quax-blocks floor (`quax>=0.3.7`) and keeps unxt's declared minimum honest (0.4.0 is already the effective minimum via quax-blocks).

## Verification

- `uv lock` resolves `quax 0.4.0`; released quaxed 0.10.5 + quax-blocks 0.4.2 accept it; no other packages changed.
- Full CI-scope suite green on quax 0.4.0 (3758 passed); `tests/unit` under beartype (352 passed).
- No code cleanups are unlocked: 0.4.0 is perf/internal only, no API changes — no `_compat` shims, version gates, or fast-paths in unxt to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: fix jax 0.11 `aval` staging (commit 69650b7)

CI's `test-newest` job (`uv sync --upgrade` on py3.14) pulls **jax 0.11.0**, and 27 `StaticQuantity` tests failed there with `AttributeError: 'NoneType' object has no attribute 'stage_value'`.

Isolated it precisely — only the **combination** breaks:

| combo | result |
|---|---|
| quax 0.3.7 + jax 0.11 | ✅ |
| quax 0.4.0 + jax 0.10 | ✅ |
| quax 0.4.0 + jax 0.11 | ❌ |

**Root cause (an unxt bug, not quax):** `AbstractQuantity.aval` materialised a `StaticValue` via `jnp.asarray` before reading its type. Under jax ≥0.11 `jnp.asarray` routes through the new `lax.stage` primitive, which needs an active trace — but `aval` runs *outside* any trace (quax 0.4.0 legitimately caches it at tracer construction). `aval` only needs shape + canonical dtype, so it now reads them straight off the raw array (`jax.typeof(value.array)`) with no staging. Behaviour is unchanged on jax 0.10.

Verified: all 52 `StaticQuantity` tests pass on quax 0.4.0 + jax 0.11, and the full `src/ tests/` suite is green on the newest-deps stack (2945 passed) — so `test-newest` goes green. (The Windows job failure on the earlier run was an unrelated transient `setup-uv` `fetch failed`.)