### PR TITLE
🐛 fix(quantity): StaticQuantity.mT, at[].get(fill_value=), at[].apply/power messages

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -311,15 +311,15 @@ class AbstractQuantity(
         Examples
         --------
         >>> import unxt as u
-        >>> q = u.Q([[0, 1], [1, 2]], "m")
+        >>> q = u.Q([[0, 1], [2, 3]], "m")
         >>> q.mT
-        Quantity(Array([[0, 1],
-                                  [1, 2]], dtype=int32), unit='m')
+        Quantity(Array([[0, 2],
+                                  [1, 3]], dtype=int32), unit='m')
 
         It also works for a ``StaticQuantity``:
 
-        >>> u.StaticQuantity([[0, 1], [1, 2]], "m").mT.value.tolist()
-        [[0, 1], [1, 2]]
+        >>> u.StaticQuantity([[0, 1], [2, 3]], "m").mT.value.tolist()
+        [[0, 2], [1, 3]]
 
         """
         # Use ``self.value.mT`` (like ``.T``) rather than
@@ -1312,10 +1312,18 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         # TODO: by quaxified super
         if fill_value is not None:
             fv = uapi.ustrip(self.array.unit, fill_value)
-            # JAX treats ``fill_value`` as a *static* scalar and hashes it; a
-            # concrete ``jax.Array`` is unhashable there, so coerce the stripped
-            # value (always a 0-d array) to a Python scalar. (A traced fill value
-            # cannot be static and is unsupported.)
+            # JAX treats ``fill_value`` as a *static* scalar and hashes it, so it
+            # must be a concrete Python scalar. A traced value cannot be static;
+            # detect it and raise a clear error rather than letting ``.item()``
+            # fail with a cryptic concretization error.
+            if isinstance(fv, jax.core.Tracer):
+                msg = (
+                    "Quantity.at[...].get(fill_value=...) requires a concrete "
+                    "scalar fill value; a traced Quantity cannot be used "
+                    "because JAX treats fill_value as a static scalar."
+                )
+                raise TypeError(msg)
+            # ``fv`` is always a 0-d array; coerce it to a Python scalar.
             fill_value = fv.item()
         value = self.array.value.at[self.index].get(fill_value=fill_value, **kw)
         return replace(self.array, value=value)
@@ -1334,7 +1342,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
             "Quantity.at[...].apply is not implemented: the applied function "
             "would have to be unit-aware. Strip the units, apply the function "
             "to the raw array, and re-wrap: "
-            "`u.Quantity(q.ustrip(unit).at[idx].apply(func), unit)`."
+            "`u.Q(q.ustrip(q.unit).at[...].apply(func), q.unit)`."
         )
         raise NotImplementedError(msg)
 

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -316,8 +316,17 @@ class AbstractQuantity(
         Quantity(Array([[0, 1],
                                   [1, 2]], dtype=int32), unit='m')
 
+        It also works for a ``StaticQuantity``:
+
+        >>> u.StaticQuantity([[0, 1], [1, 2]], "m").mT.value.tolist()
+        [[0, 1], [1, 2]]
+
         """
-        return replace(self, value=jnp.matrix_transpose(self.value))
+        # Use ``self.value.mT`` (like ``.T``) rather than
+        # ``jnp.matrix_transpose(self.value)``: the latter rejects a
+        # ``StaticValue`` (StaticQuantity's value), while ``.mT`` delegates to
+        # the wrapped NumPy/JAX array for both quantity kinds.
+        return replace(self, value=self.value.mT)
 
     @property
     def ndim(self) -> int:
@@ -1301,14 +1310,13 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         self, *, fill_value: AbstractQuantity | None = None, **kw: Any
     ) -> AbstractQuantity:
         # TODO: by quaxified super
-        value = self.array.value.at[self.index].get(
-            fill_value=(
-                fill_value
-                if fill_value is None
-                else uapi.ustrip(self.array.unit, fill_value)
-            ),
-            **kw,
-        )
+        if fill_value is not None:
+            fv = uapi.ustrip(self.array.unit, fill_value)
+            # JAX treats ``fill_value`` as a *static* scalar and hashes it; a
+            # concrete ``jax.Array`` is unhashable there, so coerce to a Python
+            # scalar. (A traced fill value cannot be static and is unsupported.)
+            fill_value = fv.item() if hasattr(fv, "item") else fv
+        value = self.array.value.at[self.index].get(fill_value=fill_value, **kw)
         return replace(self.array, value=value)
 
     @override
@@ -1321,7 +1329,13 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
 
     @override
     def apply(self, func: Any, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
-        raise NotImplementedError  # TODO: by quaxified super
+        msg = (
+            "Quantity.at[...].apply is not implemented: the applied function "
+            "would have to be unit-aware. Strip the units, apply the function "
+            "to the raw array, and re-wrap: "
+            "`u.Quantity(q.ustrip(unit).at[idx].apply(func), unit)`."
+        )
+        raise NotImplementedError(msg)
 
     @override
     def add(self, values: AbstractQuantity, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1359,7 +1373,13 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
 
     @override
     def power(self, values: ArrayLike, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
-        raise NotImplementedError
+        msg = (
+            "Quantity.at[...].power is not supported: raising only some elements "
+            "to a power would give them different units from the rest of the "
+            "array, which a Quantity (one unit for all elements) cannot "
+            "represent."
+        )
+        raise NotImplementedError(msg)
 
     @override
     def min(self, values: AbstractQuantity, **kw: Any) -> AbstractQuantity:  # type: ignore[override]

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -1313,9 +1313,10 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         if fill_value is not None:
             fv = uapi.ustrip(self.array.unit, fill_value)
             # JAX treats ``fill_value`` as a *static* scalar and hashes it; a
-            # concrete ``jax.Array`` is unhashable there, so coerce to a Python
-            # scalar. (A traced fill value cannot be static and is unsupported.)
-            fill_value = fv.item() if hasattr(fv, "item") else fv
+            # concrete ``jax.Array`` is unhashable there, so coerce the stripped
+            # value (always a 0-d array) to a Python scalar. (A traced fill value
+            # cannot be static and is unsupported.)
+            fill_value = fv.item()
         value = self.array.value.at[self.index].get(fill_value=fill_value, **kw)
         return replace(self.array, value=value)
 

--- a/tests/unit/test_quantity_indexing_and_mt.py
+++ b/tests/unit/test_quantity_indexing_and_mt.py
@@ -1,0 +1,34 @@
+"""Tests for Quantity.mT, and the .at[...] get/apply/power methods."""
+
+import pytest
+
+import unxt as u
+
+
+def test_static_quantity_mt_transposes():
+    """StaticQuantity.mT returns the matrix transpose (was a TypeError)."""
+    sq = u.StaticQuantity([[0, 1], [2, 3]], "m")
+    assert sq.mT.value.tolist() == [[0, 2], [1, 3]]
+    assert sq.mT.unit == u.unit("m")
+    # and the regular Quantity still works
+    assert u.Q([[0, 1], [2, 3]], "m").mT.value.tolist() == [[0, 2], [1, 3]]
+
+
+def test_at_get_fill_value_accepts_a_quantity():
+    """.at[oob].get(fill_value=Quantity) works (was unhashable ArrayImpl)."""
+    q = u.Q([1.0, 2.0, 3.0], "m")
+    got = q.at[10].get(mode="fill", fill_value=u.Q(-1.0, "m"))
+    assert got.unit == u.unit("m")
+    assert float(got.value) == -1.0
+    # unit conversion of the fill value is honoured
+    got_km = q.at[10].get(mode="fill", fill_value=u.Q(-0.001, "km"))
+    assert float(got_km.value) == -1.0
+
+
+def test_at_apply_and_power_raise_explanatory_errors():
+    """.at[...].apply / .power raise NotImplementedError *with a message*."""
+    q = u.Q([1.0, 2.0, 3.0], "m")
+    with pytest.raises(NotImplementedError, match="apply is not implemented"):
+        q.at[0].apply(lambda x: x)
+    with pytest.raises(NotImplementedError, match="power is not supported"):
+        q.at[0].power(2)

--- a/tests/unit/test_quantity_indexing_and_mt.py
+++ b/tests/unit/test_quantity_indexing_and_mt.py
@@ -1,5 +1,6 @@
 """Tests for Quantity.mT, and the .at[...] get/apply/power methods."""
 
+import jax
 import pytest
 
 import unxt as u
@@ -23,6 +24,18 @@ def test_at_get_fill_value_accepts_a_quantity():
     # unit conversion of the fill value is honoured
     got_km = q.at[10].get(mode="fill", fill_value=u.Q(-0.001, "km"))
     assert float(got_km.value) == -1.0
+
+
+def test_at_get_traced_fill_value_raises_clear_error():
+    """A traced fill_value raises a clear TypeError, not a concretization error."""
+
+    @jax.jit
+    def f(fill):
+        q = u.Q([1.0, 2.0, 3.0], "m")
+        return q.at[10].get(mode="fill", fill_value=u.Q(fill, "m"))
+
+    with pytest.raises(TypeError, match="requires a concrete scalar fill value"):
+        f(-1.0)
 
 
 def test_at_apply_and_power_raise_explanatory_errors():


### PR DESCRIPTION
## Summary

Three quantity-core findings from the audit verification.

- **`StaticQuantity.mT` raised `TypeError`.** `mT` used `jnp.matrix_transpose(self.value)`, which rejects a `StaticValue`. Mirror `.T` and use `self.value.mT` (delegates to the wrapped NumPy/JAX array for both `Quantity` and `StaticQuantity`).
- **`Quantity.at[...].get(fill_value=<Quantity>)` was entirely broken** — the only legal non-`None` fill type crashed with `TypeError: unhashable type: 'ArrayImpl'`. The stripped fill was a `jax.Array`, which JAX hashes as a static scalar. Coerce a concrete stripped value to a Python scalar via `.item()`.
- **`.at[...].apply` / `.at[...].power` raised bare `NotImplementedError`** (no message) on documented, tab-completed public API. Both now raise with an explanation; `power` is a permanent limitation (per-element powers would need per-element units, which a single-unit `Quantity` can't hold).

## Verification (TDD)

New `tests/unit/test_quantity_indexing_and_mt.py`: StaticQuantity/Quantity `mT` transpose, `at[].get` with a `Quantity` fill (incl. unit conversion), and the explanatory `apply`/`power` errors. `tests/unit/` 354 passed; new `mT` doctest passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)