### PR TITLE
🐛 fix(config): make root update_config() work; document reload()

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -401,9 +401,11 @@ Apply to the nested config instances:
 Q([1., 2., 3.], unit='m')
 ```
 
-Or update the **root** config, which forwards to the nested sections:
+Or update the **root** config, which forwards to the nested sections. Capture the current value first so we can restore it afterward:
 
 ```{code-block} python
+>>> baseline_short_arrays = u.config.quantity_repr.short_arrays
+
 >>> root_cfg = Config()
 >>> root_cfg.QuantityReprConfig.short_arrays = "compact"
 
@@ -412,14 +414,14 @@ Or update the **root** config, which forwards to the nested sections:
 'compact'
 ```
 
-Restore the default so the rest of this guide is unaffected:
+Restore the previous value so the rest of this guide is unaffected:
 
 ```{code-block} python
 >>> reset_cfg = Config()
->>> reset_cfg.QuantityReprConfig.short_arrays = False
+>>> reset_cfg.QuantityReprConfig.short_arrays = baseline_short_arrays
 >>> u.config.update_config(reset_cfg)
->>> u.config.quantity_repr.short_arrays
-False
+>>> u.config.quantity_repr.short_arrays == baseline_short_arrays
+True
 ```
 
 ## See Also

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -246,6 +246,16 @@ use_short_name = true
 
 The loaded configuration is applied globally for the active Python process.
 
+### Reloading file-based configuration
+
+The `[tool.unxts.unxt]` section is read **once, at import**, using the working directory at that moment. If you import `unxt` _before_ changing into your project directory — common in notebooks and test runners — that section is missed. Re-read it with `reload()`:
+
+```{code-block} python
+>>> loaded = u.config.reload()  # re-read pyproject.toml from the current cwd
+```
+
+`reload()` returns a `bool`: `False` when no `pyproject.toml` was found (or it could not be read, or had no `[tool.unxts.unxt]` settings), so you can detect a no-op reload. Only keys present in the file are applied; every other setting keeps its current value.
+
 ## Temporary Configuration with Context Manager
 
 Use context managers for temporary changes that are automatically restored. There are two approaches:
@@ -391,20 +401,26 @@ Apply to the nested config instances:
 Q([1., 2., 3.], unit='m')
 ```
 
-Or update the root config:
-
-<!-- skip: start -->
+Or update the **root** config, which forwards to the nested sections:
 
 ```{code-block} python
-from traitlets.config import Config
+>>> root_cfg = Config()
+>>> root_cfg.QuantityReprConfig.short_arrays = "compact"
 
-cfg = Config()
-cfg.QuantityReprConfig.short_arrays = "compact"
-
-u.config.update_config(cfg)
+>>> u.config.update_config(root_cfg)
+>>> u.config.quantity_repr.short_arrays
+'compact'
 ```
 
-<!-- skip: end -->
+Restore the default so the rest of this guide is unaffected:
+
+```{code-block} python
+>>> reset_cfg = Config()
+>>> reset_cfg.QuantityReprConfig.short_arrays = False
+>>> u.config.update_config(reset_cfg)
+>>> u.config.quantity_repr.short_arrays
+False
+```
 
 ## See Also
 

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -521,7 +521,7 @@ class AbstractUnxtConfig:
 
         return _ConfigContext(self, parsed_overrides)
 
-    def update_config(self, config: Config) -> None:
+    def update_config(self, cfg: Config) -> None:
         """Apply a traitlets ``Config`` to this config and its nested sections.
 
         ``traitlets``'s own ``update_config`` only touches *this* object's
@@ -531,9 +531,11 @@ class AbstractUnxtConfig:
         ``cfg.QuantityReprConfig.short_arrays = "compact"`` takes effect instead
         of silently doing nothing.
         """
-        super().update_config(config)  # type: ignore[misc]  # provided by Configurable
+        # ``super()`` resolves through the concrete class's MRO to
+        # ``Configurable.update_config`` (this mixin is combined with it).
+        super().update_config(cfg)  # type: ignore[misc]  # pylint: disable=no-member
         for name in self._override_config_keys:
-            getattr(self, name).update_config(config)
+            getattr(self, name).update_config(cfg)
 
 
 class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -526,10 +526,11 @@ class AbstractUnxtConfig:
 
         ``traitlets``'s own ``update_config`` only touches *this* object's
         traits, but the display settings actually live on the eagerly-built
-        nested configs (``quantity_repr`` / ``quantity_str``). Forward to them
-        so ``config.update_config(cfg)`` with e.g.
-        ``cfg.QuantityReprConfig.short_arrays = "compact"`` takes effect instead
-        of silently doing nothing.
+        nested configs. Forward the config to every nested section this config
+        declares in ``_override_config_keys`` (e.g. ``quantity_repr`` /
+        ``quantity_str`` for ``UnxtConfig``) so ``config.update_config(cfg)``
+        with e.g. ``cfg.QuantityReprConfig.short_arrays = "compact"`` takes
+        effect instead of silently doing nothing.
         """
         # ``super()`` resolves through the concrete class's MRO to
         # ``Configurable.update_config`` (this mixin is combined with it).

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -521,6 +521,20 @@ class AbstractUnxtConfig:
 
         return _ConfigContext(self, parsed_overrides)
 
+    def update_config(self, config: Config) -> None:
+        """Apply a traitlets ``Config`` to this config and its nested sections.
+
+        ``traitlets``'s own ``update_config`` only touches *this* object's
+        traits, but the display settings actually live on the eagerly-built
+        nested configs (``quantity_repr`` / ``quantity_str``). Forward to them
+        so ``config.update_config(cfg)`` with e.g.
+        ``cfg.QuantityReprConfig.short_arrays = "compact"`` takes effect instead
+        of silently doing nothing.
+        """
+        super().update_config(config)  # type: ignore[misc]  # provided by Configurable
+        for name in self._override_config_keys:
+            getattr(self, name).update_config(config)
+
 
 class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
     """Configuration for unxt display and printing options.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1141,3 +1141,23 @@ def test_override_does_not_leak_between_instances() -> None:
     with u.config.quantity_repr.override(short_arrays=override):
         assert u.config.quantity_repr.short_arrays == override
     assert u.config.quantity_repr.short_arrays == baseline
+
+
+def test_update_config_forwards_to_nested_sections():
+    """`update_config` on the root config reaches the nested sections.
+
+    Regression: `UnxtConfig.update_config(cfg)` was a silent no-op because the
+    nested `quantity_repr`/`quantity_str` configs are built eagerly in
+    `__init__`; a later `update_config` on the parent never reached them.
+    """
+    baseline = u.config.quantity_repr.short_arrays
+    try:
+        cfg = Config()
+        cfg.QuantityReprConfig.short_arrays = "compact"
+        u.config.update_config(cfg)
+        assert u.config.quantity_repr.short_arrays == "compact"
+    finally:
+        reset = Config()
+        reset.QuantityReprConfig.short_arrays = baseline
+        u.config.update_config(reset)
+    assert u.config.quantity_repr.short_arrays == baseline

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1168,9 +1168,9 @@ def test_update_config_forwards_to_nested_sections() -> None:
         assert u.config.quantity_repr.short_arrays == repr_override
         assert u.config.quantity_str.short_arrays == str_override
     finally:
-        reset = Config()
-        reset.QuantityReprConfig.short_arrays = repr_baseline
-        reset.QuantityStrConfig.short_arrays = str_baseline
-        u.config.update_config(reset)
+        # Restore via direct trait assignment -- independent of the
+        # ``update_config`` behavior this test is exercising.
+        u.config.quantity_repr.short_arrays = repr_baseline
+        u.config.quantity_str.short_arrays = str_baseline
     assert u.config.quantity_repr.short_arrays == repr_baseline
     assert u.config.quantity_str.short_arrays == str_baseline

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1150,18 +1150,27 @@ def test_update_config_forwards_to_nested_sections() -> None:
     nested `quantity_repr`/`quantity_str` configs are built eagerly in
     `__init__`; a later `update_config` on the parent never reached them.
     """
-    baseline = u.config.quantity_repr.short_arrays
-    # Pick an override value guaranteed to differ from the baseline so the test
-    # detects the no-op regression even if the baseline was changed to "compact"
+    # Assert forwarding into *every* nested section, not just quantity_repr, so
+    # a partial-forwarding regression (e.g. `_override_config_keys` omitting a
+    # section) is caught.
+    repr_baseline = u.config.quantity_repr.short_arrays
+    str_baseline = u.config.quantity_str.short_arrays
+    # Pick override values guaranteed to differ from each baseline so the test
+    # detects the no-op regression even if a baseline was changed to "compact"
     # via TOML/environment config.
-    override = "compact" if baseline != "compact" else False
+    repr_override = "compact" if repr_baseline != "compact" else False
+    str_override = "compact" if str_baseline != "compact" else False
     try:
         cfg = Config()
-        cfg.QuantityReprConfig.short_arrays = override
+        cfg.QuantityReprConfig.short_arrays = repr_override
+        cfg.QuantityStrConfig.short_arrays = str_override
         u.config.update_config(cfg)
-        assert u.config.quantity_repr.short_arrays == override
+        assert u.config.quantity_repr.short_arrays == repr_override
+        assert u.config.quantity_str.short_arrays == str_override
     finally:
         reset = Config()
-        reset.QuantityReprConfig.short_arrays = baseline
+        reset.QuantityReprConfig.short_arrays = repr_baseline
+        reset.QuantityStrConfig.short_arrays = str_baseline
         u.config.update_config(reset)
-    assert u.config.quantity_repr.short_arrays == baseline
+    assert u.config.quantity_repr.short_arrays == repr_baseline
+    assert u.config.quantity_str.short_arrays == str_baseline

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1143,7 +1143,7 @@ def test_override_does_not_leak_between_instances() -> None:
     assert u.config.quantity_repr.short_arrays == baseline
 
 
-def test_update_config_forwards_to_nested_sections():
+def test_update_config_forwards_to_nested_sections() -> None:
     """`update_config` on the root config reaches the nested sections.
 
     Regression: `UnxtConfig.update_config(cfg)` was a silent no-op because the
@@ -1151,11 +1151,15 @@ def test_update_config_forwards_to_nested_sections():
     `__init__`; a later `update_config` on the parent never reached them.
     """
     baseline = u.config.quantity_repr.short_arrays
+    # Pick an override value guaranteed to differ from the baseline so the test
+    # detects the no-op regression even if the baseline was changed to "compact"
+    # via TOML/environment config.
+    override = "compact" if baseline != "compact" else False
     try:
         cfg = Config()
-        cfg.QuantityReprConfig.short_arrays = "compact"
+        cfg.QuantityReprConfig.short_arrays = override
         u.config.update_config(cfg)
-        assert u.config.quantity_repr.short_arrays == "compact"
+        assert u.config.quantity_repr.short_arrays == override
     finally:
         reset = Config()
         reset.QuantityReprConfig.short_arrays = baseline


### PR DESCRIPTION
## Summary

Two related config findings from the audit.

- **`u.config.update_config(cfg)` was a silent no-op** (medium). The nested `quantity_repr`/`quantity_str` configs are built eagerly in `UnxtConfig.__init__`, so a later `update_config` on the parent never reached them. Added a generic `update_config` to the `AbstractUnxtConfig` mixin that forwards to each nested section (`unxts.parametric`'s config gets it too, for free). The guide's "update the root config" example — previously `<!-- skip -->`-wrapped precisely because it did nothing — is now an executed doctest.
- **`config.reload()` was undocumented** (low). Added a "Reloading file-based configuration" subsection to the configuration guide covering the import-time/cwd pitfall it solves and the `bool` return meaning.

## Verification (TDD)

New `test_update_config_forwards_to_nested_sections`. `docs/guides/configuration.md` sybil 71 passed (the `update_config` + `reload()` examples now execute); `tests/unit/` 372 passed.

## Not in this PR (follow-up)

Moving `reload()` onto the shared mixin so `unxts.parametric.config` also gets it (finding: "ParametricConfig lacks reload()") is a larger refactor — each config module has its own `_auto_load_project_toml_config` with a hardcoded tool path — so it's deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)