### PR TITLE
📝 docs: Phase 2 audit remediation — nav, headings, Quickstart order, and guide content

### DIFF
--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -129,18 +129,10 @@ def outer_func(x, y):
 %timeit jax.block_until_ready(outer_func(x, y))
 ```
 
-The same pattern scales to more realistic code. Two generalizations come up
-often:
+The same pattern scales to more realistic code. Two generalizations come up often:
 
-- **The inner function is itself built from several unitful operations.**
-  `func2` below calls the quaxified function twice and combines the results.
-  The outer wrapper still hoists every pytree conversion inside a single JIT
-  boundary, so the extra sub-calls cost nothing at the interface.
-- **The units are chosen by a unit system.** Passing a
-  {class}`~unxt.unitsystems.AbstractUnitSystem` as a `static_argnames`
-  argument lets one wrapper serve many unit choices: build the inputs with
-  {meth}`u.Q.from_ <unxt.quantity.Quantity.from_>` and `usys["length"]`, and
-  strip the result with `out.ustrip(usys)`.
+- **The inner function is itself built from several unitful operations.** `func2` below calls the quaxified function twice and combines the results. The outer wrapper still hoists every pytree conversion inside a single JIT boundary, so the extra sub-calls cost nothing at the interface.
+- **The units are chosen by a unit system.** Passing a {class}`~unxt.unitsystems.AbstractUnitSystem` as a `static_argnames` argument lets one wrapper serve many unit choices: build the inputs with {meth}`u.Q.from_ <unxt.quantity.Quantity.from_>` and `usys["length"]`, and strip the result with `out.ustrip(usys)`.
 
 ```{code-cell} ipython3
 def func2(x, y):
@@ -161,8 +153,7 @@ def outer_func3(x, y, *, usys):
     return out.ustrip(usys)
 ```
 
-Timing it shows the same near-baseline performance, now with the working
-units selected at call time:
+Timing it shows the same near-baseline performance, now with the working units selected at call time:
 
 ```{code-cell} ipython3
 usys = u.unitsystems.si

--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -129,6 +129,19 @@ def outer_func(x, y):
 %timeit jax.block_until_ready(outer_func(x, y))
 ```
 
+The same pattern scales to more realistic code. Two generalizations come up
+often:
+
+- **The inner function is itself built from several unitful operations.**
+  `func2` below calls the quaxified function twice and combines the results.
+  The outer wrapper still hoists every pytree conversion inside a single JIT
+  boundary, so the extra sub-calls cost nothing at the interface.
+- **The units are chosen by a unit system.** Passing a
+  {class}`~unxt.unitsystems.AbstractUnitSystem` as a `static_argnames`
+  argument lets one wrapper serve many unit choices: build the inputs with
+  {meth}`u.Q.from_ <unxt.quantity.Quantity.from_>` and `usys["length"]`, and
+  strip the result with `out.ustrip(usys)`.
+
 ```{code-cell} ipython3
 def func2(x, y):
     out1 = jitted_quax_func(x, y)
@@ -147,6 +160,9 @@ def outer_func3(x, y, *, usys):
 
     return out.ustrip(usys)
 ```
+
+Timing it shows the same near-baseline performance, now with the working
+units selected at call time:
 
 ```{code-cell} ipython3
 usys = u.unitsystems.si

--- a/docs/guides/quantity.md
+++ b/docs/guides/quantity.md
@@ -421,13 +421,13 @@ Q([1, 2, 3], unit='m')
 
 See the [`wadler_lindig` documentation](https://docs.kidger.site/wadler_lindig) for more details on the pretty printing options.
 
-# Specialized Quantity Objects
+## Specialized Quantity Objects
 
-## Working with `Angle` Objects
+### Working with `Angle` Objects
 
 The {class}`~unxt.quantity.Angle` class is a specialized quantity for representing angular measurements, similar to {class}`~unxt.quantity.Quantity` but with additional features and constraints tailored for angles.
 
-### Creating Angles
+#### Creating Angles
 
 You can create an {class}`~unxt.quantity.Angle` just like a {class}`~unxt.quantity.Quantity`, by specifying a value and a unit with angular dimensions:
 
@@ -451,7 +451,7 @@ Angle(Array([10, 15, 20], dtype=int32), unit='deg')
 
 ```
 
-### Mathematical Operations
+#### Mathematical Operations
 
 {class}`~unxt.quantity.Angle` objects support arithmetic operations, broadcasting, and most mathematical functions, just like {class}`~unxt.quantity.Quantity`:
 
@@ -467,7 +467,7 @@ Angle(Array(0.7853982, dtype=float32, weak_type=True), unit='rad')
 
 For more information on mathematical operations, see the unxt documentation.
 
-### Enforced Dimensionality
+#### Enforced Dimensionality
 
 Unlike a generic {class}`~unxt.quantity.Quantity`, the {class}`~unxt.quantity.Angle` class enforces that the unit must be angular (e.g., degrees, radians). Attempting to use a non-angular unit will raise an error:
 
@@ -477,7 +477,7 @@ Unlike a generic {class}`~unxt.quantity.Quantity`, the {class}`~unxt.quantity.An
 Angle must have units with angular dimensions.
 ```
 
-### Wrapping Angles
+#### Wrapping Angles
 
 A key feature of {class}`~unxt.quantity.Angle` is the ability to wrap values to a specified range, which is useful for keeping angles within a branch cut:
 
@@ -494,7 +494,7 @@ The {meth}`~unxt.quantity.Angle.wrap_to` method has a function counterpart
 Angle(Array(10, dtype=int32...), unit='deg')
 ```
 
-## Working with `StaticQuantity` Objects
+### Working with `StaticQuantity` Objects
 
 The {class}`~unxt.quantity.StaticQuantity` class is a non-parametric quantity with a static value stored as a NumPy array. It accepts Python scalars and NumPy arrays only, rejecting JAX arrays. This makes it convenient for static arguments in `jax.jit` or `jax.vmap`.
 
@@ -516,7 +516,7 @@ The {class}`~unxt.quantity.StaticQuantity` class is a non-parametric quantity wi
 Quantity(Array([2., 3.], dtype=float32), unit='m')
 ```
 
-## Working with `StaticValue` in a `Quantity`
+### Working with `StaticValue` in a `Quantity`
 
 If you want a {class}`~unxt.Quantity` but need its value to be static (for hashing or static JAX arguments), wrap the value with {class}`~unxt.quantity.StaticValue`. Arithmetic behaves like the wrapped array, and `StaticValue + StaticValue` returns a `StaticValue`:
 
@@ -533,7 +533,7 @@ If you want a {class}`~unxt.Quantity` but need its value to be static (for hashi
 Quantity(Array([4., 6.], dtype=float32), unit='m')
 ```
 
-### Equality returns a scalar `bool`
+#### Equality returns a scalar `bool`
 
 The equality operator on a `Quantity` backed by a `StaticValue` returns a **scalar `bool`**, not an element-wise array. This is the key property that makes it usable as a `static_argnames` argument in {func}`jax.jit`. (This behaviour lives on {class}`~unxt.quantity.AbstractQuantity`, so it applies to every quantity class.)
 
@@ -565,7 +565,7 @@ This contrasts with a regular `Quantity` (JAX array value), where `==` follows N
 Quantity(Array([ True, False], dtype=bool), unit='')
 ```
 
-### Equality vs. equivalence
+#### Equality vs. equivalence
 
 Because `==` on a `StaticValue`-backed quantity is **unit-blind**, reach for {func}`unxt.equivalent` (or the {meth}`~unxt.quantity.AbstractQuantity.is_equivalent` method) when you want a **unit-aware** "same physical quantity" check:
 
@@ -589,7 +589,7 @@ False
 
 **Rule of thumb:** use `==` for structural identity (and as a `jax.jit` `static_argnames` key); use `equivalent` to ask whether two quantities represent the same physical amount regardless of unit. The same `equivalent` function also compares unit systems (see {doc}`units_and_systems`).
 
-### Using `Quantity(StaticValue)` as a `jax.jit` static argument
+#### Using `Quantity(StaticValue)` as a `jax.jit` static argument
 
 Because equality returns `bool` and `StaticValue` is hashable, the whole `Quantity` is hashable, which lets JAX use it as a compile-time constant:
 

--- a/docs/guides/type-checking.md
+++ b/docs/guides/type-checking.md
@@ -96,6 +96,28 @@ Quantity(Array([2.], dtype=float32), unit='m / s')
 
 ```
 
+The check earns its keep when an argument violates its annotation. Both
+parameters above share the axis name `"N"`, so arrays whose shapes disagree are
+rejected before the body runs:
+
+```{code-block} python
+>>> x2 = u.Q([2.0, 3.0], "m")  # shape (2,)
+>>> t2 = u.Q([1.0], "s")       # shape (1,)
+
+>>> try:
+...     velocity(x2, t2)
+... except Exception as e:
+...     print(type(e).__name__)
+TypeCheckError
+
+```
+
+The enforcement here comes from the explicit `@jaxtyped(typechecker=...)`
+decorator. Setting `UNXT_ENABLE_RUNTIME_TYPECHECKING` applies the same checking
+across `unxt` — and to your own annotated functions via the import hook —
+without decorating each one by hand. With no typechecker active the annotations
+are inert: the call would simply broadcast `(2,)` against `(1,)`.
+
 ## Dimension annotations
 
 The default {class}`unxt.quantity.Quantity` carries **dtype and shape** in its type, but no dimension — so `Quantity[<dimension>]` **does nothing** (it is informational only). To additionally check the physical **dimension** of an argument (e.g. `up.PQ["length"]`), use `ParametricQuantity` from the separate [`unxts.parametric`](../packages/unxts.parametric/index) package, which encodes the dimension in its _type_. For construction, dimension inference/checking, and the parametric-class theory, see [Dimension annotations for type checking](../packages/unxts.parametric/type-checking).

--- a/docs/guides/type-checking.md
+++ b/docs/guides/type-checking.md
@@ -96,9 +96,7 @@ Quantity(Array([2.], dtype=float32), unit='m / s')
 
 ```
 
-The check earns its keep when an argument violates its annotation. Both
-parameters above share the axis name `"N"`, so arrays whose shapes disagree are
-rejected before the body runs:
+The check earns its keep when an argument violates its annotation. Both parameters above share the axis name `"N"`, so arrays whose shapes disagree are rejected before the body runs:
 
 ```{code-block} python
 >>> x2 = u.Q([2.0, 3.0], "m")  # shape (2,)
@@ -112,11 +110,7 @@ TypeCheckError
 
 ```
 
-The enforcement here comes from the explicit `@jaxtyped(typechecker=...)`
-decorator. Setting `UNXT_ENABLE_RUNTIME_TYPECHECKING` applies the same checking
-across `unxt` — and to your own annotated functions via the import hook —
-without decorating each one by hand. With no typechecker active the annotations
-are inert: the call would simply broadcast `(2,)` against `(1,)`.
+The enforcement here comes from the explicit `@jaxtyped(typechecker=...)` decorator. Setting `UNXT_ENABLE_RUNTIME_TYPECHECKING` applies the same checking across `unxt` — and to your own annotated functions via the import hook — without decorating each one by hand. With no typechecker active the annotations are inert: the call would simply broadcast `(2,)` against `(1,)`.
 
 ## Dimension annotations
 

--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -130,30 +130,11 @@ LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08
 LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
 ```
 
-The defining constants come out to 1 by construction. For example, decomposing the speed of light and Newton's constant into the geometrized system:
-
-```{code-block} python
->>> import numpy as np
->>> from astropy.constants import c, G
-
->>> bool(np.isclose(c.decompose(geometrized).value, 1.0))
-True
-
->>> bool(np.isclose(G.decompose(geometrized).value, 1.0))
-True
-```
-
-The two systems with a remaining free scale accept it as a keyword — `energy` for `HEPUSysFlag` (default `"GeV"`) and `length` for `GeometrizedUSysFlag` (default `"m"`):
-
-```{code-block} python
->>> from unxt.unitsystems import unitsystem, HEPUSysFlag, GeometrizedUSysFlag
-
->>> unitsystem(HEPUSysFlag, energy="TeV")["time"] == hep["time"] / 1000
-True
-
->>> unitsystem(GeometrizedUSysFlag, length="km")["length"]
-Unit("km")
-```
+By construction the defining constants evaluate to 1 in each system, and the
+two systems with a remaining free scale (`HEPUSysFlag`, `GeometrizedUSysFlag`)
+accept it as a keyword. For worked examples on each system — setting those
+scales, recovering familiar values, and the semantics of natural-unit
+quantities — see the {doc}`natural-units` guide.
 
 ### Functions for Unit Systems
 

--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -130,15 +130,11 @@ LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08
 LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
 ```
 
-By construction the defining constants evaluate to 1 in each system, and the
-two systems with a remaining free scale (`HEPUSysFlag`, `GeometrizedUSysFlag`)
-accept it as a keyword. For worked examples on each system — setting those
-scales, recovering familiar values, and the semantics of natural-unit
-quantities — see the {doc}`natural-units` guide.
+By construction the defining constants evaluate to 1 in each system, and the two systems with a remaining free scale (`HEPUSysFlag`, `GeometrizedUSysFlag`) accept it as a keyword. For worked examples on each system — setting those scales, recovering familiar values, and the semantics of natural-unit quantities — see the {doc}`natural-units` guide.
 
 ### Functions for Unit Systems
 
-`unxt` has two primary functions for working with units: `unitsystem` and `unitsystem_of`.
+`unxt` has two primary functions for working with unit systems: `unitsystem` and `unitsystem_of`.
 
 ```{code-block} python
 >>> from unxt.unitsystems import unitsystem, unitsystem_of

--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -49,9 +49,7 @@ Unit("m")
 
 :::
 
-<br><br><br>
-
-# Unit Systems
+## Unit Systems
 
 A unit system is a standardized collection of units used together, such as the International System of Units (SI), the Imperial system, and natural units like Planck or atomic units. Each system defines base units (e.g., meters, kilograms) and derived units (e.g., joules, newtons) for consistent expression of quantities.
 
@@ -63,7 +61,7 @@ A unit system is a standardized collection of units used together, such as the I
 
 :::
 
-## `AbstractUnitSystem` class
+### `AbstractUnitSystem` class
 
 :::{seealso}
 
@@ -84,7 +82,7 @@ This rarely needs to be used. See `unxt.unitsystem`.
 
 ```
 
-## Built-in Unit Systems
+### Built-in Unit Systems
 
 `unxt` provides several built-in unit systems.
 
@@ -112,7 +110,7 @@ unitsystem(kpc, Myr, solMass, rad)
 unitsystem(AU, yr, solMass, rad)
 ```
 
-### Natural unit systems
+#### Natural unit systems
 
 [Natural unit systems](https://en.wikipedia.org/wiki/Natural_units) fix a chosen set of fundamental physical constants to the dimensionless value 1. `unxt` realizes this _numerically_: the base units are chosen so that the named constants evaluate to `1.0`, while the full dimensional structure is preserved. Four systems are built in, available both as named realizations and by string:
 
@@ -157,7 +155,7 @@ True
 Unit("km")
 ```
 
-## Functions for Unit Systems
+### Functions for Unit Systems
 
 `unxt` has two primary functions for working with units: `unitsystem` and `unitsystem_of`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,109 @@ pip install -e .  # editable mode
 
 ## Quickstart
 
+### Creating and Working with Quantity objects
+
+The primary API of {mod}`unxt` is the {class}`~unxt.Quantity` class (the lightweight, non-parametric default). It combines a JAX array with unit information. We currently use [astropy.units][apyunits] for unit handling.
+
+Create a `Quantity` by passing a JAX array-compatible object and a unit:
+
+```{code-block} python
+
+>>> import unxt as u
+
+>>> x = u.Q([1.0, 2.0, 3.0], unit="m")  # same as u.Quantity(...)
+>>> x
+Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
+```
+
+As a shorthand, we also support `u.Q` and specifying units as strings (parsed by `unxt.unit`, using Astropy as the backend):
+
+```{code-block} python
+
+>>> y = u.Q([4.0, 5.0, 6.0], "m")
+>>> y
+Quantity(Array([4., 5., 6.], dtype=float32), unit='m')
+```
+
+The constituent value and unit are accessible as attributes:
+
+```{code-block} python
+>>> x.value
+Array([1., 2., 3.], dtype=float32)
+
+>>> x.unit
+Unit("m")
+
+```
+
+`Quantity` objects obey the rules of unitful arithmetic. For example, adding, multiplying, or dividing two quantities produces a new `Quantity` with the correct units:
+
+```{code-block} python
+
+>>> x + y
+Quantity(Array([5., 7., 9.], dtype=float32), unit='m')
+
+>>> x * y
+Quantity(Array([ 4., 10., 18.], dtype=float32), unit='m2')
+
+>>> x / y
+Quantity(Array([0.25, 0.4 , 0.5 ], dtype=float32), unit='')
+
+```
+
+Arithmetic will raise an error if the units are incompatible:
+
+```{code-block} python
+
+>>> z = u.Q(5.0, "second")
+>>> try: x + z
+... except Exception as e: print(e)
+'s' (time) and 'm' (length) are not convertible
+```
+
+### Converting Units
+
+Quantities can be converted to different units:
+
+::::{tab-set}
+
+:::{tab-item} method
+
+using the explicit syntax
+
+```{code-block} python
+
+>>> x.uconvert("cm")
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
+
+```
+
+or Astropy's API
+
+```{code-block} python
+
+>>> x.to("cm")
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
+
+```
+
+:::
+
+:::{tab-item} function
+
+or a function-oriented approach
+
+```{code-block} python
+
+>>> u.uconvert("cm", x)
+Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
+
+```
+
+:::
+
+::::
+
 ### Dimensions
 
 Dimensions represent the physical nature of quantities (length, time, velocity, etc.). They're independent of the units used to measure them.
@@ -277,109 +380,6 @@ unitsystem(kpc, Myr, ...)
 ```
 
 For more details, see the [Unit Systems Guide](guides/units_and_systems.md).
-
-### Creating and Working with Quantity objects
-
-The primary API of {mod}`unxt` is the {class}`~unxt.Quantity` class (the lightweight, non-parametric default). It combines a JAX array with unit information. We currently use [astropy.units][apyunits] for unit handling.
-
-Create a `Quantity` by passing a JAX array-compatible object and a unit:
-
-```{code-block} python
-
->>> import unxt as u
-
->>> x = u.Q([1.0, 2.0, 3.0], unit="m")  # same as u.Quantity(...)
->>> x
-Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
-```
-
-As a shorthand, we also support `u.Q` and specifying units as strings (parsed by `unxt.unit`, using Astropy as the backend):
-
-```{code-block} python
-
->>> y = u.Q([4.0, 5.0, 6.0], "m")
->>> y
-Quantity(Array([4., 5., 6.], dtype=float32), unit='m')
-```
-
-The constituent value and unit are accessible as attributes:
-
-```{code-block} python
->>> x.value
-Array([1., 2., 3.], dtype=float32)
-
->>> x.unit
-Unit("m")
-
-```
-
-`Quantity` objects obey the rules of unitful arithmetic. For example, adding, multiplying, or dividing two quantities produces a new `Quantity` with the correct units:
-
-```{code-block} python
-
->>> x + y
-Quantity(Array([5., 7., 9.], dtype=float32), unit='m')
-
->>> x * y
-Quantity(Array([ 4., 10., 18.], dtype=float32), unit='m2')
-
->>> x / y
-Quantity(Array([0.25, 0.4 , 0.5 ], dtype=float32), unit='')
-
-```
-
-Arithmetic will raise an error if the units are incompatible:
-
-```{code-block} python
-
->>> z = u.Q(5.0, "second")
->>> try: x + z
-... except Exception as e: print(e)
-'s' (time) and 'm' (length) are not convertible
-```
-
-### Converting Units
-
-Quantities can be converted to different units:
-
-::::{tab-set}
-
-:::{tab-item} method
-
-using the explicit syntax
-
-```{code-block} python
-
->>> x.uconvert("cm")
-Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
-
-```
-
-or Astropy's API
-
-```{code-block} python
-
->>> x.to("cm")
-Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
-
-```
-
-:::
-
-:::{tab-item} function
-
-or a function-oriented approach
-
-```{code-block} python
-
->>> u.uconvert("cm", x)
-Quantity(Array([100., 200., 300.], dtype=float32), unit='cm')
-
-```
-
-:::
-
-::::
 
 ### JAX functions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,6 @@ unxts.linalg <packages/unxts.linalg/index>
 unxts.interop.gala <packages/unxts.interop.gala/index>
 unxts.interop.matplotlib <packages/unxts.interop.matplotlib/index>
 unxts.interop.xarray <packages/unxts.interop.xarray/index>
-unxt-api <packages/unxt-api/index>
-unxt-hypothesis <packages/unxt-hypothesis/index>
 ```
 
 ```{toctree}
@@ -27,13 +25,13 @@ unxt-hypothesis <packages/unxt-hypothesis/index>
 :caption: 📚 Guides
 
 guides/quantity
-guides/configuration
 guides/dimensions
 guides/units_and_systems
 guides/natural-units
 guides/type-checking
 guides/sharp-bits
 Performance Optimization <guides/perf.ipynb>
+guides/configuration
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ guides/units_and_systems
 guides/natural-units
 guides/type-checking
 guides/sharp-bits
-Performance Optimization <guides/perf.ipynb>
+Performance Optimization <guides/perf>
 guides/configuration
 ```
 

--- a/docs/packages/unxt-api
+++ b/docs/packages/unxt-api
@@ -1,1 +1,0 @@
-../../packages/unxts.api/docs

--- a/docs/packages/unxt-hypothesis
+++ b/docs/packages/unxt-hypothesis
@@ -1,1 +1,0 @@
-../../packages/unxts.hypothesis/docs


### PR DESCRIPTION
## Summary

Phase 2 of the docs audit — the full main-docs remediation pass, in five focused commits (structure first, then content).

### Structure

- **Drop stale nav entries.** Removed the `unxt-api` / `unxt-hypothesis` toctree entries and their `docs/packages/` symlinks — pure duplicates of the `unxts.api` / `unxts.hypothesis` package docs (restored in #771). Also clears 3 pre-existing `myst.xref_missing` warnings that pointed at the stale `unxt-api/docs/*` / `unxt-hypothesis/docs/*` paths.
- **Reorder Guides toctree.** `configuration` now comes last: quantity → dimensions → units → natural-units → type-checking → sharp-bits → perf → configuration.
- **Fix double-H1 pages.** `quantity.md` and `units_and_systems.md` each had two `#` H1s; demoted the second and cascade-demoted its subtree so each page has one H1 with correct nesting.
- **Lead the landing Quickstart with `Quantity`.** Was bottom-up (dimensions → units → unit systems → Quantity); now leads with the object the library is about, then the building-block sections, then JAX integration. Namespace-safe block move.

### Content

- **`perf` guide.** Narrated the previously-bare `func2` / `outer_func3` cells (the outer-wrapper pattern generalizing to composed functions and unit systems) + a timing lead-in. Relabelled the toctree to the `guides/perf` docname (`perf.md` is the tracked `md:myst` source; `perf.ipynb` is gitignored and absent on RTD).
- **natural-units dedup.** `units_and_systems.md` duplicated the constant-decomposition proof and free-scale flag examples from the dedicated `natural-units.md` tutorial. Kept the compact 4-system reference listing; deferred the depth to a `{doc}`natural-units`` pointer.
- **`type-checking` guide.** Added an example of runtime checking *catching* a shape mismatch (`jaxtyping.TypeCheckError`) and clarified that enforcement comes from `@jaxtyped` / `UNXT_ENABLE_RUNTIME_TYPECHECKING`, not annotations alone.

## Verification

`nox -s docs`: **0 `myst.xref_missing`**, `build succeeded`. sybil: `index.md` 92 passed, edited guides 59+162 passed.

## Follow-up

The stray gitignored `docs/guides/perf.ipynb` (a jupytext pair, regenerated at build time) is left as-is; it never ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)