### PR TITLE
✅ test(unxts-linalg): cover `QuantityMatrix` short_name "QM"

### DIFF
--- a/packages/unxts.linalg/tests/test_printing.py
+++ b/packages/unxts.linalg/tests/test_printing.py
@@ -1,0 +1,29 @@
+"""Tests for QuantityMatrix printing with wadler-lindig."""
+
+import jax.numpy as jnp
+import wadler_lindig as wl
+from unxts.linalg import QM, QuantityMatrix
+
+
+class TestQuantityMatrixShortName:
+    """Short-name / pretty-printing behavior specific to ``QuantityMatrix``."""
+
+    def test_quantitymatrix_short_name(self):
+        """``QuantityMatrix`` (``QM``) has short_name 'QM'."""
+        assert hasattr(QuantityMatrix, "short_name")
+        assert QuantityMatrix.short_name == "QM"
+        assert QM.short_name == "QM"
+
+    def test_uses_full_name_by_default(self):
+        """``QuantityMatrix`` uses its full name by default."""
+        qv = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+        result = wl.pformat(qv)
+        assert result.startswith("QuantityMatrix")
+        assert not result.startswith("QM(")
+
+    def test_use_short_name_true(self):
+        """``QuantityMatrix`` uses its short name 'QM'."""
+        qv = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+        result = wl.pformat(qv, use_short_name=True)
+        assert result.startswith("QM(")
+        assert "unit='(m, s, kg)'" in result


### PR DESCRIPTION
## Summary

Adds a printing test module for `QuantityMatrix`, mirroring the existing `Quantity` / `ParametricQuantity` short-name tests. It asserts:

- `QuantityMatrix.short_name == "QM"` (and via the `QM` alias)
- the full class name is used by default
- `use_short_name=True` renders `QM(...)`

## Stacking

**Stacked on #795** (which adds `short_name = "QM"`). Until #795 merges, the diff here also shows that one-line change; it collapses to just the new test once #795 lands in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)