### PR TITLE
🐛 fix(quantity): len() of a 0-d Quantity raises instead of returning 0

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -498,6 +498,34 @@ class AbstractQuantity(
     # ===============================================================
     # JAX API
 
+    def __len__(self) -> int:
+        """Length of the leading axis; a 0-d quantity has no length.
+
+        Mirrors NumPy/JAX (and ``__iter__`` below): ``len`` of a scalar raises
+        ``TypeError`` rather than returning ``0`` (the ``quax_blocks.LaxLenMixin``
+        default), which made a scalar look empty to ``len(q) == 0`` guards.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> len(u.Q([1, 2, 3], "m"))
+        3
+
+        >>> try:
+        ...     len(u.Q(1.0, "m"))
+        ... except TypeError as e:
+        ...     print(e)
+        len() of unsized object
+
+        """
+        # ``np.ndim`` (not ``self.value.ndim``): during a ``jax.tree`` map the
+        # value can transiently be a plain list, and it handles tracers,
+        # NumPy/JAX arrays and ``StaticValue`` alike -- matching ``__iter__``.
+        if np.ndim(self.value) == 0:
+            msg = "len() of unsized object"
+            raise TypeError(msg)
+        return int(np.shape(self.value)[0])
+
     def __iter__(self) -> Any:
         """Iterate over the quantity's value.
 

--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -361,9 +361,12 @@ def test_len():
     q = u.Q([1, 2, 3], "m")
     assert len(q) == 3
 
-    # Scalar
+    # A 0-d (scalar) quantity has no length: like NumPy/JAX, ``len`` raises
+    # rather than returning 0 (which made a scalar look empty to ``len(q) == 0``
+    # guards). This mirrors ``iter(0-d q)`` also raising.
     q = u.Q(1, "m")
-    assert len(q) == 0
+    with pytest.raises(TypeError, match="len"):
+        len(q)
 
 
 def test_add():


### PR DESCRIPTION
## Summary

From the medium/low audit-findings verification: `len(u.Q(1.0, "m"))` returned **`0`** instead of raising. `AbstractQuantity` inherited `quax_blocks.LaxLenMixin` (`return self.shape[0] if self.shape else 0`), so a 0-d quantity looked *empty* to any `if len(q) == 0` / `if not len(q)` guard — a silent wrong answer — and diverged from NumPy/JAX, which raise `TypeError`. It was also internally inconsistent with `__iter__`, which already raises on a 0-d quantity (added in #738).

Override `__len__` on `AbstractQuantity` to raise `TypeError("len() of unsized object")` when `ndim == 0` (via `np.ndim`, matching `__iter__`'s tracer/list/StaticValue-safe check), else return the leading-axis length.

## Verification (TDD)

Rewrote `test_len` to assert the scalar case raises (watched it fail on the old code), then added the override. Full `tests/unit/` suite: 351 passed (excluding the pre-existing `test_package::test_version` local-version artifact). New `__len__` doctest passes.

## Note

This is the one cleanly-mechanical fix from the audit's "correctness" cluster. The others each need a semantic decision and are better handled separately: `jnp.where` fabricating units on a raw operand (the `select_n` leniency is shared by `triu`/`tril`/`hypot`/`trace`, and fill-zeros can't be distinguished from data under jit); `equivalent(usys_a, usys_b)` ignoring units (rename to `same_dimensions` vs. make it unit-aware); and the bool-`+`→`or_p` "phantom dimensionless" message (JAX-lowering surprise, message is technically accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)