### PR TITLE
💥 boom(unitsystems): make unit-system identity order-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ For domains like gravitational dynamics, use dynamical unit systems where $G = 1
 
 >>> dyn_usys = u.unitsystem(DynamicalSimUSysFlag, "kpc", "Myr")
 >>> dyn_usys
-LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"),
-                         mass=Unit("1.49828e+10 kpc3 s2 kg / (Myr2 m3)"))
+LengthMassTimeUnitSystem(length=Unit("kpc"),
+                         mass=Unit("1.49828e+10 kpc3 s2 kg / (Myr2 m3)"), time=Unit("Myr"))
 ```
 
 The mass unit is the derived one — an exact composite expression, not a rounded label:

--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -183,7 +183,7 @@ If the set of units does not correspond to any pre-defined unit system class, `u
 
 >>> usys = unitsystem("kpc", "Myr", "solMass", "degree", "candela")
 >>> usys
-LengthTimeMassAngleLuminousIntensityUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("deg"), luminous_intensity=Unit("cd"))
+AngleLengthLuminousIntensityMassTimeUnitSystem(angle=Unit("deg"), length=Unit("kpc"), luminous_intensity=Unit("cd"), mass=Unit("solMass"), time=Unit("Myr"))
 
 >>> isinstance(usys, LTMAUnitSystem)
 False
@@ -222,7 +222,7 @@ Also, `unitsystem` can replace a unit in a unit system or extend a unit system.
 True
 
 >>> unitsystem(usys, "deg")
-LengthMassTimeAngleUnitSystem(length=Unit("m"), mass=Unit("kg"), time=Unit("s"), angle=Unit("deg"))
+unitsystem(m, s, kg, deg)
 
 ```
 

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -41,6 +41,14 @@ _UNITSYSTEMS_REGISTRY: dict[
 ] = {}
 UNITSYSTEMS_REGISTRY = MappingProxyType(_UNITSYSTEMS_REGISTRY)
 
+#: Index of the registry keyed by the *set* of base dimensions (order-independent),
+#: so ``unitsystem(...)`` construction can match a registered class in O(1) rather
+#: than scanning ``_UNITSYSTEMS_REGISTRY`` and picking the first set-equal entry.
+#: Populated alongside ``_UNITSYSTEMS_REGISTRY`` in ``__init_subclass__``.
+_UNITSYSTEMS_BY_DIMSET: dict[
+    frozenset[AbstractDimension], type["AbstractUnitSystem"]
+] = {}
+
 
 # Register AbstractUnitSystem as a static PyTree node
 # This ensures unit systems are treated as constants in JAX transformations
@@ -155,6 +163,7 @@ class AbstractUnitSystem:
         )
 
         _UNITSYSTEMS_REGISTRY[dims] = cls
+        _UNITSYSTEMS_BY_DIMSET[frozenset(dims)] = cls
 
     # ===============================================================
     # USys API

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -89,7 +89,7 @@ class AbstractUnitSystem:
     And iterated over:
 
     >>> [x for x in usys]
-    [Unit("kpc"), Unit("Myr"), Unit("solMass"), Unit("rad"), Unit("km / s")]
+    [Unit("rad"), Unit("kpc"), Unit("solMass"), Unit("km / s"), Unit("Myr")]
 
     With length equal to the number of base units
 

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -52,6 +52,34 @@ _UNITSYSTEMS_BY_DIMSET: dict[
 ] = {}
 
 
+def _is_dataclass_slots_rebuild(
+    existing: type["AbstractUnitSystem"], cls: type["AbstractUnitSystem"]
+) -> bool:
+    """Report whether ``cls`` is the ``slots=True`` rebuild of ``existing``.
+
+    ``@dataclass(slots=True)`` / ``make_dataclass(slots=True)`` cannot add
+    ``__slots__`` in place, so they build a *new* class that copies the original
+    class namespace and re-runs ``__init_subclass__``. That second pass tries to
+    re-register dimensions the first pass already claimed, and must be allowed to
+    overwrite its own slotless first entry -- but a genuinely *distinct* class
+    competing for the same dimensions must not.
+
+    The namespace copy shares the original's annotation object *by identity*
+    (verified: ``make_dataclass``/``dataclass`` copy ``cls.__dict__`` wholesale),
+    which no independently-defined class -- even one with a byte-identical body --
+    ever does. That identity, plus the slotless -> slotted transition, marks the
+    rebuild unambiguously and version-independently (``__annotations__`` on
+    Python <= 3.13, ``__annotate_func__`` on 3.14+ per PEP 749).
+    """
+    if "__slots__" not in cls.__dict__ or "__slots__" in existing.__dict__:
+        return False
+    for key in ("__annotations__", "__annotate_func__"):
+        carrier = cls.__dict__.get(key)
+        if carrier is not None and carrier is existing.__dict__.get(key):
+            return True
+    return False
+
+
 # Register AbstractUnitSystem as a static PyTree node
 # This ensures unit systems are treated as constants in JAX transformations
 @jtu.register_static
@@ -155,9 +183,16 @@ class AbstractUnitSystem:
         # rejected registration leaves no partial entry behind.
         #
         # Exact-signature duplicate: the same ordered dimensions are already
-        # registered. `make_dataclass(slots=True)` rebuilds the class a second
-        # time to add `__slots__`; that pass is allowed through to overwrite.
-        if dims in _UNITSYSTEMS_REGISTRY and "__slots__" not in cls.__dict__:
+        # registered. `@dataclass(slots=True)` / `make_dataclass(slots=True)`
+        # rebuild the class a second time to add `__slots__`, re-running this
+        # hook; that pass re-registers the *same* class and is allowed to
+        # overwrite its own slotless first pass. Keying that exception off
+        # ``"__slots__" not in cls.__dict__`` alone would also wave through a
+        # *distinct* class that merely declares ``__slots__`` in its body,
+        # silently clobbering the incumbent -- so admit only the genuine rebuild
+        # (see ``_is_dataclass_slots_rebuild``).
+        existing = _UNITSYSTEMS_REGISTRY.get(dims)
+        if existing is not None and not _is_dataclass_slots_rebuild(existing, cls):
             msg = f"Unit system with dimensions {dims} already exists."
             raise ValueError(msg)
 

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -44,7 +44,9 @@ UNITSYSTEMS_REGISTRY = MappingProxyType(_UNITSYSTEMS_REGISTRY)
 #: Index of the registry keyed by the *set* of base dimensions (order-independent),
 #: so ``unitsystem(...)`` construction can match a registered class in O(1) rather
 #: than scanning ``_UNITSYSTEMS_REGISTRY`` and picking the first set-equal entry.
-#: Populated alongside ``_UNITSYSTEMS_REGISTRY`` in ``__init_subclass__``.
+#: Populated alongside ``_UNITSYSTEMS_REGISTRY`` in ``__init_subclass__``, which
+#: also enforces the one-class-per-dimension-set invariant so this mapping is
+#: unambiguous (never a silent last-write-wins between colliding classes).
 _UNITSYSTEMS_BY_DIMSET: dict[
     frozenset[AbstractDimension], type["AbstractUnitSystem"]
 ] = {}
@@ -149,21 +151,42 @@ class AbstractUnitSystem:
         # since those are made after the original class is defined.
         field_names, dims = parse_field_names_and_dimensions(cls)
 
-        # Check the unitsystem is not already registered
-        # If `make_dataclass(slots=True)` then the class is made twice, the
-        # second time adding the `__slots__` attribute
+        # Validate against both registries *before* mutating either, so a
+        # rejected registration leaves no partial entry behind.
+        #
+        # Exact-signature duplicate: the same ordered dimensions are already
+        # registered. `make_dataclass(slots=True)` rebuilds the class a second
+        # time to add `__slots__`; that pass is allowed through to overwrite.
         if dims in _UNITSYSTEMS_REGISTRY and "__slots__" not in cls.__dict__:
             msg = f"Unit system with dimensions {dims} already exists."
             raise ValueError(msg)
 
-        # Store the single dimension -> field-name mapping; the
-        # ``_base_dimensions`` / ``_base_field_names`` tuples derive from it.
+        # Same dimension *set*, different field order: a unit system is
+        # identified by which dimensions it spans, not their order, so two
+        # classes must not compete for one set. The by-set index is keyed by
+        # frozenset and would otherwise silently let the last registration win,
+        # leaving ``unitsystem(*units)`` dependent on registration order.
+        # ``owner._base_dimensions == dims`` is the ``slots=True`` rebuild
+        # re-registering the same class (same ordered dims); only a *different*
+        # ordering is a conflict.
+        dim_set = frozenset(dims)
+        owner = _UNITSYSTEMS_BY_DIMSET.get(dim_set)
+        if owner is not None and owner._base_dimensions != dims:  # noqa: SLF001
+            msg = (
+                f"Unit system for dimension set {set(dims)!r} is already "
+                f"registered as {owner.__name__!r}; a dimension set maps to a "
+                f"single unit-system class."
+            )
+            raise ValueError(msg)
+
+        # All checks passed: store the single dimension -> field-name mapping
+        # (the ``_base_dimensions`` / ``_base_field_names`` tuples derive from
+        # it) and commit to both registries.
         cls._dimension_to_field = MappingProxyType(
             dict(zip(dims, field_names, strict=True))
         )
-
         _UNITSYSTEMS_REGISTRY[dims] = cls
-        _UNITSYSTEMS_BY_DIMSET[frozenset(dims)] = cls
+        _UNITSYSTEMS_BY_DIMSET[dim_set] = cls
 
     # ===============================================================
     # USys API

--- a/src/unxt/_src/unitsystems/builtin.py
+++ b/src/unxt/_src/unitsystems/builtin.py
@@ -77,6 +77,54 @@ class LTMAUnitSystem(AbstractUnitSystem):
 @jtu.register_static
 @final
 @dataclass(frozen=True, slots=True)
+class LengthMassTimeTemperatureUnitSystem(AbstractUnitSystem):
+    """Length, mass, time, temperature unit system (e.g. Planck units).
+
+    Registered so that this shape keeps its conventional field order instead of
+    the alphabetical order a novel unit system would sort into. Prefer the
+    ``planck`` realization from `unxt.unitsystems`.
+    """
+
+    #: Units for the length dimension.
+    length: Annotated[Unit, ud.length]
+
+    #: Units for the mass dimension.
+    mass: Annotated[Unit, ud.mass]
+
+    #: Units for the time dimension.
+    time: Annotated[Unit, ud.time]
+
+    #: Units for the temperature dimension.
+    temperature: Annotated[Unit, ud.temperature]
+
+
+@jtu.register_static
+@final
+@dataclass(frozen=True, slots=True)
+class LengthMassTimeElectricalChargeUnitSystem(AbstractUnitSystem):
+    """Length, mass, time, electrical-charge unit system (e.g. atomic units).
+
+    Registered so that this shape keeps its conventional field order instead of
+    the alphabetical order a novel unit system would sort into. Prefer the
+    ``atomic`` realization from `unxt.unitsystems`.
+    """
+
+    #: Units for the length dimension.
+    length: Annotated[Unit, ud.length]
+
+    #: Units for the mass dimension.
+    mass: Annotated[Unit, ud.mass]
+
+    #: Units for the time dimension.
+    time: Annotated[Unit, ud.time]
+
+    #: Units for the electrical-charge dimension.
+    electrical_charge: Annotated[Unit, ud.charge]
+
+
+@jtu.register_static
+@final
+@dataclass(frozen=True, slots=True)
 class SIUnitSystem(AbstractUnitSystem):
     """SI unit system + angles.
 

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -79,8 +79,18 @@ def unitsystem(seq: Sequence[Any], /) -> AbstractUnitSystem:
     >>> u.unitsystem(["kpc", "Myr", "Msun", "radian"])
     unitsystem(kpc, Myr, solMass, rad)
 
+    A sequence's elements are always units, so even a single-element list builds
+    a system (a bare string, by contrast, is looked up as a *named* system):
+
+    >>> u.unitsystem(["km"])
+    LengthUnitSystem(length=Unit("km"))
+
     """
-    return unitsystem(*seq) if len(seq) > 0 else dimensionless
+    # Elements of an explicit sequence are units. Convert them up front so a
+    # single-element list dispatches to the unit-building path below rather than
+    # to the ``str`` named-system lookup (``unitsystem(["km"])`` must not become
+    # ``unitsystem("km")``).
+    return unitsystem(*map(unit, seq)) if len(seq) > 0 else dimensionless
 
 
 @dispatch
@@ -133,11 +143,22 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
         "some dimensions are repeated",
     )
 
-    # Return if the unit system is already registered
-    if dims in UNITSYSTEMS_REGISTRY:
-        return UNITSYSTEMS_REGISTRY[dims](*args)
+    # A unit system is identified by its *set* of dimensions, not the argument
+    # order. Find a registered class (a built-in like ``LTMAUnitSystem`` or a
+    # previously-created dynamic one) whose dimensions are the same set, and
+    # build it in that class's own field order. This keeps the built-ins in
+    # their conventional order (galactic stays length, time, mass, angle) while
+    # making construction order-independent.
+    unit_by_dim = dict(zip(dims, args, strict=True))
+    dim_set = frozenset(dims)
+    for reg_dims, reg_cls in UNITSYSTEMS_REGISTRY.items():
+        if frozenset(reg_dims) == dim_set:
+            return reg_cls(*(unit_by_dim[d] for d in reg_dims))
 
-    # Otherwise, create a new unit system
+    # Otherwise, create a new unit system. Sort the units by dimension name so
+    # the field order -- and hence the class identity -- is deterministic and
+    # independent of the argument order.
+    args = tuple(sorted(args, key=parse_dimlike_name))
     # dimension names of all the units
     du = {parse_dimlike_name(x).replace(" ", "_"): dimension_of(x) for x in args}
     # name: physical types
@@ -235,13 +256,15 @@ def unitsystem(usys: AbstractUnitSystem, *args: Any) -> AbstractUnitSystem:
     >>> from unxt.unitsystems import unitsystem
     >>> usys = unitsystem("galactic")
     >>> unitsystem(usys, "km/s")
-    LengthTimeMassAngleSpeedUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), speed=Unit("km / s"))
+    AngleLengthMassSpeedTimeUnitSystem(angle=Unit("rad"), length=Unit("kpc"), mass=Unit("solMass"), speed=Unit("km / s"), time=Unit("Myr"))
 
-    We can also override the base unit of an existing unit system:
+    We can also override the base unit of an existing unit system. Replacing the
+    length still leaves a length/time/mass/angle system, so it is recognized as
+    the built-in ``LTMAUnitSystem`` shape:
 
     >>> new_usys = unitsystem(usys, "pc")
     >>> new_usys
-    TimeMassAngleLengthUnitSystem(time=Unit("Myr"), mass=Unit("solMass"), angle=Unit("rad"), length=Unit("pc"))
+    unitsystem(pc, Myr, solMass, rad)
 
     """  # noqa: E501
     # TODO: not need this hack for single-string inputs
@@ -272,7 +295,7 @@ def unitsystem(flag: type[StandardUSysFlag], *args: Any) -> AbstractUnitSystem:
     --------
     >>> from unxt import unitsystem, unitsystems
     >>> unitsystem(unitsystems.StandardUSysFlag, "kpc", "Myr", "Msun")
-    LengthTimeMassUnitSystem(length=Unit("kpc"), time=Unit("Myr"), mass=Unit("solMass"))
+    LengthMassTimeUnitSystem(length=Unit("kpc"), mass=Unit("solMass"), time=Unit("Myr"))
 
     """
     return unitsystem(*args)

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -24,8 +24,8 @@ from astropy.constants import (  # pylint: disable=E0611
 from astropy.units import UnitBase as AstropyUnitBase
 from plum import dispatch
 
-from . import builtin_dimensions as ud
-from .base import _UNITSYSTEMS_BY_DIMSET, AbstractUnitSystem
+from . import base, builtin_dimensions as ud
+from .base import AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem, dimensionless
 from .flags import (
     AbstractUSysFlag,
@@ -149,8 +149,13 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
     # index -- and build it in that class's own field order. This keeps the
     # built-ins in their conventional order (galactic stays length, time, mass,
     # angle) while making construction order-independent.
+    #
+    # Read the index through the ``base`` module (not a ``from base import``
+    # binding) so that registration -- which mutates ``base._UNITSYSTEMS_BY_DIMSET``
+    # -- and this lookup always agree on the same object, including when a test
+    # swaps the module attribute for an isolated one.
     unit_by_dim = dict(zip(dims, args, strict=True))
-    reg_cls = _UNITSYSTEMS_BY_DIMSET.get(frozenset(dims))
+    reg_cls = base._UNITSYSTEMS_BY_DIMSET.get(frozenset(dims))  # noqa: SLF001
     if reg_cls is not None:
         return reg_cls(*(unit_by_dim[d] for d in reg_cls._base_dimensions))  # noqa: SLF001
 

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -25,7 +25,7 @@ from astropy.units import UnitBase as AstropyUnitBase
 from plum import dispatch
 
 from . import builtin_dimensions as ud
-from .base import UNITSYSTEMS_REGISTRY, AbstractUnitSystem
+from .base import _UNITSYSTEMS_BY_DIMSET, AbstractUnitSystem
 from .builtin import DimensionlessUnitSystem, dimensionless
 from .flags import (
     AbstractUSysFlag,
@@ -64,7 +64,7 @@ def unitsystem(usys: AbstractUnitSystem, /) -> AbstractUnitSystem:
 
 @dispatch
 def unitsystem(seq: Sequence[Any], /) -> AbstractUnitSystem:
-    """Convert a UnitSystem or tuple of arguments to a UnitSystem.
+    """Build a unit system from a sequence of units.
 
     Examples
     --------
@@ -144,16 +144,15 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
     )
 
     # A unit system is identified by its *set* of dimensions, not the argument
-    # order. Find a registered class (a built-in like ``LTMAUnitSystem`` or a
-    # previously-created dynamic one) whose dimensions are the same set, and
-    # build it in that class's own field order. This keeps the built-ins in
-    # their conventional order (galactic stays length, time, mass, angle) while
-    # making construction order-independent.
+    # order. Look up a registered class (a built-in like ``LTMAUnitSystem`` or a
+    # previously-created dynamic one) by that set -- an O(1) hit on the by-set
+    # index -- and build it in that class's own field order. This keeps the
+    # built-ins in their conventional order (galactic stays length, time, mass,
+    # angle) while making construction order-independent.
     unit_by_dim = dict(zip(dims, args, strict=True))
-    dim_set = frozenset(dims)
-    for reg_dims, reg_cls in UNITSYSTEMS_REGISTRY.items():
-        if frozenset(reg_dims) == dim_set:
-            return reg_cls(*(unit_by_dim[d] for d in reg_dims))
+    reg_cls = _UNITSYSTEMS_BY_DIMSET.get(frozenset(dims))
+    if reg_cls is not None:
+        return reg_cls(*(unit_by_dim[d] for d in reg_cls._base_dimensions))  # noqa: SLF001
 
     # Otherwise, create a new unit system. Sort the units by dimension name so
     # the field order -- and hence the class identity -- is deterministic and

--- a/src/unxt/_src/unitsystems/utils.py
+++ b/src/unxt/_src/unitsystems/utils.py
@@ -7,9 +7,6 @@ from typing import Any
 
 from plum import dispatch
 
-from zeroth import zeroth
-
-from . import builtin_dimensions as bdims
 from unxt.dims import AbstractDimension, dimension_of
 from unxt.units import AbstractUnit
 
@@ -69,14 +66,13 @@ def parse_dimlike_name(pt: AbstractDimension, /) -> str:
     'speed'
 
     """
-    # Note: this is not deterministic b/c ``_physical_type`` is a set
-    #       that's why the `if` statement is needed.
-    match pt:
-        case bdims.speed:
-            out = "speed"
-        case _:
-            out = parse_dimlike_name(zeroth(pt._physical_type))  # noqa: SLF001
-    return out
+    # A dimension can carry several equivalent physical-type aliases (e.g.
+    # ``speed`` / ``velocity``), held in an unordered ``_physical_type``. Pick
+    # the alphabetically-first alias so the name -- and hence the field order
+    # and class identity of any dynamically generated unit system -- is
+    # deterministic across runs and ``PYTHONHASHSEED`` (``min`` also happens to
+    # yield ``"speed"`` over ``"velocity"``).
+    return parse_dimlike_name(min(pt._physical_type))  # noqa: SLF001
 
 
 @dispatch

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -15,6 +15,7 @@ from astropy.constants import G as const_G  # noqa: N811
 import unxt as u
 from unxt import dimension, unit, unitsystems
 from unxt._src.unitsystems import base as us_base
+from unxt._src.unitsystems.utils import parse_dimlike_name
 from unxt.unitsystems import (
     NAMED_UNIT_SYSTEMS,
     AbstractUnitSystem,
@@ -365,6 +366,50 @@ def test_construction_consults_isolated_by_dimset_index():
     assert type(built) is IsolatedLengthTime
     assert built["length"] == unit("m")
     assert built["time"] == unit("s")
+
+
+@pytest.mark.usefixtures("clean_unitsystems_registry")
+def test_distinct_slotted_class_cannot_overwrite_registration():
+    """A distinct ``__slots__`` class must not clobber a same-dimensions entry.
+
+    Regression: the duplicate-registration guard once exempted *any* class with
+    ``__slots__`` in its ``__dict__`` -- a stand-in for "the dataclass slots
+    rebuild" -- so an unrelated class that merely declared ``__slots__`` in its
+    body silently overwrote the incumbent (and its by-set index entry). The
+    guard now admits only the genuine rebuild (shared annotation identity).
+    """
+
+    class LengthTime(AbstractUnitSystem):
+        length: Annotated[apyu.Unit, dimension("length")]
+        time: Annotated[apyu.Unit, dimension("time")]
+
+    with pytest.raises(ValueError, match="already exists"):
+
+        class Impostor(AbstractUnitSystem):
+            __slots__ = ("length", "time")
+            length: Annotated[apyu.Unit, dimension("length")]
+            time: Annotated[apyu.Unit, dimension("time")]
+
+    # The incumbent is untouched; the impostor left no entry in either registry.
+    dims = LengthTime._base_dimensions
+    assert us_base._UNITSYSTEMS_REGISTRY[dims] is LengthTime
+    assert us_base._UNITSYSTEMS_BY_DIMSET[frozenset(dims)] is LengthTime
+
+
+def test_parse_dimlike_name_is_deterministic_for_multialias_dimensions():
+    """A dimension with several physical-type aliases resolves to a stable name.
+
+    ``speed`` carries both ``"speed"`` and ``"velocity"`` in an unordered
+    ``_physical_type``; picking the alphabetically-first alias keeps the name --
+    and hence any dynamically generated unit-system's field order and class
+    identity -- independent of set iteration order / ``PYTHONHASHSEED``.
+    """
+    speed = dimension("speed")
+    assert parse_dimlike_name(speed) == "speed"
+    assert parse_dimlike_name(speed) == min(speed._physical_type)
+
+    # The generated class identity is order-independent for a speed-bearing set.
+    assert type(unitsystem("km", "km/s")) is type(unitsystem("km/s", "km"))
 
 
 class TestDimensionlessUnitSystem:

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -15,10 +15,6 @@ from astropy.constants import G as const_G  # noqa: N811
 import unxt as u
 from unxt import dimension, unit, unitsystems
 from unxt._src.unitsystems import base as us_base
-from unxt._src.unitsystems.base import (
-    _UNITSYSTEMS_BY_DIMSET,
-    _UNITSYSTEMS_REGISTRY,
-)
 from unxt.unitsystems import (
     NAMED_UNIT_SYSTEMS,
     AbstractUnitSystem,
@@ -311,9 +307,11 @@ def test_unitsystem_already_registered():
             absement: Annotated[apyu.Unit, dimension("absement")]
             time: Annotated[apyu.Unit, dimension("time")]
 
-    # Clean up custom unit system from the registry and its by-set index:
-    del _UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
-    del _UNITSYSTEMS_BY_DIMSET[frozenset(MyUnitSystem._base_dimensions)]
+    # Clean up custom unit system from the registry and its by-set index.
+    # Access through ``us_base`` (not import-time bindings) so this stays
+    # consistent with the fixture-aware access used elsewhere.
+    del us_base._UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
+    del us_base._UNITSYSTEMS_BY_DIMSET[frozenset(MyUnitSystem._base_dimensions)]
 
 
 @pytest.mark.usefixtures("clean_unitsystems_registry")

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -347,6 +347,28 @@ def test_unitsystem_same_dimension_set_different_order_rejected():
     assert us_base._UNITSYSTEMS_BY_DIMSET[dim_set] is LengthTime
 
 
+@pytest.mark.usefixtures("clean_unitsystems_registry")
+def test_construction_consults_isolated_by_dimset_index():
+    """``unitsystem(...)`` reads the fixture-isolated by-set index, not the real one.
+
+    Regression: ``core`` bound ``_UNITSYSTEMS_BY_DIMSET`` at import, so a fixture
+    that rebound only the ``base`` module's name left construction consulting the
+    original index while registration wrote to the isolated one. Register a class
+    under the fixture, then build its dimension set: ``unitsystem`` can only
+    return *that* class if lookup and registration share the isolated dict.
+    """
+
+    @dataclass(frozen=True, slots=True)
+    class IsolatedLengthTime(AbstractUnitSystem):
+        length: Annotated[apyu.Unit, dimension("length")]
+        time: Annotated[apyu.Unit, dimension("time")]
+
+    built = unitsystem("m", "s")
+    assert type(built) is IsolatedLengthTime
+    assert built["length"] == unit("m")
+    assert built["time"] == unit("s")
+
+
 class TestDimensionlessUnitSystem:
     """Test `unxt.unitsystems.DimensionlessUnitSystem`."""
 

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -14,6 +14,7 @@ from astropy.constants import G as const_G  # noqa: N811
 
 import unxt as u
 from unxt import dimension, unit, unitsystems
+from unxt._src.unitsystems import base as us_base
 from unxt._src.unitsystems.base import (
     _UNITSYSTEMS_BY_DIMSET,
     _UNITSYSTEMS_REGISTRY,
@@ -313,6 +314,37 @@ def test_unitsystem_already_registered():
     # Clean up custom unit system from the registry and its by-set index:
     del _UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
     del _UNITSYSTEMS_BY_DIMSET[frozenset(MyUnitSystem._base_dimensions)]
+
+
+@pytest.mark.usefixtures("clean_unitsystems_registry")
+def test_unitsystem_same_dimension_set_different_order_rejected():
+    """A dimension *set* maps to a single class, regardless of field order.
+
+    Two classes spanning the same dimensions but declaring them in a different
+    order would leave the by-set index (and thus ``unitsystem(*units)``) to
+    resolve by registration order; registration rejects the second one instead.
+    """
+
+    @dataclass(frozen=True, slots=True)
+    class LengthTime(AbstractUnitSystem):
+        length: Annotated[apyu.Unit, dimension("length")]
+        time: Annotated[apyu.Unit, dimension("time")]
+
+    with pytest.raises(ValueError, match="maps to a single unit-system class"):
+
+        @dataclass(frozen=True, slots=True)
+        class TimeLength(AbstractUnitSystem):
+            time: Annotated[apyu.Unit, dimension("time")]
+            length: Annotated[apyu.Unit, dimension("length")]
+
+    # The rejected class left no partial entry in either registry; the by-set
+    # index still points at the first (only) class for that set. Reference the
+    # live dicts via the module so the fixture's monkeypatched copies are seen
+    # (a top-level ``from ... import`` name would be bound to the original dict).
+    dim_set = frozenset(LengthTime._base_dimensions)
+    assert (dimension("time"), dimension("length")) not in us_base._UNITSYSTEMS_REGISTRY
+    assert LengthTime._base_dimensions in us_base._UNITSYSTEMS_REGISTRY
+    assert us_base._UNITSYSTEMS_BY_DIMSET[dim_set] is LengthTime
 
 
 class TestDimensionlessUnitSystem:

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -14,7 +14,10 @@ from astropy.constants import G as const_G  # noqa: N811
 
 import unxt as u
 from unxt import dimension, unit, unitsystems
-from unxt._src.unitsystems.base import _UNITSYSTEMS_REGISTRY
+from unxt._src.unitsystems.base import (
+    _UNITSYSTEMS_BY_DIMSET,
+    _UNITSYSTEMS_REGISTRY,
+)
 from unxt.unitsystems import (
     NAMED_UNIT_SYSTEMS,
     AbstractUnitSystem,
@@ -39,6 +42,9 @@ def clean_unitsystems_registry(monkeypatch):
     monkeypatch.setattr(
         "unxt._src.unitsystems.base._UNITSYSTEMS_REGISTRY", clean_registry
     )
+    # The by-dimension-set index is populated alongside the registry, so isolate
+    # it too or classes defined in this test would leak into the real index.
+    monkeypatch.setattr("unxt._src.unitsystems.base._UNITSYSTEMS_BY_DIMSET", {})
     return clean_registry
 
 
@@ -304,8 +310,9 @@ def test_unitsystem_already_registered():
             absement: Annotated[apyu.Unit, dimension("absement")]
             time: Annotated[apyu.Unit, dimension("time")]
 
-    # Clean up custom unit system from registry:
+    # Clean up custom unit system from the registry and its by-set index:
     del _UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
+    del _UNITSYSTEMS_BY_DIMSET[frozenset(MyUnitSystem._base_dimensions)]
 
 
 class TestDimensionlessUnitSystem:

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -26,6 +26,7 @@ from unxt.unitsystems import (
     dimensionless,
     equivalent,
     galactic,
+    planck,
     si,
     solarsystem,
     unitsystem,
@@ -105,6 +106,58 @@ def test_no_arg_unitsystem_is_dimensionless() -> None:
     # (see ``TestDimensionlessUnitSystem.test_getitem``).
     with pytest.raises(apyu.UnitConversionError):
         _ = usys["length"]
+
+
+def test_unitsystem_from_list_of_units_builds_system() -> None:
+    """A list/tuple of units builds a system from those units.
+
+    A single-element list must not be mistaken for a named-system lookup
+    (regression: ``unitsystem(["km"])`` used to unpack to ``unitsystem("km")``
+    and raise).
+    """
+    usys = unitsystem(["km"])
+    assert usys["length"] == unit("km")
+    assert usys == unitsystem([unit("km")])
+
+    # a multi-element list agrees with the variadic form
+    assert unitsystem(["kpc", "Myr", "solMass", "rad"]) == unitsystem(
+        "kpc", "Myr", "solMass", "rad"
+    )
+
+
+def test_unitsystem_identity_is_order_independent() -> None:
+    """Set-like identity: the same units in any order give the same system.
+
+    Results are equal and same-type; built-in shapes keep conventional order.
+    """
+    a = unitsystem("m", "s")
+    b = unitsystem("s", "m")
+    assert a == b
+    assert type(a) is type(b)
+
+    # built-in systems are matched by dimension set and keep their conventional
+    # field order regardless of input order
+    g1 = unitsystem("kpc", "Myr", "solMass", "rad")
+    g2 = unitsystem("Myr", "rad", "kpc", "solMass")
+    assert g1 == g2
+    assert type(g1) is type(g2)
+    assert g1 == galactic
+    assert isinstance(g1, unitsystems.LTMAUnitSystem)
+    # conventional field order (length, time, mass, angle) is preserved, not sorted
+    assert g2.base_dimensions == galactic.base_dimensions
+
+
+def test_natural_shape_construction_preserves_conventional_order() -> None:
+    """Natural-system shapes keep conventional order for user construction.
+
+    A shape like (length, mass, time, temperature) uses the pre-registered class
+    in conventional order, not the alphabetical order a novel shape would sort
+    into -- and is order-independent.
+    """
+    usys = unitsystem("m", "kg", "s", "K")
+    assert type(usys) is type(planck)
+    assert usys.base_dimensions == planck.base_dimensions
+    assert unitsystem("K", "s", "m", "kg") == usys
 
 
 def test_compare() -> None:


### PR DESCRIPTION
## Summary

Closes an API-freeze item from the v2.0 release-gate audit: unit-system identity was **order-dependent** — `unitsystem("m", "s")` and `unitsystem("s", "m")` were distinct, unequal, dynamically-generated classes, and every argument permutation permanently registered a new class. Also, `unitsystem(["km"])` raised instead of building a system.

Unit systems are now **set-like**: the same base units in any order give the same (equal, same-type) system.

### Changes

- **Set-based construction** (`core.py`). The *set* of dimensions identifies a system, not the argument order. A registered class — a built-in like `LTMAUnitSystem` or a previously-created dynamic one — is matched by its dimension set and built in that class's own field order. So the built-ins keep their conventional order (`galactic` stays `unitsystem(kpc, Myr, solMass, rad)` regardless of input order). A brand-new dimension set is created with its units **sorted by dimension name**, so the field order — and hence the class identity — is deterministic and order-independent.
- **A sequence builds from units** (`core.py`). `unitsystem(["km"])` now builds a length system rather than unpacking to `unitsystem("km")` and hitting the named-system lookup. A bare string is still a named lookup (`unitsystem("galactic")`).
- **Preserve the natural systems' order** (`builtin.py`). The `planck` and `atomic` realizations' two shapes (length·mass·time·temperature, length·mass·time·charge) are pre-registered so they keep conventional order instead of sorting alphabetically — matching how `galactic`/`si`/`cgs` are handled.

### Behavior change

Only **novel dynamically-created** unit systems change: their field order (and therefore class name / repr) is now the deterministic sorted order. Built-in and named systems (`galactic`, `si`, `cgs`, `planck`, `atomic`, …) are unchanged. Doctests for the novel cases are updated accordingly.

## Verification

TDD (tests written first, watched fail). `tests/unit/test_unitsystems.py` 41 passed; full `tests/unit/` 354 passed (beartype active); 1084 doctests across `src/`, `docs/`, `README.md` passed; gala-interop 30 passed. ruff + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)