### PR TITLE
🐛 fix(config): make override() per-instance, not a global-leaking singleton

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -17,7 +17,6 @@ __all__ = (
 )
 
 import contextlib
-import threading
 import tomllib
 from pathlib import Path
 from typing import Any, ClassVar, Final
@@ -136,7 +135,6 @@ class _ParametricLocalConfig(LocalConfigurable):
 class ParametricQuantityReprConfig(_ParametricLocalConfig):
     """``include_params`` for ``ParametricQuantity.__repr__`` (default ``False``)."""
 
-    _local: threading.local = threading.local()
     _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_REPR_CONFIG_KEYS
 
     include_params: ClassVar[object] = Bool(
@@ -148,7 +146,6 @@ class ParametricQuantityReprConfig(_ParametricLocalConfig):
 class ParametricQuantityStrConfig(_ParametricLocalConfig):
     """``include_params`` for ``ParametricQuantity.__str__`` (default ``True``)."""
 
-    _local: threading.local = threading.local()
     _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_STR_CONFIG_KEYS
 
     include_params: ClassVar[object] = Bool(

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -37,6 +37,14 @@ class LocalConfigurable(Configurable):
     # Thread-local storage for context manager overrides
     _local: threading.local
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Per-instance override stack. This MUST NOT be a class attribute:
+        # sharing one ``threading.local`` across instances lets ``override()``
+        # on any instance (e.g. a throwaway ``QuantityReprConfig()``) leak into
+        # every other instance, including the global ``unxt.config`` singleton.
+        object.__setattr__(self, "_local", threading.local())
+
 
 @dataclass(frozen=True, slots=True)
 class _NestedConfigContext:
@@ -114,9 +122,6 @@ class QuantityReprConfig(LocalConfigurable):
     Q([1, 2, 3], unit='m')
 
     """
-
-    # Thread-local storage for context manager overrides
-    _local: threading.local = threading.local()
 
     short_arrays: ClassVar[object] = Union(
         [Bool(), Enum(("compact",))],
@@ -321,9 +326,6 @@ class QuantityStrConfig(LocalConfigurable):
     Quantity([1, 2, 3], unit='m')
 
     """
-
-    # Thread-local storage for context manager overrides
-    _local: threading.local = threading.local()
 
     short_arrays: ClassVar[object] = Union(
         [Bool(), Enum(("compact",))],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,6 +15,7 @@ from traitlets.config import Config
 
 import unxt as u
 from unxt._src.config import (
+    QuantityReprConfig,
     _find_pyproject,
     _load_toml_config_from_pyproject,
     _walk_toml_config,
@@ -1114,3 +1115,25 @@ def test_new_namespace_does_not_warn() -> None:
         # and isn't made fragile by unrelated warnings.
         warnings.simplefilter("error", DeprecationWarning)
         _warn_if_legacy_unxt_config(data)  # must not raise
+
+
+def test_override_does_not_leak_between_instances():
+    """`override()` is per-instance: a throwaway config must not touch the global.
+
+    Regression: ``_local`` was a class attribute, so an ``override()`` on any
+    instance pushed onto a stack shared with the global ``unxt.config``
+    singleton, leaking the temporary setting into unrelated reads.
+    """
+    fresh = QuantityReprConfig()
+    baseline = u.config.quantity_repr.short_arrays
+
+    with fresh.override(short_arrays="compact"):
+        # the global singleton is unaffected by the throwaway instance ...
+        assert u.config.quantity_repr.short_arrays == baseline
+        # ... while the instance sees its own override
+        assert fresh.short_arrays == "compact"
+
+    # and the global override path still works and restores itself
+    with u.config.quantity_repr.override(short_arrays="compact"):
+        assert u.config.quantity_repr.short_arrays == "compact"
+    assert u.config.quantity_repr.short_arrays == baseline

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1117,7 +1117,7 @@ def test_new_namespace_does_not_warn() -> None:
         _warn_if_legacy_unxt_config(data)  # must not raise
 
 
-def test_override_does_not_leak_between_instances():
+def test_override_does_not_leak_between_instances() -> None:
     """`override()` is per-instance: a throwaway config must not touch the global.
 
     Regression: ``_local`` was a class attribute, so an ``override()`` on any
@@ -1126,14 +1126,18 @@ def test_override_does_not_leak_between_instances():
     """
     fresh = QuantityReprConfig()
     baseline = u.config.quantity_repr.short_arrays
+    # Pick an override value guaranteed to differ from the baseline so the test
+    # reliably detects leaks and validates restoration even if the baseline was
+    # changed to "compact" via TOML/environment config.
+    override = "compact" if baseline != "compact" else False
 
-    with fresh.override(short_arrays="compact"):
+    with fresh.override(short_arrays=override):
         # the global singleton is unaffected by the throwaway instance ...
         assert u.config.quantity_repr.short_arrays == baseline
         # ... while the instance sees its own override
-        assert fresh.short_arrays == "compact"
+        assert fresh.short_arrays == override
 
     # and the global override path still works and restores itself
-    with u.config.quantity_repr.override(short_arrays="compact"):
-        assert u.config.quantity_repr.short_arrays == "compact"
+    with u.config.quantity_repr.override(short_arrays=override):
+        assert u.config.quantity_repr.short_arrays == override
     assert u.config.quantity_repr.short_arrays == baseline


### PR DESCRIPTION
## Summary

Per your ruling on this audit finding. `LocalConfigurable._local` — the thread-local override stack — was a **class** attribute, so a single `threading.local()` was shared by every config instance. Using `override()` on any instance therefore pushed onto the same stack the global `unxt.config` singleton reads from:

```python
fresh = QuantityReprConfig()
with fresh.override(short_arrays="compact"):
    u.config.quantity_repr.short_arrays   # was "compact" (leaked!) → now unchanged
```

Give each instance its own `_local` in `LocalConfigurable.__init__` (via `object.__setattr__`, bypassing traitlets), and drop the now-redundant class-level assignments — here and in `unxts.parametric`'s config, which inherits the same `LocalConfigurable` machinery (the fix propagates; verified). The global override path is unchanged.

## Verification (TDD)

New `test_override_does_not_leak_between_instances`: a throwaway instance's `override()` leaves the global singleton untouched while the instance sees its own override, and the global override path still works and restores itself. `tests/unit/` 360 passed; parametric tests 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)