### PR TITLE
📝 docs: raise myst_heading_anchors to 4 for H4 deep-links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,7 +173,7 @@ myst_enable_extensions = [
     "smartquotes",  # convert straight quotes to curly quotes
     "substitution",  # substitution definitions
 ]
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 
 myst_substitutions = {
     "ArrayLike": ":obj:`jaxtyping.ArrayLike`",


### PR DESCRIPTION
## Summary

Followup to #774. That PR demoted several guide headings to H4 to fix double-H1 structure. With `myst_heading_anchors = 3` in `docs/conf.py`, H4 headings receive no auto-generated anchor and are therefore not deep-linkable.

This bumps the setting to `4` so the demoted headings remain addressable:

- `docs/guides/quantity.md` — "Creating Angles", "Mathematical Operations", "Enforced Dimensionality", "Wrapping Angles", "Equality returns a scalar `bool`", "Equality vs. equivalence", "Using `Quantity(StaticValue)` as a `jax.jit` static argument"
- `docs/guides/units_and_systems.md` — "Natural unit systems"
- `docs/guides/dimensions.md` — "Simple Dimension Names", "Mathematical Expressions", "Whitespace Handling"

No headings are deeper than H4, so `4` is sufficient.

## Context

Nothing currently links to these anchors, so this is not fixing a broken link — it restores deep-link addressability that the #774 heading demotions would otherwise have quietly removed. Surfaced during code review of #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)