### PR TITLE
🐛 fix(unitsystems): equivalent() consults units, not just dimensions

### DIFF
--- a/src/unxt/_src/unitsystems/compare.py
+++ b/src/unxt/_src/unitsystems/compare.py
@@ -9,5 +9,35 @@ from .base import AbstractUnitSystem
 
 @dispatch
 def equivalent(a: AbstractUnitSystem, b: AbstractUnitSystem, /) -> bool:
-    """Check if two unit systems are equivalent."""
-    return set(a.base_dimensions) == set(b.base_dimensions)
+    """Whether two unit systems describe the same physical structure.
+
+    Two unit systems are equivalent when they share the same set of base
+    dimensions **and**, for each dimension, their units are interconvertible.
+    Unlike ``==``, the specific units need not be identical -- only
+    convertible -- so systems that measure the same dimensions in different
+    (but compatible) units are equivalent.
+
+    Examples
+    --------
+    >>> from unxt.unitsystems import galactic, solarsystem, si, equivalent
+
+    ``galactic`` (kpc, Myr, solMass, rad) and ``solarsystem`` (AU, yr, solMass,
+    rad) have the same base dimensions and interconvertible units:
+
+    >>> equivalent(galactic, solarsystem)
+    True
+
+    >>> equivalent(galactic, galactic)
+    True
+
+    A system with different base dimensions is not equivalent:
+
+    >>> equivalent(galactic, si)
+    False
+
+    """
+    dims = set(a.base_dimensions)
+    if dims != set(b.base_dimensions):
+        return False
+    # Same dimensions: require each dimension's units to be interconvertible.
+    return all(a[d].is_equivalent(b[d]) for d in dims)

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -490,3 +490,16 @@ def test_natural_unitsystem_pickle(tmp_path: Path) -> None:
         with path.open(mode="rb") as f:
             usys2 = pickle.load(f)  # noqa: S301
         assert usys == usys2
+
+
+def test_equivalent_checks_dimensions_and_unit_convertibility() -> None:
+    """`equivalent(usys, usys)` = same base dimensions + convertible units.
+
+    Same dimensions in interconvertible units are equivalent even when the
+    specific units differ (galactic uses kpc/Myr, solarsystem AU/yr); different
+    base dimensions are not.
+    """
+    assert equivalent(galactic, solarsystem)
+    assert equivalent(galactic, galactic)
+    assert not equivalent(galactic, si)
+    assert not equivalent(si, cgs)


### PR DESCRIPTION
## Summary

Per the maintainer ruling on this audit finding: `equivalent(a, b)` for unit systems previously returned `set(a.base_dimensions) == set(b.base_dimensions)` — the units were never consulted. It now checks that the two systems share the same base dimensions **and**, for each dimension, their units are interconvertible.

The units need only be *convertible*, not identical, so `galactic` (kpc, Myr, …) and `solarsystem` (AU, yr, …) are equivalent, while systems with different base dimensions are not. Documented with doctests.

## Verification

New `test_equivalent_checks_dimensions_and_unit_convertibility`; `compare.py` doctests execute. `test_unitsystems.py` + `test_quantity_equivalence.py`: 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)