### PR TITLE
✨ feat(unxts-linalg): give `QuantityMatrix` short_name "QM"

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -1,6 +1,6 @@
 """QuantityMatrix class and unit-conversion helpers."""
 
-from typing import Any, NoReturn
+from typing import Any, ClassVar, NoReturn
 
 import equinox as eqx
 import jax
@@ -94,6 +94,8 @@ class QuantityMatrix(u.AbstractQuantity):
 
     value: Shaped[Array, "..."] = eqx.field()
     unit: UnitsMatrix = eqx.field(static=True, converter=u.unit)  # ty: ignore[invalid-assignment]
+
+    short_name: ClassVar[str] = "QM"
 
     def __check_init__(self) -> None:
         """Check the value's trailing shape matches the unit structure.


### PR DESCRIPTION
## Summary

Add a `short_name` class variable to `QuantityMatrix`, mirroring `Quantity` (`"Q"`) and `ParametricQuantity` (`"PQ"`).

`AbstractQuantity`'s printing path honors a `short_name` class var when `use_short_name=True`, but `QuantityMatrix` never defined one — so short-name rendering fell back to the full class name. This adds `short_name = "QM"`, matching the existing `QM` module-level alias.

## Change

```python
short_name: ClassVar[str] = "QM"
```

## Verification

```pycon
>>> import jax.numpy as jnp, wadler_lindig as wl
>>> from unxts.linalg import QuantityMatrix
>>> qv = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
>>> wl.pprint(qv, use_short_name=True)
QM(f32[3], unit='(m, s, kg)')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)