### PR TITLE
🐛 fix(interop-xarray): reject quantify() unit specs for unknown names

### DIFF
--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -271,7 +271,14 @@ def _reject_unknown_unit_names(
     """
     unknown = [k for k in units if k not in valid_names]
     if unknown:
-        valid = ", ".join(sorted(repr(n) for n in valid_names if n is not None))
+        # ``None`` is the DataArray's own-data key; surface it explicitly so the
+        # message stays helpful (and non-empty) when there are no other names.
+        valid = (
+            ", ".join(
+                sorted("None (the data)" if n is None else repr(n) for n in valid_names)
+            )
+            or "(none)"
+        )
         bad = ", ".join(repr(k) for k in unknown)
         msg = (
             f"got unit(s) for name(s) not in the {obj_kind}: {bad}. "

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -260,6 +260,26 @@ def extract_units(obj: object, /) -> dict:
     raise TypeError(msg)
 
 
+def _reject_unknown_unit_names(
+    units: "Mapping[Hashable, Any]", valid_names: "set[Any]", obj_kind: str
+) -> None:
+    """Raise if units names something that is not a variable/coordinate.
+
+    Without this, a typo in a **unit_kwargs name (e.g.
+    quantify(temperatrue="K")) is silently dropped by units.get(name),
+    leaving the data unquantified with no error or warning.
+    """
+    unknown = [k for k in units if k not in valid_names]
+    if unknown:
+        valid = ", ".join(sorted(repr(n) for n in valid_names if n is not None))
+        bad = ", ".join(repr(k) for k in unknown)
+        msg = (
+            f"got unit(s) for name(s) not in the {obj_kind}: {bad}. "
+            f"Valid names: {valid}."
+        )
+        raise ValueError(msg)
+
+
 @dispatch
 def attach_units(
     obj: DataArray, units: Mapping[Hashable, u.AbstractUnit | str | None]
@@ -296,6 +316,8 @@ def attach_units(
     {}
 
     """
+    _reject_unknown_unit_names(units, {None} | set(obj.coords), "DataArray")
+
     # Handle the data array itself (None key = the DataArray's own data)
     data_unit = units.get(None)
     new_data = _array_attach_units(obj.data, data_unit)
@@ -346,6 +368,8 @@ def attach_units(
         New Dataset with units attached as Quantities.
 
     """
+    _reject_unknown_unit_names(units, set(obj.data_vars) | set(obj.coords), "Dataset")
+
     # Handle all variables in dataset
     new_vars = {}
     for name, var in obj.data_vars.items():

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -269,22 +269,18 @@ def _reject_unknown_unit_names(
     quantify(temperatrue="K")) is silently dropped by units.get(name),
     leaving the data unquantified with no error or warning.
     """
-    unknown = [k for k in units if k not in valid_names]
-    if unknown:
-        # ``None`` is the DataArray's own-data key; surface it explicitly so the
-        # message stays helpful (and non-empty) when there are no other names.
-        valid = (
-            ", ".join(
-                sorted("None (the data)" if n is None else repr(n) for n in valid_names)
-            )
-            or "(none)"
-        )
-        bad = ", ".join(repr(k) for k in unknown)
-        msg = (
-            f"got unit(s) for name(s) not in the {obj_kind}: {bad}. "
-            f"Valid names: {valid}."
-        )
-        raise ValueError(msg)
+    unknown = [repr(k) for k in units if k not in valid_names]
+    if not unknown:
+        return
+    # ``None`` is the DataArray's own-data key; render it explicitly so the
+    # message stays helpful (and non-empty) when there are no other names.
+    names = ("None (the data)" if n is None else repr(n) for n in valid_names)
+    valid = ", ".join(sorted(names)) or "(none)"
+    msg = (
+        f"got unit(s) for name(s) not in the {obj_kind}: {', '.join(unknown)}. "
+        f"Valid names: {valid}."
+    )
+    raise ValueError(msg)
 
 
 @dispatch

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -269,7 +269,9 @@ def _reject_unknown_unit_names(
     quantify(temperatrue="K")) is silently dropped by units.get(name),
     leaving the data unquantified with no error or warning.
     """
-    unknown = [repr(k) for k in units if k not in valid_names]
+    # Sort so the message is deterministic: `units` insertion order follows the
+    # accessor's ``set(...)`` iteration, which is not stable across processes.
+    unknown = sorted(repr(k) for k in units if k not in valid_names)
     if not unknown:
         return
     # ``None`` is the DataArray's own-data key; render it explicitly so the

--- a/packages/unxts.interop.xarray/tests/test_unknown_unit_keys.py
+++ b/packages/unxts.interop.xarray/tests/test_unknown_unit_keys.py
@@ -21,9 +21,14 @@ def test_dataset_typo_key_raises():
 
 
 def test_dataarray_typo_coord_key_raises():
-    da = xr.DataArray([1.0, 2.0], dims=["x"], coords={"x": ("x", [0.0, 1.0])})
-    with pytest.raises(ValueError, match=r"not in the DataArray.*'xx'"):
-        da.unxt.quantify(xx="s")
-    # valid data + coord names still work
-    q = da.unxt.quantify("m", x="s")
+    # ``y`` is a *non-dimension* coordinate on dim ``x``. A dimension coordinate
+    # would be wrapped in a pandas index by xarray, which drops the unit (a
+    # separate, known limitation), so a non-dimension coord is used here to
+    # verify that a valid coord name actually quantifies.
+    da = xr.DataArray([1.0, 2.0], dims=["x"], coords={"y": ("x", [10.0, 20.0])})
+    with pytest.raises(ValueError, match=r"not in the DataArray.*'yy'"):
+        da.unxt.quantify(yy="s")
+    # valid data + coord names still quantify
+    q = da.unxt.quantify("m", y="s")
     assert u.unit_of(q.data) == u.unit("m")
+    assert u.unit_of(q.coords["y"].data) == u.unit("s")

--- a/packages/unxts.interop.xarray/tests/test_unknown_unit_keys.py
+++ b/packages/unxts.interop.xarray/tests/test_unknown_unit_keys.py
@@ -1,0 +1,29 @@
+"""quantify()/attach_units reject unit specs for names that don't exist.
+
+Regression: a typo in a `**unit_kwargs` name was silently dropped, leaving the
+data unquantified with no error.
+"""
+
+import pytest
+import unxts.interop.xarray  # noqa: F401  # registers the .unxt accessor
+import xarray as xr
+
+import unxt as u
+
+
+def test_dataset_typo_key_raises():
+    ds = xr.Dataset({"temperature": ("x", [1.0, 2.0])})
+    with pytest.raises(ValueError, match=r"not in the Dataset.*temperatrue"):
+        ds.unxt.quantify(temperatrue="K")
+    # the correct name still works
+    q = ds.unxt.quantify(temperature="K")
+    assert u.unit_of(q["temperature"].data) == u.unit("K")
+
+
+def test_dataarray_typo_coord_key_raises():
+    da = xr.DataArray([1.0, 2.0], dims=["x"], coords={"x": ("x", [0.0, 1.0])})
+    with pytest.raises(ValueError, match=r"not in the DataArray.*'xx'"):
+        da.unxt.quantify(xx="s")
+    # valid data + coord names still work
+    q = da.unxt.quantify("m", x="s")
+    assert u.unit_of(q.data) == u.unit("m")


### PR DESCRIPTION
## Summary

`attach_units` iterated the object's variables/coords doing `units.get(name)`, so any key that matched **nothing** — most easily a typo in a `**unit_kwargs` name — was silently dropped:

```python
ds.unxt.quantify(temperatrue="K")   # typo → temperature left completely unquantified, no error
```

Now both the DataArray and Dataset `attach_units` dispatches validate the supplied names against the object's variables/coordinates (plus the `None` key for a DataArray's own data) and raise a `ValueError` naming the unmatched keys.

## Verification (TDD)

New `test_unknown_unit_keys.py`: a typo'd key raises for both `Dataset` and `DataArray` (naming the bad key), while the correct names still quantify. `unxts.interop.xarray` tests: 15 passed.

## Notes

- The related HIGH "stale `units` attr after quantify" finding is **already fixed** (verified — attrs come back `{}`; handled by #748).
- The LOW "units silently dropped on **dimension** coordinates" finding is left for a follow-up: warning on it correctly requires distinguishing an *explicitly-requested* unit from an *attribute-derived* one (a roundtrip, where the attr preserves the record) — that distinction lives in the accessor, not `attach_units`, so a naive warning is noisy and breaks the roundtrip contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)