### PR TITLE
🐛 fix(packaging): correct package __version__ exposure and an api docstring

### DIFF
--- a/packages/unxt-api/src/unxt_api/__init__.py
+++ b/packages/unxt-api/src/unxt_api/__init__.py
@@ -5,8 +5,9 @@ This package re-exports the complete public API and will be maintained long-term
 No changes are required in code that imports ``unxt_api``.
 """
 
+from importlib.metadata import version as _dist_version
+
 from unxts.api import (
-    __version__,
     dimension,
     dimension_of,
     is_unit_convertible,
@@ -18,6 +19,9 @@ from unxts.api import (
     ustrip,
     wrap_to,
 )
+
+#: Version of the ``unxt-api`` distribution (not ``unxts.api``).
+__version__ = _dist_version("unxt-api")
 
 __all__ = (
     "__version__",

--- a/packages/unxt-api/tests/test_public_api.py
+++ b/packages/unxt-api/tests/test_public_api.py
@@ -17,3 +17,10 @@ def test_same_objects():
         assert getattr(unxt_api, name) is getattr(unxts.api, name), (
             f"unxt_api.{name} is not unxts.api.{name}"
         )
+
+
+def test_version_reports_own_distribution():
+    """`unxt_api.__version__` is the `unxt-api` dist version, not `unxts.api`'s."""
+    from importlib.metadata import version
+
+    assert unxt_api.__version__ == version("unxt-api")

--- a/packages/unxt-api/tests/test_public_api.py
+++ b/packages/unxt-api/tests/test_public_api.py
@@ -1,5 +1,7 @@
 """Test that unxt_api re-exports the full public API from unxts.api."""
 
+from importlib.metadata import version
+
 import unxts.api
 
 import unxt_api  # noqa: ICN001
@@ -21,6 +23,4 @@ def test_same_objects():
 
 def test_version_reports_own_distribution():
     """`unxt_api.__version__` is the `unxt-api` dist version, not `unxts.api`'s."""
-    from importlib.metadata import version
-
     assert unxt_api.__version__ == version("unxt-api")

--- a/packages/unxts.api/src/unxts/api/_src/quantity.py
+++ b/packages/unxts.api/src/unxts/api/_src/quantity.py
@@ -76,7 +76,7 @@ def ustrip(*args: Any) -> Any:
     >>> import unxt as u  # implements `unxts.api.ustrip`
 
     >>> q = u.Q(1, "km")
-    >>> ustrip(u.unit("m"), q)
+    >>> u.ustrip(u.unit("m"), q)
     Array(1000., dtype=float32, ...)
 
     >>> u.ustrip("m", q)

--- a/packages/unxts.linalg/src/unxts/linalg/__init__.py
+++ b/packages/unxts.linalg/src/unxts/linalg/__init__.py
@@ -9,7 +9,10 @@ reduce-sum) plus the ``matmul``/``matvec``/``vecmat``/``vecdot`` products and
 algebra.
 """
 
+from ._version import version as __version__
+
 __all__ = (
+    "__version__",
     "QM",
     "QuantityMatrix",
     "UnitsMatrix",

--- a/packages/unxts.linalg/tests/test_public_api.py
+++ b/packages/unxts.linalg/tests/test_public_api.py
@@ -1,0 +1,15 @@
+"""Public-API surface tests for `unxts.linalg`."""
+
+from importlib.metadata import version
+
+import unxts.linalg as ul
+
+
+def test_all_symbols_importable():
+    for name in ul.__all__:
+        assert hasattr(ul, name), f"unxts.linalg missing: {name}"
+
+
+def test_version_exposed():
+    assert "__version__" in ul.__all__
+    assert ul.__version__ == version("unxts.linalg")


### PR DESCRIPTION
## Summary

Package API-surface consistency findings from the audit verification.

- **`unxts.linalg` never exposed `__version__`** — the only workspace package missing it, though it generates `_version.py`. Import and add to `__all__`.
- **`unxt_api.__version__` reported the wrong distribution.** The shim re-exported `unxts.api`'s `__version__`, so `unxt_api.__version__` gave `unxts.api`'s version (`0.1.dev…`) rather than the separately-tagged `unxt-api` dist version (`1.11.…`). Source it from `importlib.metadata.version("unxt-api")`.
- **`ustrip` docstring** in `unxts.api` used bare `ustrip(...)` (resolving only via sybil's module globals) unlike its siblings; use `u.ustrip(...)`.

## Verification

New `test_version_reports_own_distribution` (`unxt-api`) and a first `test_public_api.py` for `unxts.linalg` (symbols importable + version matches dist). Package tests 259 passed, `tests/unit/` 351 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)