### PR TITLE
🐛 fix(quantity): keep wrap_to in [min, max); export it from unxt top level

### DIFF
--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -56,6 +56,7 @@ __all__ = (
     "uconvert",  # convert units
     "ustrip",  # strip units
     "is_unit_convertible",  # check if units can be converted
+    "wrap_to",  # wrap an angle into the half-open range [min, max)
     "equivalent",  # physical equivalence (unit-aware), incl. unit systems
 )
 
@@ -76,6 +77,7 @@ with install_import_hook("unxt"):
         uconvert,
         uconvert_value,
         ustrip,
+        wrap_to,
     )
     from .units import AbstractUnit, unit, unit_of
     from .unitsystems import (

--- a/src/unxt/_src/quantity/register_api.py
+++ b/src/unxt/_src/quantity/register_api.py
@@ -353,4 +353,11 @@ def wrap_to(
     """
     minv, maxv = min.ustrip(angle.unit), max.ustrip(angle.unit)
     value = ((angle.value - minv) % (maxv - minv)) + minv
+    # The modulo is mathematically in ``[minv, maxv)``, but float rounding can
+    # push a value that is just below ``maxv`` up to exactly ``maxv`` (e.g.
+    # wrapping ``-1e-8 deg`` into ``[0, 360)`` yields ``360.0``). Fold any such
+    # value back to ``minv`` so the documented half-open contract holds. Plain
+    # arithmetic (rather than ``where``) keeps this valid for both traced and
+    # static (NumPy) values.
+    value = value - (value >= maxv) * (maxv - minv)
     return replace(angle, value=value)

--- a/tests/unit/test_wrap_to.py
+++ b/tests/unit/test_wrap_to.py
@@ -1,0 +1,39 @@
+"""Tests for ``wrap_to`` -- the half-open [min, max) contract and its export."""
+
+import jax
+import pytest
+
+import unxt as u
+
+
+def test_wrap_to_is_top_level_export():
+    """``wrap_to`` is re-exported from ``unxt`` like the other api verbs."""
+    assert "wrap_to" in u.__all__
+    assert u.wrap_to is u.quantity.wrap_to
+
+
+def test_wrap_to_normal_case():
+    """A value above the range wraps down into it."""
+    r = u.wrap_to(u.Angle(370, "deg"), u.Q(0, "deg"), u.Q(360, "deg"))
+    assert float(r.value) == 10
+
+
+@pytest.mark.parametrize("v", [-1e-8, -1e-6, -1e-4])
+def test_wrap_to_never_returns_max(v):
+    """A tiny negative angle must land in [0, 360), never exactly 360.
+
+    Float rounding used to push ``(-1e-8) % 360`` up to exactly ``360.0``,
+    violating the documented half-open contract.
+    """
+    r = u.Angle(v, "deg").wrap_to(u.Q(0.0, "deg"), u.Q(360.0, "deg"))
+    assert 0.0 <= float(r.value) < 360.0
+
+
+def test_wrap_to_half_open_holds_under_jit():
+    """The fold-back is arithmetic, so it survives ``jax.jit``."""
+
+    def wrap(a):
+        return a.wrap_to(u.Q(0.0, "deg"), u.Q(360.0, "deg"))
+
+    r = jax.jit(wrap)(u.Angle(-1e-8, "deg"))
+    assert 0.0 <= float(r.value) < 360.0


### PR DESCRIPTION
## Summary

Two `wrap_to` findings from the audit verification.

- **Half-open contract violated.** `wrap_to` returns `((angle - min) % (max - min)) + min` — mathematically in `[min, max)`, but float rounding can push a value just below `max` up to exactly `max`. Wrapping `-1e-8 deg` into `[0, 360)` returned **`360.0`**. Fold any `>= max` value back to `min` using plain arithmetic (`value - (value >= max) * (max - min)`), so it stays valid for both traced and static (NumPy) values and survives `jax.jit`.
- **Missing top-level export.** `wrap_to` was in `unxts.api.__all__` but, unlike the other nine api verbs, was not re-exported from `unxt` — only reachable as `u.quantity.wrap_to`. Added it to `unxt.__all__` / top level.

## Verification (TDD)

New `tests/unit/test_wrap_to.py`: the half-open contract holds for tiny negative inputs (eager + jit), the normal case (`370 → 10`) still works, and `u.wrap_to is u.quantity.wrap_to`. Full `tests/unit/` suite: 357 passed (excluding the pre-existing `test_version` local-version artifact). The `register_api.py` `wrap_to` doctest still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)