### PR TITLE
📝 docs(quantity): document select_n's raw-operand unit adoption as intentional

### DIFF
--- a/docs/guides/sharp-bits.md
+++ b/docs/guides/sharp-bits.md
@@ -253,6 +253,8 @@ Quantity(Array([1., 0.], dtype=float32), unit='m')
 Quantity(Array([ 1., 20.], dtype=float32), unit='m')
 ```
 
+Or reach for `unxt.experimental.where`, a strict alternative that **rejects** a raw-array branch outright (both branches must be quantities), so a bare array can never silently acquire a unit.
+
 ### ✅ Dimension Checking Works in JIT
 
 Good news! Dimensions are checked inside JIT:

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4625,12 +4625,16 @@ def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
 
     The raw ``case0`` operand is **intentionally** taken to be in ``case1``'s
     unit -- so ``jnp.where`` attaches the quantity's unit to bare numbers rather
-    than rejecting the mix (unlike ``jnp.concat``). Masking ops
-    (``triu``/``tril``/``trace``, ``where(mask, q, 0)``) rely on this to
-    zero-fill without losing the unit, and a genuine raw-data operand is
+    than rejecting the mix (unlike ``jnp.concat``). This ``(raw, quantity)``
+    ordering is what ``where(mask, q, 0)`` lowers to: ``jnp.where`` reverses its
+    branches into ``select_n(mask, 0, q)``, putting the raw zero-fill in
+    ``case0``. Masking ops that likewise zero-fill in ``case0`` -- ``tril`` and
+    ``trace`` -- route here too and rely on the raw zero adopting the unit.
+    (``triu`` and ``where(mask, 0, q)`` use the opposite ``(quantity, raw)``
+    ordering and dispatch to ``select_n_p_jqj``.) A genuine raw-data operand is
     indistinguishable from a masking zero-fill here. For a strict, unit-checked
-    select use ``unxt.experimental.where``; see the "``jnp.where`` adopts
-    the quantity's unit for a raw-array branch" sharp bit.
+    select use ``unxt.experimental.where``; see the "``jnp.where`` adopts the
+    quantity's unit for a raw-array branch" sharp bit.
     """
     # Used by a `jnp.linalg.trace`
     return replace(case1, value=lax.select_n(which, case0, ustrip(case1)))
@@ -4657,9 +4661,13 @@ def select_n_p_jqj(which: ArrayLike, case0: ABCQ, case1: ArrayLike, /) -> ABCQ:
 
     The raw ``case1`` operand is **intentionally** taken to be in ``case0``'s
     unit (as the ``triu`` zero-fill above shows), so ``jnp.where`` attaches the
-    quantity's unit to bare numbers rather than rejecting the mix. For a strict,
-    unit-checked select use ``unxt.experimental.where``; see the
-    "``jnp.where`` adopts the quantity's unit for a raw-array branch" sharp bit.
+    quantity's unit to bare numbers rather than rejecting the mix. This
+    ``(quantity, raw)`` ordering is what ``triu`` and ``where(mask, 0, q)`` --
+    lowered to ``select_n(mask, q, 0)`` -- route through. (The mirror case,
+    ``tril``/``trace`` and ``where(mask, q, 0)``, puts the raw operand in
+    ``case0`` and dispatches to ``select_n_p_jjq``.) For a strict, unit-checked
+    select use ``unxt.experimental.where``; see the "``jnp.where`` adopts the
+    quantity's unit for a raw-array branch" sharp bit.
 
     """
     return replace(case0, value=lax.select_n(which, ustrip(case0), case1))

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4621,7 +4621,17 @@ def select_n_p_q(which: ABCQ, /, *cases: ABCQ | ArrayLike) -> ABCQ | ArrayLike:
 
 @quax.register(lax.select_n_p)
 def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
-    """Select from an array and quantity using a quantity selector."""
+    """Select from a raw array and a quantity using a quantity selector.
+
+    The raw ``case0`` operand is **intentionally** taken to be in ``case1``'s
+    unit -- so ``jnp.where`` attaches the quantity's unit to bare numbers rather
+    than rejecting the mix (unlike ``concatenate``). Masking ops
+    (``triu``/``tril``/``trace``, ``where(mask, q, 0)``) rely on this to
+    zero-fill without losing the unit, and a genuine raw-data operand is
+    indistinguishable from a masking zero-fill here. For a strict, unit-checked
+    select use ``unxt.experimental.where``; see the "``jnp.where`` adopts
+    the quantity's unit for a raw-array branch" sharp bit.
+    """
     # Used by a `jnp.linalg.trace`
     return replace(case1, value=lax.select_n(which, case0, ustrip(case1)))
 
@@ -4644,6 +4654,12 @@ def select_n_p_jqj(which: ArrayLike, case0: ABCQ, case1: ArrayLike, /) -> ABCQ:
     >>> jnp.triu(u.Q([[1, 2], [3, 4]], "km"))
     Quantity(Array([[1, 2],
                               [0, 4]], dtype=int32), unit='km')
+
+    The raw ``case1`` operand is **intentionally** taken to be in ``case0``'s
+    unit (as the ``triu`` zero-fill above shows), so ``jnp.where`` attaches the
+    quantity's unit to bare numbers rather than rejecting the mix. For a strict,
+    unit-checked select use ``unxt.experimental.where``; see the
+    "``jnp.where`` adopts the quantity's unit for a raw-array branch" sharp bit.
 
     """
     return replace(case0, value=lax.select_n(which, ustrip(case0), case1))

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4625,7 +4625,7 @@ def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
 
     The raw ``case0`` operand is **intentionally** taken to be in ``case1``'s
     unit -- so ``jnp.where`` attaches the quantity's unit to bare numbers rather
-    than rejecting the mix (unlike ``concatenate``). Masking ops
+    than rejecting the mix (unlike ``jnp.concat``). Masking ops
     (``triu``/``tril``/``trace``, ``where(mask, q, 0)``) rely on this to
     zero-fill without losing the unit, and a genuine raw-data operand is
     indistinguishable from a masking zero-fill here. For a strict, unit-checked

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4621,7 +4621,7 @@ def select_n_p_q(which: ABCQ, /, *cases: ABCQ | ArrayLike) -> ABCQ | ArrayLike:
 
 @quax.register(lax.select_n_p)
 def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
-    """Select from a raw array and a quantity using a quantity selector.
+    """Select from a raw array and a quantity using a non-quantity selector.
 
     The raw ``case0`` operand is **intentionally** taken to be in ``case1``'s
     unit -- so ``jnp.where`` attaches the quantity's unit to bare numbers rather

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4626,11 +4626,11 @@ def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
     The raw ``case0`` operand is **intentionally** taken to be in ``case1``'s
     unit -- so ``jnp.where`` attaches the quantity's unit to bare numbers rather
     than rejecting the mix (unlike ``jnp.concat``). This ``(raw, quantity)``
-    ordering is what ``where(mask, q, 0)`` lowers to: ``jnp.where`` reverses its
-    branches into ``select_n(mask, 0, q)``, putting the raw zero-fill in
+    ordering is what ``jnp.where(mask, q, 0)`` lowers to: ``jnp.where`` reverses
+    its branches into ``select_n(mask, 0, q)``, putting the raw zero-fill in
     ``case0``. Masking ops that likewise zero-fill in ``case0`` -- ``tril`` and
     ``trace`` -- route here too and rely on the raw zero adopting the unit.
-    (``triu`` and ``where(mask, 0, q)`` use the opposite ``(quantity, raw)``
+    (``triu`` and ``jnp.where(mask, 0, q)`` use the opposite ``(quantity, raw)``
     ordering and dispatch to ``select_n_p_jqj``.) A genuine raw-data operand is
     indistinguishable from a masking zero-fill here. For a strict, unit-checked
     select use ``unxt.experimental.where``; see the "``jnp.where`` adopts the
@@ -4662,9 +4662,9 @@ def select_n_p_jqj(which: ArrayLike, case0: ABCQ, case1: ArrayLike, /) -> ABCQ:
     The raw ``case1`` operand is **intentionally** taken to be in ``case0``'s
     unit (as the ``triu`` zero-fill above shows), so ``jnp.where`` attaches the
     quantity's unit to bare numbers rather than rejecting the mix. This
-    ``(quantity, raw)`` ordering is what ``triu`` and ``where(mask, 0, q)`` --
-    lowered to ``select_n(mask, q, 0)`` -- route through. (The mirror case,
-    ``tril``/``trace`` and ``where(mask, q, 0)``, puts the raw operand in
+    ``(quantity, raw)`` ordering is what ``triu`` and ``jnp.where(mask, 0, q)``
+    -- lowered to ``select_n(mask, q, 0)`` -- route through. (The mirror case,
+    ``tril``/``trace`` and ``jnp.where(mask, q, 0)``, puts the raw operand in
     ``case0`` and dispatches to ``select_n_p_jjq``.) For a strict, unit-checked
     select use ``unxt.experimental.where``; see the "``jnp.where`` adopts the
     quantity's unit for a raw-array branch" sharp bit.


### PR DESCRIPTION
## Summary

Per your ruling (option A) on the `jnp.where` / `select_n` finding: **document the behavior as intentional** rather than attempt a fragile fix. As you noted, the unit-safe path already exists (`unxt.experimental.where`) and the sharp-bit already explains the inherent inconsistency.

`jnp.where(mask, raw, q)` (and `select_n`) intentionally treats a raw operand as being in the quantity's unit rather than rejecting the mix — because JAX lowers masking ops (`triu`/`tril`/`trace`, `where(mask, q, 0)`) to the same `select_n` primitive and *relies* on the raw zero-fill adopting the unit. A genuine raw-data operand is indistinguishable from a masking zero-fill at that level, so it can't be rejected without breaking those ops (verified: `jnp.triu(Q_km)` etc. all route through this path).

- State the intent explicitly in the `select_n_p_jjq` / `select_n_p_jqj` docstrings (they were silent — the finding's specific ask).
- Cross-reference `unxt.experimental.where` (the strict, raw-branch-rejecting alternative) from the existing sharp-bit, which previously only warned about the problem without pointing at the solution.

## Verification

`nox -s docs`: 0 `myst.xref_missing`, build succeeded. sybil on the edited files: 1299 passed (the `select_n` and sharp-bit doctests, including `jnp.triu`/`hypot`/`trace`, still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)