### PR TITLE
📝 docs(hypothesis): correct inaccurate strategy docstrings

### DIFF
--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
@@ -58,7 +58,8 @@ def quantities(
         - `unxt.AbstractDimension`: Dimension to derive unit from (uses
           `unxts.hypothesis.units` strategy)
         - SearchStrategy: Strategy that generates units (e.g., from `units()`)
-          or dimensions. The default strategy samples from SI base units.
+          or dimensions. The default strategy samples from the Astropy
+          physical types (see ``named_dimensions``).
     quantity_cls : type[`unxt.AbstractQuantity`], optional
         The target quantity class to convert to. Default is `unxt.Quantity`.
         Can be any `unxt.AbstractQuantity` subclass like
@@ -80,8 +81,7 @@ def quantities(
         Whether to wrap the generated array in `unxt.quantity.StaticValue`.
         Default is `False`.
     **kwargs : Any
-        Additional keyword arguments (currently unused, reserved for future
-        use).
+        Additional keyword arguments forwarded to ``quantity_cls``.
 
     Returns
     -------
@@ -136,11 +136,11 @@ def quantities(
 
     Using dtype as a strategy:
 
-    >>> dtype_strat = st.sampled_from([jnp.float32, jnp.float64])
+    >>> dtype_strat = st.sampled_from([jnp.float32, jnp.int32])
     >>> @given(q=ust.quantities("m", dtype=dtype_strat))
     ... def test_varying_dtype(q):
-    ...     # dtype will vary between float32 and float64
-    ...     assert q.dtype in (jnp.float32, jnp.float64)
+    ...     # dtype will vary between float32 and int32
+    ...     assert q.dtype in (jnp.float32, jnp.int32)
 
     Using elements to constrain value ranges for distances (positive values):
 

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
@@ -60,7 +60,7 @@ def derived_units(
 
     Generate units from a strategy:
 
-    >>> @given(unit=ust.derived_units(st.sampled_from(["km", "m/s^2"])))
+    >>> @given(unit=ust.derived_units(st.sampled_from(["km/s", "m/s^2"])))
     ... def test_velocity_derived(unit):
     ...     assert u.dimension_of(unit) in (
     ...         u.dimension("velocity"),
@@ -161,7 +161,7 @@ def units(
     dimension : str | apyu.PhysicalType
         Physical dimension (e.g., "velocity", "length") or a `hypothesis`
         strategy that generates such dimensions. Default is a strategy sampling
-        from SI base dimensions.
+        from the Astropy physical types (see ``named_dimensions``).
     **kwargs : Any
         Additional keyword arguments passed to `derived_units()`.
         For example:

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
@@ -35,7 +35,7 @@ def unitsystems(
 
     Examples
     --------
-    >>> from hypothesis import given
+    >>> from hypothesis import given, strategies as st
     >>> import unxt as u
     >>> import unxts.hypothesis as ust
 
@@ -57,7 +57,7 @@ def unitsystems(
 
     Use predefined unit systems by name:
 
-    >>> @given(usys="galactic")  # Predefined
+    >>> @given(usys=st.just(u.unitsystem("galactic")))  # a fixed system
     ... def test_galactic_system(usys):
     ...     assert isinstance(usys, u.AbstractUnitSystem)
     ...     assert len(usys) == 4


### PR DESCRIPTION
## Summary

Factual corrections to `unxts.hypothesis` strategy docstrings from the audit verification. These examples pass vacuously today (the package's `@given` docstring examples are defined but never executed), so the errors went unnoticed.

- **`quantities`**: `**kwargs` was documented "currently unused" though it's forwarded to `quantity_cls`; the dtype example used `jnp.float64`, which raises `InvalidArgument` under JAX's default x32 config → `jnp.int32`; "samples from SI base units" → the Astropy physical types (via `named_dimensions`).
- **`units`**: `derived_units` velocity example sampled base `"km"` (a *length*), so the velocity/acceleration assertion couldn't hold → `"km/s"`; the same "SI base dimensions" claim corrected.
- **`unitsystems`**: `@given(usys="galactic")` is invalid Hypothesis usage (a bare value, not a strategy) → `@given(usys=st.just(u.unitsystem("galactic")))`, plus `import strategies as st`.

## Verification

Ran the corrected `dtype` (int32/float32) and `velocity` (km/s, m/s²) examples — both pass (they previously raised `InvalidArgument` / `AssertionError`). All three examples define cleanly.

## Not in this PR (bigger / separate)

Making the docstring `@given` examples self-executing (the medium-severity finding) risks flaky hypothesis-in-doctests; and the `derived_units` compound-unit no-op and `from_type(AbstractUnitSystem)` zero-entropy findings are logic bugs, not docstring fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)