### PR TITLE
🐛 fix(quantity): str(StaticQuantity) shows values, like str(Quantity)

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -23,7 +23,6 @@ from typing import (
     NoReturn,
     TypeAlias,
     TypeGuard,
-    cast,
     override,
 )
 
@@ -1464,9 +1463,15 @@ def custom_pdoc_no_kind(obj: Any) -> wl.AbstractDoc | None:
 
 
 def custom_pdoc_noarray(obj: Any) -> wl.AbstractDoc | None:
-    """Return custom pdoc for ``AbstractQuantity`` objects."""
-    if isinstance(obj, jax.Array):
-        return wl.TextDoc(np.array2string(cast("np.ndarray", obj), separator=", "))
+    """Return the compact (values-only) pdoc for an array-like value.
+
+    Handles both a JAX ``Array`` and a NumPy ``ndarray`` -- the latter is what a
+    ``StaticQuantity``'s ``StaticValue`` wraps -- so ``str(StaticQuantity)``
+    shows its values like ``str(Quantity)`` rather than an ``f64[2](numpy)``
+    type summary.
+    """
+    if isinstance(obj, (jax.Array, np.ndarray)):
+        return wl.TextDoc(np.array2string(np.asarray(obj), separator=", "))
     return None
 
 

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -884,7 +884,7 @@ def test_quantity_ops_with_static_value() -> None:
     assert out_mul.unit == u.unit("m2")
 
 
-def test_str_shows_values_like_quantity():
+def test_str_shows_values_like_quantity() -> None:
     """`str(StaticQuantity)` shows its values, mirroring `str(Quantity)`.
 
     Regression: it used to render a `f64[2](numpy)` type summary because the

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -882,3 +882,19 @@ def test_quantity_ops_with_static_value() -> None:
     out_mul = q_static * q
     assert np.allclose(np.asarray(out_mul.value), np.array([3.0, 8.0]))
     assert out_mul.unit == u.unit("m2")
+
+
+def test_str_shows_values_like_quantity():
+    """`str(StaticQuantity)` shows its values, mirroring `str(Quantity)`.
+
+    Regression: it used to render a `f64[2](numpy)` type summary because the
+    compact pdoc handler only special-cased `jax.Array`, not the NumPy array a
+    `StaticValue` wraps.
+    """
+    sq = u.StaticQuantity([1.0, 2.0], "m")
+    assert str(sq) == "StaticQuantity([1., 2.], unit='m')"
+    assert "numpy" not in str(sq)
+    # scalar too
+    assert str(u.StaticQuantity(3.0, "m")) == "StaticQuantity(3., unit='m')"
+    # repr is unchanged (shows the NumPy array wrapper)
+    assert repr(sq) == "StaticQuantity(array([1., 2.]), unit='m')"


### PR DESCRIPTION
## Summary

`str(u.StaticQuantity([1., 2.], "m"))` printed `StaticQuantity(f64[2](numpy), unit='m')` — a dtype/shape summary instead of the values — diverging from `str(Quantity)` → `Quantity([1., 2.], unit='m')`.

Root cause: the compact (values-only) pdoc handler `custom_pdoc_noarray` special-cased only `jax.Array`. A `StaticQuantity`'s value is a `StaticValue` wrapping a **NumPy** array, which fell through to wadler-lindig's short-array summary. Handle `numpy.ndarray` too (via `np.asarray` + `array2string`).

`str` now shows values for both array and scalar StaticQuantities; `repr` is unchanged (still shows the `array([...])` wrapper).

## Verification (TDD)

New `test_str_shows_values_like_quantity`: `str(StaticQuantity([1.,2.],"m")) == "StaticQuantity([1., 2.], unit='m')"`, scalar too, and `repr` unchanged. `tests/unit/` 371 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)