### PR TITLE
📝 docs: fill migration-guide gaps and fix doc-consistency findings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To use, run `nox`. This will lint and test using every installed version of Pyth
 
 ```console
 $ nox -s lint  # Lint only
-$ nox -s tests  # Python tests
+$ nox -s test  # Python tests
 $ nox -s docs -- --serve  # Build and serve the docs
 $ nox -s build  # Make an SDist and wheel
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Before being merged, a pull request for a new feature will be reviewed to see if
 - Are there tests for any exceptions raised?
 - Are there tests for the expected performance?
 - Are the sources for the tests documented?
-- Does `uv run --group test nox -s tests` run without failures?
+- Does `uv run --group test nox -s test` run without failures?
 
 **Documentation:**
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,7 +49,7 @@ Before being merged, a pull request for a new feature will be reviewed to see if
 - Are there tests for any exceptions raised?
 - Are there tests for the expected performance?
 - Are the sources for the tests documented?
-- Does `uv run --group test nox -s tests` run without failures?
+- Does `uv run --group test nox -s test` run without failures?
 
 **Documentation:**
 

--- a/docs/interop/dataclassish.md
+++ b/docs/interop/dataclassish.md
@@ -22,7 +22,7 @@ All of these work seamlessly across:
 - Dimensions
 - Units
 - Unit Systems
-- Quantity types (Quantity, ParametricQuantity, Angle, etc.)
+- Quantity types (`Quantity`, `Angle`, etc.; also `ParametricQuantity`, provided by the separate `unxts.parametric` package)
 
 This makes it easy to build generic code that works with unxt types without needing to know their internal structure.
 

--- a/docs/interop/dataclassish.md
+++ b/docs/interop/dataclassish.md
@@ -22,7 +22,7 @@ All of these work seamlessly across:
 - Dimensions
 - Units
 - Unit Systems
-- Quantity types (Quantity, ParametricQuantity, Angle, Distance, etc.)
+- Quantity types (Quantity, ParametricQuantity, Angle, etc.)
 
 This makes it easy to build generic code that works with unxt types without needing to know their internal structure.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -129,7 +129,7 @@ In-code configuration via `u.config` is unchanged.
 
 If you do **not** rename, the leftover `[tool.unxt.*]` section is **silently ignored** and those settings revert to their defaults. `unxt` emits a `DeprecationWarning` at import so the drift is greppable:
 
-> The '[tool.unxt]' pyproject.toml section is deprecated and ignored; unxt now reads its configuration from '[tool.unxts.unxt]'.
+> The '[tool.unxt]' pyproject.toml section is deprecated and ignored; unxt now reads its configuration from '[tool.unxts.unxt]'. Move your settings there.
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -34,6 +34,8 @@ pip install unxts.parametric   # or: uv add unxts.parametric
 
 Accessing the moved names on `unxt` now raises `AttributeError` with a message pointing to the new package — this covers `unxt.ParametricQuantity`, `unxt.PQ`, `unxt.AbstractParametricQuantity`, and their `unxt.quantity.*` equivalents.
 
+The two support packages were likewise renamed into the shared `unxts.*` namespace: `unxt-api` → `unxts.api` and `unxt-hypothesis` → `unxts.hypothesis` (imported as `unxts.api` / `unxts.hypothesis`). The old distributions and their `import unxt_api` / `import unxt_hypothesis` names still work as compatibility shims, but prefer the `unxts.*` names.
+
 ### Update your imports
 
 | v1 (`unxt`) | v2 (`unxts.parametric`) |
@@ -124,6 +126,10 @@ Defaults are unchanged (`repr` hides the parameter, `str` shows it). The other d
 | `[tool.unxt.quantity.str]`  | `[tool.unxts.unxt.quantity.str]`  |
 
 In-code configuration via `u.config` is unchanged.
+
+If you do **not** rename, the leftover `[tool.unxt.*]` section is **silently ignored** and those settings revert to their defaults. `unxt` emits a `DeprecationWarning` at import so the drift is greppable:
+
+> The '[tool.unxt]' pyproject.toml section is deprecated and ignored; unxt now reads its configuration from '[tool.unxts.unxt]'.
 
 ---
 
@@ -269,6 +275,31 @@ Use `ParametricQuantity` for dimension-specific dispatch instead:
 
 >>> f(up.PQ(1.0, "s"))
 'time!'
+```
+
+### (c) Equality on `StaticValue`-backed quantities is now unit-blind
+
+A `Quantity` whose value is wrapped in `StaticValue` (so it can be a `jax.jit` `static_argnames` key) now compares with `==` **structurally** — same unit _label_ and array — rather than converting units first. Like the `isinstance` change, this is **silent**: no warning, `==` just returns a different answer.
+
+```{code-block} python
+>>> import unxt as u
+>>> from unxt.quantity import StaticValue
+
+>>> a = u.Q(StaticValue(1000.0), "m")
+>>> b = u.Q(StaticValue(1.0), "km")
+
+>>> a == b   # v1: True (unit-aware); v2: unit-blind
+False
+```
+
+**Migration:** for a unit-aware "same physical quantity" check, use `u.equivalent` (or the `.is_equivalent` method) as the drop-in replacement for v1 `==`:
+
+```{code-block} python
+>>> u.equivalent(a, b)
+True
+
+>>> a.is_equivalent(b)
+True
 ```
 
 ---

--- a/packages/unxts.parametric/README.md
+++ b/packages/unxts.parametric/README.md
@@ -19,5 +19,10 @@ import unxts.parametric as up
 
 up.PQ([1, 2, 3], "m")  # dimension inferred from the unit
 up.PQ["length"](1, "m")  # dimension checked against the unit
-up.PQ["length"](1, "s")  # raises: 's' is not a length
+
+# A unit that doesn't match the declared dimension raises:
+try:
+    up.PQ["length"](1, "s")
+except ValueError as e:
+    print(e)  # Physical type mismatch.
 ```

--- a/packages/unxts.parametric/README.md
+++ b/packages/unxts.parametric/README.md
@@ -12,6 +12,12 @@ pip install unxts.parametric
 
 ## Usage
 
+`ParametricQuantity` (alias `PQ`) encodes its physical dimension in its _type_, so — unlike the default `unxt.Quantity` — it checks the dimension at construction:
+
 ```python
-import unxts.parametric as upq
+import unxts.parametric as up
+
+up.PQ([1, 2, 3], "m")            # dimension inferred from the unit
+up.PQ["length"](1, "m")          # dimension checked against the unit
+up.PQ["length"](1, "s")          # raises: 's' is not a length
 ```

--- a/packages/unxts.parametric/README.md
+++ b/packages/unxts.parametric/README.md
@@ -17,7 +17,7 @@ pip install unxts.parametric
 ```python
 import unxts.parametric as up
 
-up.PQ([1, 2, 3], "m")            # dimension inferred from the unit
-up.PQ["length"](1, "m")          # dimension checked against the unit
-up.PQ["length"](1, "s")          # raises: 's' is not a length
+up.PQ([1, 2, 3], "m")  # dimension inferred from the unit
+up.PQ["length"](1, "m")  # dimension checked against the unit
+up.PQ["length"](1, "s")  # raises: 's' is not a length
 ```


### PR DESCRIPTION
## Summary

Docs cluster from the medium/low audit-findings verification — the highest-value being two **silent** v2 breaks the migration guide never mentioned.

- **Migration guide — silent breaks documented.**
  - `StaticValue`-backed `==` is now **unit-blind** (structural, for `jax.jit` `static_argnames` use). Added a `(c)` behavioral-change subsection with a runnable before/after and `u.equivalent` / `.is_equivalent` as the drop-in for v1 `==`.
  - An un-renamed `[tool.unxt]` section is **silently ignored** and reverts to defaults — added a note quoting the `DeprecationWarning` so it's greppable.
  - Noted the `unxt-api`→`unxts.api` / `unxt-hypothesis`→`unxts.hypothesis` renames (old `import unxt_api` still works as a shim).
- **parametric README**: canonical `up` alias (was `upq`, contradicting all other docs) + a runnable dimension-check example.
- **dataclassish.md**: removed `Distance` from the quantity-types list (no such type).
- **CONTRIBUTING.md**: `nox -s tests` → `nox -s test`.

## Verification

`nox -s docs`: **0 `myst.xref_missing`**, `build succeeded`. sybil on `migration.md`: 52 passed (the new static-equality / `equivalent` doctests execute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)