### PR TITLE
📝 docs(interop): direct-install tabs + API/guide for gala & matplotlib

### DIFF
--- a/packages/unxts.interop.gala/docs/api.md
+++ b/packages/unxts.interop.gala/docs/api.md
@@ -1,0 +1,57 @@
+# `unxts.interop.gala` API
+
+`unxts.interop.gala` exposes two conversion functions. Both are registered as [`plum`](https://beartype.github.io/plum/) conversion methods when the package is imported, so the idiomatic way to use them is through `plum.convert` (shown below). The functions are also importable directly.
+
+```python
+from unxts.interop.gala import (
+    convert_gala_unitsystem_to_unxt_unitsystem,
+    convert_unxt_unitsystem_to_gala_unitsystem,
+)
+```
+
+## `convert_gala_unitsystem_to_unxt_unitsystem(usys)`
+
+Convert a `gala.units.UnitSystem` to a [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem].
+
+```{code-block} python
+
+>>> import gala.units as gu
+>>> from unxts.interop.gala import convert_gala_unitsystem_to_unxt_unitsystem
+
+>>> convert_gala_unitsystem_to_unxt_unitsystem(gu.galactic)
+unitsystem(kpc, Myr, solMass, rad)
+
+```
+
+## `convert_unxt_unitsystem_to_gala_unitsystem(usys)`
+
+Convert a `unxt.unitsystems.AbstractUnitSystem` to a `gala.units.UnitSystem`.
+
+```{code-block} python
+
+>>> import unxt
+>>> from unxts.interop.gala import convert_unxt_unitsystem_to_gala_unitsystem
+
+>>> usys = unxt.unitsystem("galactic")
+>>> convert_unxt_unitsystem_to_gala_unitsystem(usys)
+<UnitSystem (kpc, Myr, solMass, rad)>
+
+```
+
+## Using `plum.convert` (preferred)
+
+The two calls above are equivalent to `plum.convert` with the target type, which is the recommended interface:
+
+```{code-block} python
+
+>>> from plum import convert
+
+>>> convert(gu.galactic, unxt.AbstractUnitSystem)
+unitsystem(kpc, Myr, solMass, rad)
+
+>>> convert(usys, gu.UnitSystem)
+<UnitSystem (kpc, Myr, solMass, rad)>
+
+```
+
+[unxt-AbstractUnitSystem]: https://unxt.readthedocs.io/en/latest/api/unitsystems/#unxt.unitsystems.AbstractUnitSystem

--- a/packages/unxts.interop.gala/docs/guide.md
+++ b/packages/unxts.interop.gala/docs/guide.md
@@ -1,0 +1,72 @@
+# `gala` Interoperability Guide
+
+This guide shows how to convert between [`gala`][gala-link]'s `gala.units.UnitSystem` and `unxt`'s [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem].
+
+## Setup
+
+Importing `unxts.interop.gala` registers the conversions with [`plum`](https://beartype.github.io/plum/) as a side effect. `unxt` imports the package automatically when it is installed, so in practice you usually only need to import `unxt` and `gala`:
+
+```{code-block} python
+
+>>> import unxt
+>>> import gala.units as gu
+
+```
+
+## `gala` → `unxt`
+
+The most direct route is {func}`unxt.unitsystem`, which accepts a `gala.units.UnitSystem`:
+
+```{code-block} python
+
+>>> gu.galactic
+<UnitSystem (kpc, Myr, solMass, rad)>
+
+>>> unxt.unitsystem(gu.galactic)
+unitsystem(kpc, Myr, solMass, rad)
+
+```
+
+Because the conversions are registered with `plum`, you can equivalently use `plum.convert` with the target type:
+
+```{code-block} python
+
+>>> from plum import convert
+
+>>> usys = convert(gu.galactic, unxt.AbstractUnitSystem)
+>>> usys
+unitsystem(kpc, Myr, solMass, rad)
+
+```
+
+## `unxt` → `gala`
+
+The reverse conversion goes through `plum.convert` with `gala.units.UnitSystem` as the target:
+
+```{code-block} python
+
+>>> convert(usys, gu.UnitSystem)
+<UnitSystem (kpc, Myr, solMass, rad)>
+
+```
+
+## Round trip
+
+Converting a unit system to the other library and back yields an equivalent unit system:
+
+```{code-block} python
+
+>>> back = convert(convert(gu.galactic, unxt.AbstractUnitSystem), gu.UnitSystem)
+>>> back
+<UnitSystem (kpc, Myr, solMass, rad)>
+
+```
+
+## See Also
+
+- [API reference](api) — the exposed conversion functions
+- [gala documentation](https://gala.adrian.pw/en/stable/)
+- [unxt unit systems](https://unxt.readthedocs.io/)
+
+[gala-link]: https://gala.adrian.pw/en/stable/
+[unxt-AbstractUnitSystem]: https://unxt.readthedocs.io/en/latest/api/unitsystems/#unxt.unitsystems.AbstractUnitSystem

--- a/packages/unxts.interop.gala/docs/guide.md
+++ b/packages/unxts.interop.gala/docs/guide.md
@@ -4,7 +4,7 @@ This guide shows how to convert between [`gala`][gala-link]'s `gala.units.UnitSy
 
 ## Setup
 
-Importing `unxts.interop.gala` registers the conversions with [`plum`](https://beartype.github.io/plum/) as a side effect. `unxt` imports the package automatically when it is installed, so in practice you usually only need to import `unxt` and `gala`:
+Importing `unxts.interop.gala` registers the conversions with [`plum`](https://beartype.github.io/plum/) as a side effect. `unxt` imports the package automatically when both it and `gala` are importable (`gala` can be absent on some platforms, e.g. Windows, in which case the conversions are not registered), so in practice you usually only need to import `unxt` and `gala`:
 
 ```{code-block} python
 

--- a/packages/unxts.interop.gala/docs/index.md
+++ b/packages/unxts.interop.gala/docs/index.md
@@ -3,11 +3,18 @@
 ```{toctree}
 :maxdepth: 1
 :hidden:
+
+guide
+api
 ```
 
-The [`gala`][gala-link] package provides tools for Galactic dynamics. It is built on top of the [`astropy`][astropy-link] package and adds an additional units tool, the [`gala.units.UnitSystem`][gala-UnitSystem] class that can be used to convert between different unit systems.
+The [`gala`][gala-link] package provides tools for Galactic dynamics. It is built on top of [`astropy`][astropy-link] and adds a units tool, the [`gala.units.UnitSystem`][gala-UnitSystem] class, for working with different unit systems.
 
-`unxts.interop.gala` is the canonical location for `gala` integration, providing conversions between `gala.units.UnitSystem` and [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem] objects. This conversion is automatically enabled if `unxts.interop.gala` is installed. It is compatible with most versions of `gala`, but to ensure that compatible versions of `gala` and `unxt` are installed, the following installation [extra](https://peps.python.org/pep-0508/#extras) is provided:
+`unxts.interop.gala` is the canonical location for `gala` integration. It provides conversions between `gala.units.UnitSystem` and [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem] objects. Importing the package — directly, or transitively via `unxt`, which imports it when installed — registers the conversions as a side effect.
+
+## Installation
+
+The recommended install pins compatible `gala` and `unxt` versions via the `interop-gala` [extra](https://peps.python.org/pep-0508/#extras):
 
 ::::{tab-set}
 
@@ -25,47 +32,48 @@ uv add "unxt[interop-gala]"
 pip install "unxt[interop-gala]"
 ```
 
+:::
+
 ::::
 
-The following example demonstrates how to convert a `gala` unit system to a `unxt` unit system:
+Or install the package directly:
+
+::::{tab-set}
+
+:::{tab-item} uv
+
+```bash
+uv add unxts.interop.gala
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install unxts.interop.gala
+```
+
+:::
+
+::::
+
+## Quick example
 
 ```{code-block} python
 
 >>> import unxt
 >>> import gala.units as gu
 
->>> gu.galactic  # gala unit system
+>>> gu.galactic  # a gala unit system
 <UnitSystem (kpc, Myr, solMass, rad)>
 
->>> unxt.unitsystem(gu.galactic)  # unxt unit system
+>>> unxt.unitsystem(gu.galactic)  # as a unxt unit system
 unitsystem(kpc, Myr, solMass, rad)
 
 ```
 
-Alternatively, the multiple-dispatch library on which `unxt` is built enables 2-way conversion.
-
-```{code-block} python
->>> from plum import convert
-
->>> usys = convert(gu.galactic, unxt.AbstractUnitSystem)
->>> usys
-unitsystem(kpc, Myr, solMass, rad)
-
->>> convert(usys, gu.UnitSystem)
-<UnitSystem (kpc, Myr, solMass, rad)>
-
-```
-
-## Public API
-
-`unxts.interop.gala` exposes two conversion functions:
-
-- `convert_gala_unitsystem_to_unxt_unitsystem`
-- `convert_unxt_unitsystem_to_gala_unitsystem`
-
-These are `plum.conversion_method`s, registered with `plum`'s dispatch table as a side effect of importing `unxts.interop.gala`. Prefer `plum.convert(usys, ...)` (as shown above) over calling either function directly.
-
-Install: `pip install unxts.interop.gala`
+See the [guide](guide) for two-way conversion, and the [API reference](api) for the exposed functions.
 
 [gala-link]: https://gala.adrian.pw/en/stable/
 [astropy-link]: https://www.astropy.org/

--- a/packages/unxts.interop.gala/docs/index.md
+++ b/packages/unxts.interop.gala/docs/index.md
@@ -10,7 +10,7 @@ api
 
 The [`gala`][gala-link] package provides tools for Galactic dynamics. It is built on top of [`astropy`][astropy-link] and adds a units tool, the [`gala.units.UnitSystem`][gala-UnitSystem] class, for working with different unit systems.
 
-`unxts.interop.gala` is the canonical location for `gala` integration. It provides conversions between `gala.units.UnitSystem` and [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem] objects. Importing the package — directly, or transitively via `unxt`, which imports it when installed — registers the conversions as a side effect.
+`unxts.interop.gala` is the canonical location for `gala` integration. It provides conversions between `gala.units.UnitSystem` and [`unxt.unitsystems.AbstractUnitSystem`][unxt-AbstractUnitSystem] objects. Importing the package — directly, or transitively via `unxt`, which imports it when both the package and `gala` are importable — registers the conversions as a side effect. (`unxt` guards on `gala` too, so on platforms where `gala` is absent the conversions are not registered.)
 
 ## Installation
 

--- a/packages/unxts.interop.matplotlib/docs/api.md
+++ b/packages/unxts.interop.matplotlib/docs/api.md
@@ -11,9 +11,9 @@ from unxts.interop.matplotlib import (
 
 ## `setup_matplotlib_support_for_unxt(*, enable=True)`
 
-Register (or unregister) the `unxt.Quantity` converter with `matplotlib`. It is called with `enable=True` when the package is imported.
+Register (or unregister) the `unxt` quantity converter with `matplotlib`. It is called with `enable=True` when the package is imported.
 
-- `enable` (bool, keyword-only, default `True`): if `True`, register {class}`UnxtConverter` for `unxt.Quantity` so quantities can be plotted; if `False`, remove the registration.
+- `enable` (bool, keyword-only, default `True`): if `True`, register `UnxtConverter` for `unxt.quantity.AbstractQuantity` (which covers `Quantity` and the other quantity types) so quantities can be plotted; if `False`, remove the registration.
 
 ```{code-block} python
 
@@ -28,4 +28,4 @@ setup_matplotlib_support_for_unxt(enable=True)
 
 ## `UnxtConverter`
 
-A `matplotlib.units.ConversionInterface` subclass that teaches `matplotlib` how to turn a `unxt.Quantity` into plottable magnitudes (and to label axes with the unit). It is registered by `setup_matplotlib_support_for_unxt`; you rarely instantiate it yourself.
+A `matplotlib.units.ConversionInterface` subclass that teaches `matplotlib` how to turn an `unxt` quantity (any `AbstractQuantity`) into plottable magnitudes (and to label axes with the unit). It is registered — for `AbstractQuantity` — by `setup_matplotlib_support_for_unxt`; you rarely instantiate it yourself.

--- a/packages/unxts.interop.matplotlib/docs/api.md
+++ b/packages/unxts.interop.matplotlib/docs/api.md
@@ -1,0 +1,31 @@
+# `unxts.interop.matplotlib` API
+
+`unxts.interop.matplotlib` exposes the converter and a function to toggle it. Importing the package enables the converter automatically, so most users never need to call either directly.
+
+```python
+from unxts.interop.matplotlib import (
+    UnxtConverter,
+    setup_matplotlib_support_for_unxt,
+)
+```
+
+## `setup_matplotlib_support_for_unxt(*, enable=True)`
+
+Register (or unregister) the `unxt.Quantity` converter with `matplotlib`. It is called with `enable=True` when the package is imported.
+
+- `enable` (bool, keyword-only, default `True`): if `True`, register {class}`UnxtConverter` for `unxt.Quantity` so quantities can be plotted; if `False`, remove the registration.
+
+```{code-block} python
+
+from unxts.interop.matplotlib import setup_matplotlib_support_for_unxt
+
+# Stop matplotlib from converting Quantity objects
+setup_matplotlib_support_for_unxt(enable=False)
+
+# Re-enable (the default on import)
+setup_matplotlib_support_for_unxt(enable=True)
+```
+
+## `UnxtConverter`
+
+A `matplotlib.units.ConversionInterface` subclass that teaches `matplotlib` how to turn a `unxt.Quantity` into plottable magnitudes (and to label axes with the unit). It is registered by `setup_matplotlib_support_for_unxt`; you rarely instantiate it yourself.

--- a/packages/unxts.interop.matplotlib/docs/guide.md
+++ b/packages/unxts.interop.matplotlib/docs/guide.md
@@ -4,7 +4,7 @@ This guide shows how to plot `unxt.Quantity` objects with [matplotlib](https://m
 
 ## Setup
 
-Importing `unxts.interop.matplotlib` registers a `matplotlib.units.ConversionInterface` for `unxt.Quantity`. `unxt` imports the package automatically when it is installed, so plotting usually just works once the package is present:
+Importing `unxts.interop.matplotlib` registers a `matplotlib.units.ConversionInterface` for `unxt.quantity.AbstractQuantity` (so `Quantity` and the other quantity types work). `unxt` imports the package automatically when it is installed, so plotting usually just works once the package is present:
 
 ```{code-block} python
 

--- a/packages/unxts.interop.matplotlib/docs/guide.md
+++ b/packages/unxts.interop.matplotlib/docs/guide.md
@@ -1,0 +1,58 @@
+# `matplotlib` Interoperability Guide
+
+This guide shows how to plot `unxt.Quantity` objects with [matplotlib](https://matplotlib.org/).
+
+## Setup
+
+Importing `unxts.interop.matplotlib` registers a `matplotlib.units.ConversionInterface` for `unxt.Quantity`. `unxt` imports the package automatically when it is installed, so plotting usually just works once the package is present:
+
+```{code-block} python
+
+import matplotlib.pyplot as plt
+import unxt as u
+```
+
+## Plotting quantities
+
+Pass `Quantity` objects straight to `matplotlib` — the registered converter strips the units to their magnitudes for the axes:
+
+```{code-block} python
+
+import jax.numpy as jnp
+
+x = u.Q(jnp.linspace(0, 360, 100), "deg")
+y = u.Q(jnp.sin(x.ustrip("rad")), "")
+
+plt.plot(x, y)
+```
+
+## Using `quaxed.numpy`
+
+With [`quaxed`](https://quaxed.readthedocs.io/)'s unit-aware `numpy` namespace, the intermediate values stay `Quantity` objects and units propagate through the computation:
+
+```{code-block} python
+
+import quaxed.numpy as jnp
+
+x = u.Q(jnp.linspace(0, 360, 100), "deg")
+y = jnp.sin(x)
+
+plt.plot(x, y)
+```
+
+## Disabling the converter
+
+The converter is enabled on import. To turn it off (or back on) at runtime, use `setup_matplotlib_support_for_unxt` — see the [API reference](api):
+
+```{code-block} python
+
+from unxts.interop.matplotlib import setup_matplotlib_support_for_unxt
+
+setup_matplotlib_support_for_unxt(enable=False)  # stop converting Quantity
+setup_matplotlib_support_for_unxt(enable=True)  # re-enable
+```
+
+## See Also
+
+- [API reference](api) — the converter and its setup function
+- [matplotlib units documentation](https://matplotlib.org/stable/gallery/units/index.html)

--- a/packages/unxts.interop.matplotlib/docs/index.md
+++ b/packages/unxts.interop.matplotlib/docs/index.md
@@ -8,7 +8,7 @@ guide
 api
 ```
 
-`unxts.interop.matplotlib` is the canonical location for [matplotlib](https://matplotlib.org/) integration. Importing the package — or `unxt` itself, which imports it automatically when installed — registers a `matplotlib.units.ConversionInterface` so that `unxt.Quantity` objects can be plotted directly.
+`unxts.interop.matplotlib` is the canonical location for [matplotlib](https://matplotlib.org/) integration. Importing the package — or `unxt` itself, which imports it automatically when installed — registers a `matplotlib.units.ConversionInterface` for `AbstractQuantity`, so `unxt.Quantity` objects (and the other quantity types) can be plotted directly.
 
 ## Installation
 

--- a/packages/unxts.interop.matplotlib/docs/index.md
+++ b/packages/unxts.interop.matplotlib/docs/index.md
@@ -3,11 +3,16 @@
 ```{toctree}
 :maxdepth: 1
 :hidden:
+
+guide
+api
 ```
 
-`unxts.interop.matplotlib` is the canonical location for [matplotlib](https://matplotlib.org/) integration. If installed, `unxt` will automatically detect this and register a converter with `matplotlib` to enable plotting `Quantity` objects.
+`unxts.interop.matplotlib` is the canonical location for [matplotlib](https://matplotlib.org/) integration. Importing the package — or `unxt` itself, which imports it automatically when installed — registers a `matplotlib.units.ConversionInterface` so that `unxt.Quantity` objects can be plotted directly.
 
-To ensure that a compatible version of `matplotlib` is installed, you can install `unxt` with the `interop-mpl` extra:
+## Installation
+
+The recommended install pins a compatible `matplotlib` version via the `interop-mpl` [extra](https://peps.python.org/pep-0508/#extras):
 
 ::::{tab-set}
 
@@ -22,18 +27,38 @@ uv add "unxt[interop-mpl]"
 :::{tab-item} pip
 
 ```bash
-pip install unxt[interop-mpl]
+pip install "unxt[interop-mpl]"
 ```
 
 :::
 
 ::::
 
-Once installed, you can plot `Quantity` objects directly with `matplotlib`:
+Or install the package directly:
 
 ::::{tab-set}
 
-:::{tab-item} jax.numpy
+:::{tab-item} uv
+
+```bash
+uv add unxts.interop.matplotlib
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install unxts.interop.matplotlib
+```
+
+:::
+
+::::
+
+## Quick example
+
+Once installed, plot `Quantity` objects directly with `matplotlib`:
 
 ```{code-block} python
 
@@ -47,22 +72,4 @@ y = u.Q(jnp.sin(x.ustrip("rad")), "")
 plt.plot(x, y)
 ```
 
-:::
-
-:::{tab-item} quaxed.numpy
-
-```{code-block} python
-
-import quaxed.numpy as jnp
-
-x = u.Q(jnp.linspace(0, 360, 100), "deg")
-y = jnp.sin(x)
-
-plt.plot(x, y)
-```
-
-:::
-
-::::
-
-Install: `pip install unxts.interop.matplotlib`
+See the [guide](guide) for more plotting patterns, and the [API reference](api) for toggling the converter.


### PR DESCRIPTION
## What

Bring the `unxts.interop.gala` and `unxts.interop.matplotlib` docs up to parity with the other package docs.

## Background — not a #681 deletion

Unlike unxts.api/hypothesis/xarray, these packages were **extracted** from `src/unxt/_interop/` into namespace packages, *not* deleted — git history has no removed api/guide pages for them. So there was nothing to restore; the single `index.md` was all they ever had. This PR **authors** the missing docs.

## Changes

**Installation** (the direct ask): both indexes now offer a direct `uv add unxts.interop.gala` / `pip install unxts.interop.gala` option (and the matplotlib equivalents) alongside the recommended `unxt[interop-*]` extra. Also fixes a **malformed tab-item fence** in the gala index (the `pip` tab was missing its closing `:::`).

**gala**: new `guide.md` (two-way `UnitSystem` conversion, round-trip) and `api.md` (the two conversion functions + the preferred `plum.convert` interface). Wired both into the index toctree.

**matplotlib**: new `guide.md` (plotting `Quantity`; `jax.numpy` vs `quaxed.numpy`; toggling the converter) and `api.md` (`setup_matplotlib_support_for_unxt`, `UnxtConverter`). Moved the plotting examples out of the index into the guide.

## Verification

- sybil doc-code execution: gala **25**, matplotlib **7** (gala examples exercise the real `gala` ↔ `unxt` conversions; verified reprs).
- `nox -s docs` builds with **zero `myst.xref_missing`** (the new toctree/links resolve); fixed the H1→H3 header-skip the new api pages initially introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)