### PR TITLE
📦 build: add a `parametric` install extra for parity with `linalg`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ interop-gala = ["unxts.interop.gala"]
 interop-mpl = ["unxts.interop.matplotlib"]
 interop-xarray = ["unxts.interop.xarray"]
 linalg = ["unxts.linalg"]
+parametric = ["unxts.parametric"]
 workspace = [
   "unxt[interop-gala,interop-mpl,interop-xarray]",
   "unxts.api",

--- a/uv.lock
+++ b/uv.lock
@@ -3800,6 +3800,9 @@ k8s = [
 linalg = [
     { name = "unxts-linalg" },
 ]
+parametric = [
+    { name = "unxts-parametric" },
+]
 workspace = [
     { name = "unxts-api" },
     { name = "unxts-hypothesis" },
@@ -3978,12 +3981,13 @@ requires-dist = [
     { name = "unxts-linalg", marker = "extra == 'linalg'", editable = "packages/unxts.linalg" },
     { name = "unxts-linalg", marker = "extra == 'workspace'", editable = "packages/unxts.linalg" },
     { name = "unxts-parametric", marker = "extra == 'all'", editable = "packages/unxts.parametric" },
+    { name = "unxts-parametric", marker = "extra == 'parametric'", editable = "packages/unxts.parametric" },
     { name = "unxts-parametric", marker = "extra == 'workspace'", editable = "packages/unxts.parametric" },
     { name = "wadler-lindig", specifier = ">=0.1.5" },
     { name = "xmmutablemap", specifier = ">=0.1" },
     { name = "zeroth", specifier = ">=1.0.0" },
 ]
-provides-extras = ["all", "backend-astropy", "cpu", "cuda", "cuda12", "cuda12-local", "interop-gala", "interop-mpl", "interop-xarray", "k8s", "linalg", "workspace"]
+provides-extras = ["all", "backend-astropy", "cpu", "cuda", "cuda12", "cuda12-local", "interop-gala", "interop-mpl", "interop-xarray", "k8s", "linalg", "parametric", "workspace"]
 
 [package.metadata.requires-dev]
 build = [{ name = "build", specifier = ">=1.3.0" }]


### PR DESCRIPTION
## Summary

Closes a packaging inconsistency flagged in the v2.0 release-gate audit: `unxts.linalg` has a `linalg` extra, but `unxts.parametric` had none — so `pip install unxt[linalg]` worked while `pip install unxt[parametric]` failed (the package was only reachable via the `workspace` / `all` extras).

Adds `parametric = ["unxts.parametric"]`, mirroring `linalg = ["unxts.linalg"]`.

## Verification

`uv sync --extra parametric` resolves and installs `unxts.parametric` cleanly; `import unxts.parametric` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)