### PR TITLE
📝 docs(units): make the AbstractUnitSystem subclassing recipe runnable

### DIFF
--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -69,16 +69,30 @@ This rarely needs to be used. See `unxt.unitsystem`.
 
 :::
 
+A subclass declares one `Annotated` field per base dimension. Like the built-in systems, it must be a frozen dataclass and registered as a static JAX pytree node:
+
 ```{code-block} python
+>>> from dataclasses import dataclass
 >>> from typing import Annotated
+>>> import jax.tree_util as jtu
 >>> from astropy.units import UnitBase, get_physical_type
 >>> from unxt.unitsystems import AbstractUnitSystem
 
-
->>> class MyUSys(AbstractUnitSystem):
+>>> @jtu.register_static
+... @dataclass(frozen=True, slots=True)
+... class MyUSys(AbstractUnitSystem):
 ...     energy: Annotated[UnitBase, get_physical_type("energy")]
 ...     frequency: Annotated[UnitBase, get_physical_type("frequency")]
-...     luminance: Annotated[UnitBase, get_physical_type("luminance")]
+
+```
+
+Construct it with unit objects (a hand-built subclass stores its fields as given; the `unitsystem` factory is what parses strings for you):
+
+```{code-block} python
+>>> import unxt as u
+>>> usys = MyUSys(u.unit("erg"), u.unit("Hz"))
+>>> usys["energy"]
+Unit("erg")
 
 ```
 


### PR DESCRIPTION
## Summary

The `AbstractUnitSystem` subclassing recipe in the Unit Systems guide defined a bare `class MyUSys(AbstractUnitSystem)` with `Annotated` fields but never instantiated it — run verbatim it raises `TypeError: __init__() takes 1 positional argument but 3 were given` (a bare subclass gets no generated `__init__`).

Show the recipe that actually works, mirroring the built-in systems: decorate with `@jtu.register_static` + `@dataclass(frozen=True, slots=True)`, and construct with **unit objects** (a hand-built subclass stores its fields as given; the `unitsystem(...)` factory is what parses strings — passing a bare `"erg"` would leave `usys["energy"]` a `str`). It's now an executed doctest.

## Verification

`docs/guides/units_and_systems.md` sybil: 52 passed (the recipe is now a live doctest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)