### PR TITLE
✨ feat(experimental): make unxt.experimental a public, importable module

### DIFF
--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -57,6 +57,8 @@ __all__ = (
     "ustrip",  # strip units
     "is_unit_convertible",  # check if units can be converted
     "equivalent",  # physical equivalence (unit-aware), incl. unit systems
+    # experimental
+    "experimental",  # module: unit-aware autodiff (grad, jacfwd, hessian, where)
 )
 
 from .setup_package import install_import_hook
@@ -85,7 +87,10 @@ with install_import_hook("unxt"):
         unitsystem_of,
     )
 
-from ._src import experimental  # noqa: F401
+# Imported *outside* the ``install_import_hook`` block on purpose: the
+# experimental helpers raise their own domain-specific errors that beartype
+# would otherwise pre-empt (see ``unxt.experimental``).
+from . import experimental
 
 # isort: split
 from . import _interop  # noqa: F401  # register interop

--- a/src/unxt/__init__.py
+++ b/src/unxt/__init__.py
@@ -89,7 +89,7 @@ with install_import_hook("unxt"):
 
 # Imported *outside* the ``install_import_hook`` block on purpose: the
 # experimental helpers raise their own domain-specific errors that beartype
-# would otherwise pre-empt (see ``unxt.experimental``).
+# would otherwise preempt (see ``unxt.experimental``).
 from . import experimental
 
 # isort: split

--- a/src/unxt/experimental.py
+++ b/src/unxt/experimental.py
@@ -15,7 +15,7 @@ around the transformed function. See :mod:`unxt._src.experimental` for details.
 # NB: this module is intentionally *not* wrapped in ``install_import_hook``
 # (unlike ``unxt.dims`` etc.). Its functions raise their own domain-specific
 # errors -- e.g. ``where`` tells you to wrap a raw array as a Quantity -- which
-# beartype would pre-empt with a generic type-violation. Keep it unwrapped so
+# beartype would preempt with a generic type-violation. Keep it unwrapped so
 # those messages survive.
 
 __all__ = ("grad", "hessian", "jacfwd", "where")

--- a/src/unxt/experimental.py
+++ b/src/unxt/experimental.py
@@ -7,7 +7,7 @@
 Unit-aware wrappers for JAX's automatic-differentiation functions (`grad`,
 `jacfwd`, `hessian`) and a unit-checked `where`. On some occasions JAX's autodiff
 does not propagate units correctly; these wrappers strip and re-apply the units
-around the transformed function. See :mod:`unxt._src.experimental` for details.
+around the transformed function.
 
 >>> from unxt import experimental
 

--- a/src/unxt/experimental.py
+++ b/src/unxt/experimental.py
@@ -1,0 +1,23 @@
+"""Experimental features.
+
+.. warning::
+
+    These features may be removed or changed in the future without notice.
+
+Unit-aware wrappers for JAX's automatic-differentiation functions (`grad`,
+`jacfwd`, `hessian`) and a unit-checked `where`. On some occasions JAX's autodiff
+does not propagate units correctly; these wrappers strip and re-apply the units
+around the transformed function. See :mod:`unxt._src.experimental` for details.
+
+>>> from unxt import experimental
+
+"""
+# NB: this module is intentionally *not* wrapped in ``install_import_hook``
+# (unlike ``unxt.dims`` etc.). Its functions raise their own domain-specific
+# errors -- e.g. ``where`` tells you to wrap a raw array as a Quantity -- which
+# beartype would pre-empt with a generic type-violation. Keep it unwrapped so
+# those messages survive.
+
+__all__ = ("grad", "hessian", "jacfwd", "where")
+
+from ._src.experimental import grad, hessian, jacfwd, where

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1,5 +1,6 @@
 """Test the package itself."""
 
+import importlib
 import importlib.metadata
 
 import unxt as u
@@ -8,3 +9,18 @@ import unxt as u
 def test_version():
     """Test version."""
     assert importlib.metadata.version("unxt") == u.__version__
+
+
+def test_experimental_is_public_importable_module():
+    """``unxt.experimental`` is a real, importable public module.
+
+    Regression test: ``experimental`` must be listed in ``unxt.__all__`` and
+    ``import unxt.experimental`` must succeed (not just ``from unxt import
+    experimental``), which requires a genuine ``unxt/experimental.py`` module
+    rather than a mere top-level attribute.
+    """
+    assert "experimental" in u.__all__
+
+    experimental = importlib.import_module("unxt.experimental")
+    assert experimental is u.experimental
+    assert set(experimental.__all__) == {"grad", "hessian", "jacfwd", "where"}


### PR DESCRIPTION
## Summary

Per the maintainer ruling that `unxt.experimental` is **public**. It had an API-reference page and its docstring says `from unxt import experimental`, but:
- `import unxt.experimental` raised `ModuleNotFoundError` (it was only an *attribute*, bound via `from ._src import experimental` — there was no public `unxt/experimental.py`), and
- it was absent from `unxt.__all__`.

Added a real `unxt/experimental.py` public module re-exporting `grad`, `jacfwd`, `hessian`, `where`, and listed it in `__all__`. Now `import unxt.experimental`, `from unxt import experimental`, and `u.experimental` all work, and the API-reference page resolves.

## Note on the typecheck hook

Kept experimental imported **outside** the `install_import_hook` block (as it was). Its helpers raise their own domain-specific errors — e.g. `where` tells you to *wrap a raw array as a Quantity* — which beartype would otherwise pre-empt with a generic type-violation. So the related "typecheck never applies to `experimental`" finding is **intentional, not fixed**: the hand-written errors are better than beartype's here.

## Verification

`import unxt.experimental` works; `tests/unit/` 351 passed (excl. the pre-existing `test_version`); the experimental-`where` rejection tests still pass (helpful error preserved); `nox -s docs` 0 `myst.xref_missing`, build succeeded (experimental API page resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)