### PR TITLE
📝 docs: fill parametric-interop and linalg cdict_units doc gaps (audit Phase 3)

### DIFF
--- a/packages/unxts.linalg/docs/quantity-matrix.md
+++ b/packages/unxts.linalg/docs/quantity-matrix.md
@@ -58,6 +58,20 @@ You may select and reorder a subset of keys:
 '(kg, m)'
 ```
 
+`cdict_units` is the companion that reads the per-key units out of a component dict without building a matrix. It takes the dict and an explicit key order:
+
+```{code-block} python
+>>> ul.cdict_units(v, ("x", "y", "z"))
+(Unit("m"), Unit("s"), Unit("kg"))
+```
+
+Unlike `from_cdict`, it tolerates non-quantity entries, returning `None` for each — useful for inspecting a heterogeneous dict before deciding what to pack:
+
+```{code-block} python
+>>> ul.cdict_units({"x": u.Q(1.0, "m"), "n": 2.0}, ("x", "n"))
+(Unit("m"), None)
+```
+
 ## Indexing
 
 Indexing a 1-D `QuantityMatrix` returns an ordinary `unxt.Quantity` — the element and its scalar unit:

--- a/packages/unxts.parametric/docs/dimensions.md
+++ b/packages/unxts.parametric/docs/dimensions.md
@@ -15,6 +15,9 @@ Because a `ParametricQuantity` encodes its dimension in the _class itself_, `unx
 >>> u.dimension_of(up.PQ["length"])  # a parameterized class carries a dimension
 PhysicalType('length')
 
+>>> u.dimension_of(up.PQ["length"](5.0, "m"))  # as does an instance of it
+PhysicalType('length')
+
 >>> try: u.dimension_of(up.PQ)  # ... the unparameterized class does not
 ... except Exception as e: print(e)
 can only get dimensions from parametrized ParametricQuantity -- ParametricQuantity[dim].

--- a/packages/unxts.parametric/docs/quantity.md
+++ b/packages/unxts.parametric/docs/quantity.md
@@ -51,3 +51,26 @@ Filling a `ParametricQuantity`'s parameter and constructing an instance may be s
 ```
 
 The base class `AbstractParametricQuantity` and the concrete `unxt.Quantity` are _not_ parametric — `Quantity[<dimension>]` does nothing and is informational only. Explore [`plum`](https://beartype.github.io/plum/parametric.html) for more on parametric classes.
+
+## Interoperating with the default `Quantity`
+
+Importing `unxts.parametric` registers promotion rules, so `ParametricQuantity` and the default `Quantity` mix freely in arithmetic. Combining the two yields a `ParametricQuantity`, re-parametrized by the **result's** dimension:
+
+```{code-block} python
+>>> length = up.PQ["length"](2.0, "m")
+>>> plain = u.Q(3.0, "m")
+
+>>> length + plain
+ParametricQuantity(Array(5., dtype=float32, ...), unit='m')
+```
+
+Because the dimension is tracked in the type, operations that change dimension re-parametrize the result — multiplying two lengths promotes the parameter to area:
+
+```{code-block} python
+>>> area = length * up.PQ["length"](5.0, "m")
+>>> area
+ParametricQuantity(Array(10., dtype=float32, ...), unit='m2')
+
+>>> u.dimension_of(area)
+PhysicalType('area')
+```


### PR DESCRIPTION
## Summary

Phase 3 of the docs audit. Most Phase-3 items the audit flagged turned out to be **already covered** by the recent package-doc restoration (#771/#772/#686/#689) — `vecmat`/`vecdot` are in linalg's product table, `from_cdict` is shown, and the "Public API" is documented inline (there is no separate `api.md` convention). What remained were two genuine content gaps, plus a small completion:

- **linalg `cdict_units`** — was only a Public-API bullet. Added a worked example as the companion to `from_cdict`: reading per-key units out of a component dict, with `None` for non-quantity entries.
- **parametric PQ↔Q interop** — the docs said promotion rules exist but never *showed* the behaviour. Added an "Interoperating with the default `Quantity`" section: `PQ + Q` yields a `ParametricQuantity` re-parametrized by the result's dimension, and `PQ * PQ` promotes `length → area`.
- **parametric `dimensions.md`** — rounded out the class-vs-instance point by also showing `dimension_of` on an instance (it previously only showed the parametrized class).

All examples are empirically verified against the runtime before being written.

## Not included (deliberate)

A separate `getting-started.md` tutorial was on the audit list, but the landing-page Quickstart (reworked in #774 to lead with `Quantity`) already fills that role — a second top-level tutorial would duplicate it. Happy to add one if you'd like a longer Diátaxis-style walkthrough distinct from the Quickstart.

## Verification

`nox -s docs`: **0 `myst.xref_missing`**, `build succeeded`, no warnings from the edited files. sybil on the three files: 54 passed. Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)