### PR TITLE
📝 docs: Phase 1 consistency sweep of package landing pages

### DIFF
--- a/packages/unxts.interop.gala/docs/index.md
+++ b/packages/unxts.interop.gala/docs/index.md
@@ -14,7 +14,7 @@ The [`gala`][gala-link] package provides tools for Galactic dynamics. It is buil
 
 ## Installation
 
-The recommended install pins compatible `gala` and `unxt` versions via the `interop-gala` [extra](https://peps.python.org/pep-0508/#extras):
+The recommended install adds `unxts.interop.gala` alongside `unxt` via the `interop-gala` [extra](https://peps.python.org/pep-0508/#extras), so it, `unxt`, and `gala` are resolved together as a compatible set:
 
 ::::{tab-set}
 

--- a/packages/unxts.interop.matplotlib/docs/index.md
+++ b/packages/unxts.interop.matplotlib/docs/index.md
@@ -12,7 +12,7 @@ api
 
 ## Installation
 
-The recommended install pins a compatible `matplotlib` version via the `interop-mpl` [extra](https://peps.python.org/pep-0508/#extras):
+The recommended install adds `unxts.interop.matplotlib` alongside `unxt` via the `interop-mpl` [extra](https://peps.python.org/pep-0508/#extras), so it, `unxt`, and `matplotlib` are resolved together as a compatible set:
 
 ::::{tab-set}
 

--- a/packages/unxts.interop.xarray/docs/index.md
+++ b/packages/unxts.interop.xarray/docs/index.md
@@ -17,20 +17,44 @@ xarray-guide
 
 ## Installation
 
+The recommended install pins compatible `xarray` and `unxt` versions via the `interop-xarray` [extra](https://peps.python.org/pep-0508/#extras):
+
 ::::{tab-set}
+
+:::{tab-item} uv
+
+```bash
+uv add "unxt[interop-xarray]"
+```
+
+:::
 
 :::{tab-item} pip
 
 ```bash
-pip install unxts.interop.xarray
+pip install "unxt[interop-xarray]"
 ```
 
 :::
+
+::::
+
+Or install the package directly:
+
+::::{tab-set}
 
 :::{tab-item} uv
 
 ```bash
 uv add unxts.interop.xarray
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install unxts.interop.xarray
 ```
 
 :::

--- a/packages/unxts.interop.xarray/docs/index.md
+++ b/packages/unxts.interop.xarray/docs/index.md
@@ -17,7 +17,7 @@ xarray-guide
 
 ## Installation
 
-The recommended install pins compatible `xarray` and `unxt` versions via the `interop-xarray` [extra](https://peps.python.org/pep-0508/#extras):
+The recommended install adds `unxts.interop.xarray` alongside `unxt` via the `interop-xarray` [extra](https://peps.python.org/pep-0508/#extras), so it, `unxt`, and `xarray` are resolved together as a compatible set:
 
 ::::{tab-set}
 

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -17,7 +17,7 @@ It is useful for objects whose entries have mixed physical dimensions — Jacobi
 
 ## Install
 
-The recommended install pins compatible `unxt` and `unxts.linalg` versions via the `linalg` [extra](https://peps.python.org/pep-0508/#extras):
+The recommended install adds `unxts.linalg` alongside `unxt` via the `linalg` [extra](https://peps.python.org/pep-0508/#extras), so the two are resolved together as a compatible set:
 
 ::::{tab-set}
 

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -17,6 +17,30 @@ It is useful for objects whose entries have mixed physical dimensions — Jacobi
 
 ## Install
 
+The recommended install pins compatible `unxt` and `unxts.linalg` versions via the `linalg` [extra](https://peps.python.org/pep-0508/#extras):
+
+::::{tab-set}
+
+:::{tab-item} uv
+
+```bash
+uv add "unxt[linalg]"
+```
+
+:::
+
+:::{tab-item} pip
+
+```bash
+pip install "unxt[linalg]"
+```
+
+:::
+
+::::
+
+Or install the package directly:
+
 ::::{tab-set}
 
 :::{tab-item} uv

--- a/packages/unxts.parametric/docs/index.md
+++ b/packages/unxts.parametric/docs/index.md
@@ -51,10 +51,10 @@ Throughout these guides we import `unxt` as `u` and `unxts.parametric` as `up` (
 ```{code-block} python
 
 >>> up.PQ(1.0, "m")  # dimension inferred from the unit
-ParametricQuantity(Array(1., dtype=float32, weak_type=True), unit='m')
+ParametricQuantity(Array(1., dtype=float32, ...), unit='m')
 
 >>> up.PQ["length"](1.0, "m")  # dimension checked against the unit
-ParametricQuantity(Array(1., dtype=float32, weak_type=True), unit='m')
+ParametricQuantity(Array(1., dtype=float32, ...), unit='m')
 
 ```
 

--- a/packages/unxts.parametric/docs/index.md
+++ b/packages/unxts.parametric/docs/index.md
@@ -44,6 +44,22 @@ Throughout these guides we import `unxt` as `u` and `unxts.parametric` as `up` (
 >>> import unxts.parametric as up
 ```
 
+## Quick start
+
+`ParametricQuantity` (`up.PQ`) is used just like `Quantity`, but it encodes the physical dimension in its _type_ — and can check it at construction:
+
+```{code-block} python
+
+>>> up.PQ(1.0, "m")  # dimension inferred from the unit
+ParametricQuantity(Array(1., dtype=float32, weak_type=True), unit='m')
+
+>>> up.PQ["length"](1.0, "m")  # dimension checked against the unit
+ParametricQuantity(Array(1., dtype=float32, weak_type=True), unit='m')
+
+```
+
+The sections below explain when this parametric behaviour is worth its cost.
+
 ## Why the default `Quantity` is non-parametric
 
 `Quantity` (`u.Q`) is the lightweight, non-parametric default: a single class — and a single JAX pytree type — for all physical dimensions. `ParametricQuantity` (`up.PQ`) instead encodes the dimension in its _type_ — `ParametricQuantity["length"]` and `ParametricQuantity["time"]` are distinct Python classes, created on demand, and each is registered as its own JAX pytree node type.
@@ -84,5 +100,3 @@ Everything else — arithmetic, unit conversion, JAX transforms, interop — wor
 - `config` — the `unxts.parametric.config` singleton (see [Configuration](configuration)).
 
 Importing `unxts.parametric` also registers, as import side effects, the promotion rules, `plum` conversions, and JAX primitive rules that let `ParametricQuantity` interoperate with the rest of `unxt`.
-
-Install: `pip install unxts.parametric`


### PR DESCRIPTION
First phase of the docs audit follow-through — **installation consistency + landing-page polish** across the sub-package landing pages.

## Changes

**Installation consistency.** Packages that have an `unxt[…]` extra should offer *both* the recommended extra and the direct install. gala/matplotlib already do (from the recent interop docs work); this brings the two that only showed the direct install into line:
- **unxts.linalg** — add `unxt[linalg]` as the recommended install.
- **unxts.interop.xarray** — add `unxt[interop-xarray]` as the recommended install.

**unxts.parametric landing polish.**
- Add a real **quick start** (construct `up.PQ(1.0, "m")` + the dimension-checked `up.PQ["length"](…)` form, with verified reprs) right after the imports — previously the first constructed example was ~40 lines down, behind the rationale.
- Remove a stray leftover `Install: pip install unxts.parametric` line trailing the page.

## Notes / follow-ups (not in this PR)

- `unxts.parametric` keeps the direct install: unlike `linalg`, it has **no dedicated `unxt[parametric]` extra**. Adding one for parity is a separate packaging decision (pyproject + lock).
- Phases 2–3 of the audit (main-docs structure: stale duplicate nav, quickstart/guide reordering, double-H1s, perf dual-source, natural-units dedup; new getting-started tutorial; parametric interop demo + api.md; linalg vecmat/vecdot/cdict_units examples) are separate.

## Verification

sybil green on every touched package (the parametric quick-start reprs are checked). `nox -s docs` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)