### PR TITLE
♻️ refactor: hoist config override machinery into LocalConfigurable

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -16,20 +16,18 @@ __all__ = (
     "config",
 )
 
-import contextlib
 import tomllib
 from pathlib import Path
 from typing import Any, ClassVar, Final
 
 from traitlets import Bool, TraitError
-from traitlets.config import Config, SingletonConfigurable
+from traitlets.config import SingletonConfigurable
 
 from unxt._src.config import (
     AbstractUnxtConfig,
     LocalConfigurable,
     _find_pyproject,
     _load_toml_config_from_pyproject,
-    _NestedConfigContext,
 )
 
 PARAMETRIC_REPR_CONFIG_KEYS: Final = frozenset({"include_params"})
@@ -41,99 +39,14 @@ PARAMETRIC_OVERRIDE_CONFIG_KEYS: Final = {
 }
 
 
-class _ParametricLocalConfig(LocalConfigurable):
-    """Base for the parametric repr/str configs with thread-local overrides.
+class ParametricQuantityReprConfig(LocalConfigurable):
+    """``include_params`` for ``ParametricQuantity.__repr__`` (default ``False``).
 
-    Subclasses set ``_config_keys`` (their overridable trait names) and their
-    own ``_local`` thread-local storage; this base provides the generic
-    ``__getattribute__`` override lookup and ``override()`` context manager.
+    ``__getattribute__`` (thread-local override lookup) and ``override()`` (the
+    context manager) are inherited from
+    :class:`~unxt._src.config.LocalConfigurable`; this class only declares its
+    overridable trait and its ``_config_keys`` allowlist.
     """
-
-    _config_keys: ClassVar[frozenset[str]] = frozenset()
-
-    def __getattribute__(self, name: str) -> Any:
-        """Get attribute, checking thread-local overrides first."""
-        keys = object.__getattribute__(self, "_config_keys")
-        if name in keys:
-            with contextlib.suppress(AttributeError):
-                local = object.__getattribute__(self, "_local")
-                if hasattr(local, "stack") and local.stack:
-                    for overrides in reversed(local.stack):
-                        if name in overrides:
-                            return overrides[name]
-
-        return object.__getattribute__(self, name)
-
-    def override(
-        self, cfg: Config | None = None, /, **kwargs: Any
-    ) -> _NestedConfigContext:
-        """Create a context manager for temporary config changes.
-
-        Examples
-        --------
-        >>> import unxts.parametric as up
-        >>> with up.config.quantity_repr.override(include_params=True):
-        ...     print(up.config.quantity_repr.include_params)
-        True
-
-        """
-        keys = self._config_keys
-        cls_name = type(self).__name__
-
-        if cfg is not None and kwargs:
-            msg = "Cannot specify both cfg and keyword arguments to override()"
-            raise ValueError(msg)
-
-        if kwargs:
-            unknown_keys = set(kwargs) - keys
-            if unknown_keys:
-                valid_keys = ", ".join(sorted(keys))
-                unknown = ", ".join(sorted(unknown_keys))
-                msg = (
-                    f"Unknown {cls_name} override option(s): {unknown}. "
-                    f"Valid options are: {valid_keys}"
-                )
-                raise ValueError(msg)
-
-            # Validate/resolve through traitlets immediately for fast, clear errors.
-            temp_instance = self.__class__()
-            validated_kwargs: dict[str, Any] = {}
-            for key, value in kwargs.items():
-                try:
-                    setattr(temp_instance, key, value)
-                except TraitError as e:
-                    msg = (
-                        f"Invalid value for {cls_name} override option "
-                        f"'{key}': {value!r}"
-                    )
-                    raise ValueError(msg) from e
-                validated_kwargs[key] = object.__getattribute__(temp_instance, key)
-            kwargs = validated_kwargs
-
-        if cfg is not None:
-            temp_instance = self.__class__(config=cfg)
-            # Only override the traits the Config actually specifies. Iterating
-            # every trait would read the class default for traits absent from
-            # ``cfg`` and clobber any globally-configured value on entry.
-            specified: set[str] = set()
-            for klass in type(self).__mro__:
-                section = cfg.get(klass.__name__, None)
-                if section:
-                    specified |= set(section)
-            # Intersect with the *override allowlist*, not all traits:
-            # ``__getattribute__`` only consults these keys, so an entry outside
-            # it could never be observed -- it would just be a dead push.
-            overrides = {
-                name: object.__getattribute__(temp_instance, name)
-                for name in specified & set(self._config_keys)
-            }
-            kwargs = overrides
-
-        return _NestedConfigContext(self, kwargs)
-
-
-class ParametricQuantityReprConfig(_ParametricLocalConfig):
-    """``include_params`` for ``ParametricQuantity.__repr__`` (default ``False``)."""
 
     _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_REPR_CONFIG_KEYS
 
@@ -143,8 +56,12 @@ class ParametricQuantityReprConfig(_ParametricLocalConfig):
     ).tag(config=True)
 
 
-class ParametricQuantityStrConfig(_ParametricLocalConfig):
-    """``include_params`` for ``ParametricQuantity.__str__`` (default ``True``)."""
+class ParametricQuantityStrConfig(LocalConfigurable):
+    """``include_params`` for ``ParametricQuantity.__str__`` (default ``True``).
+
+    See :class:`ParametricQuantityReprConfig` — the override machinery is
+    inherited from :class:`~unxt._src.config.LocalConfigurable`.
+    """
 
     _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_STR_CONFIG_KEYS
 

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -31,11 +31,15 @@ class LocalConfigurable(Configurable):
 
     This class provides a mechanism for temporary, thread-local configuration
     changes that can be used in nested contexts (e.g., within a quantity's
-    ``__repr__()``).
+    ``__repr__()``). Concrete subclasses only declare their traits and set
+    ``_config_keys`` (the trait names eligible for override); the override
+    lookup and the ``override()`` context manager live here.
     """
 
     # Thread-local storage for context manager overrides
     _local: threading.local
+    # Names of the config traits eligible for thread-local override
+    _config_keys: ClassVar[frozenset[str]] = frozenset()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -44,6 +48,132 @@ class LocalConfigurable(Configurable):
         # on any instance (e.g. a throwaway ``QuantityReprConfig()``) leak into
         # every other instance, including the global ``unxt.config`` singleton.
         object.__setattr__(self, "_local", threading.local())
+
+    def __getattribute__(self, name: str) -> Any:
+        """Get attribute, checking thread-local overrides first."""
+        if name in object.__getattribute__(self, "_config_keys"):
+            with contextlib.suppress(AttributeError):
+                local = object.__getattribute__(self, "_local")
+                # Return the most recent override for this attribute
+                if hasattr(local, "stack") and local.stack:
+                    for overrides in reversed(local.stack):
+                        if name in overrides:
+                            return overrides[name]
+
+        return object.__getattribute__(self, name)
+
+    def override(
+        self, cfg: Config | None = None, /, **kwargs: Any
+    ) -> "_NestedConfigContext":
+        """Create a context manager for temporary config changes.
+
+        Parameters
+        ----------
+        cfg : traitlets.config.Config, optional
+            A traitlets Config object with settings for this config class.
+            Cannot be used together with keyword arguments.
+        **kwargs
+            Configuration options to set temporarily (e.g.,
+            short_arrays="compact").  Cannot be used together with cfg
+            parameter.
+
+        Returns
+        -------
+        _NestedConfigContext
+            A context manager that applies the config changes on entry
+            and restores previous values on exit.
+
+        Raises
+        ------
+        ValueError
+            If both cfg and keyword arguments are provided.
+
+        Examples
+        --------
+        Using keyword arguments:
+
+        >>> import unxt as u
+        >>> with u.config.quantity_repr.override(
+        ...     short_arrays="compact", use_short_name=True
+        ... ):
+        ...     q = u.Q([1, 2, 3], "m")
+        ...     print(repr(q))
+        Q([1, 2, 3], unit='m')
+
+        Using a Config object:
+
+        >>> from traitlets.config import Config
+        >>> cfg = Config()
+        >>> cfg.QuantityReprConfig.short_arrays = "compact"
+        >>> cfg.QuantityReprConfig.use_short_name = True
+        >>> with u.config.quantity_repr.override(cfg):
+        ...     q = u.Q([1, 2, 3], "m")
+        ...     print(repr(q))
+        Q([1, 2, 3], unit='m')
+
+        >>> print(str(q))
+        Quantity([1, 2, 3], unit='m')
+
+        """
+        keys = self._config_keys
+        cls_name = type(self).__name__
+
+        if cfg is not None and kwargs:
+            msg = "Cannot specify both cfg and keyword arguments to override()"
+            raise ValueError(msg)
+
+        if kwargs:
+            unknown_keys = set(kwargs) - keys
+            if unknown_keys:
+                valid_keys = ", ".join(sorted(keys))
+                unknown = ", ".join(sorted(unknown_keys))
+                msg = (
+                    f"Unknown {cls_name} override option(s): {unknown}. "
+                    f"Valid options are: {valid_keys}"
+                )
+                raise ValueError(msg)
+
+            # Validate and resolve values through traitlets immediately so
+            # override() fails fast with clear errors.
+            temp_instance = self.__class__()
+            validated_kwargs: dict[str, Any] = {}
+            for key, value in kwargs.items():
+                try:
+                    setattr(temp_instance, key, value)
+                except TraitError as e:
+                    msg = (
+                        f"Invalid value for {cls_name} override option "
+                        f"'{key}': {value!r}"
+                    )
+                    raise ValueError(msg) from e
+                # Bypass thread-local override lookup when reading back the
+                # resolved trait value from the temporary instance.
+                validated_kwargs[key] = object.__getattribute__(temp_instance, key)
+            kwargs = validated_kwargs
+
+        if cfg is not None:
+            # Create a temporary instance, apply the config to it, and read the
+            # resolved trait values. This ensures LazyConfigValue objects are
+            # properly resolved to their actual values.
+            temp_instance = self.__class__(config=cfg)
+            # Only override the traits the Config actually specifies. Iterating
+            # every trait would read the class default for traits absent from
+            # ``cfg`` and clobber any globally-configured value on entry.
+            specified: set[str] = set()
+            for klass in type(self).__mro__:
+                section = cfg.get(klass.__name__, None)
+                if section:
+                    specified |= set(section)
+            # Intersect with the *override allowlist*, not all traits:
+            # ``__getattribute__`` only consults these keys, so an entry outside
+            # it could never be observed -- it would just be a dead push.
+            overrides = {
+                name: object.__getattribute__(temp_instance, name)
+                for name in specified & keys
+            }
+            kwargs = overrides
+
+        return _NestedConfigContext(self, kwargs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,6 +253,8 @@ class QuantityReprConfig(LocalConfigurable):
 
     """
 
+    _config_keys: ClassVar[frozenset[str]] = QUANTITY_REPR_CONFIG_KEYS
+
     short_arrays: ClassVar[object] = Union(
         [Bool(), Enum(("compact",))],
         default_value=False,
@@ -149,129 +281,6 @@ class QuantityReprConfig(LocalConfigurable):
     indent: ClassVar[object] = Int(
         default_value=4, help="Indentation level for nested structures in repr"
     ).tag(config=True)
-
-    def __getattribute__(self, name: str) -> Any:
-        """Get attribute, checking thread-local overrides first."""
-        if name in QUANTITY_REPR_CONFIG_KEYS:
-            with contextlib.suppress(AttributeError):
-                local = object.__getattribute__(self, "_local")
-                # Return the most recent override for this attribute
-                if hasattr(local, "stack") and local.stack:
-                    for overrides in reversed(local.stack):
-                        if name in overrides:
-                            return overrides[name]
-
-        return object.__getattribute__(self, name)
-
-    def override(
-        self, cfg: Config | None = None, /, **kwargs: Any
-    ) -> "_NestedConfigContext":
-        """Create a context manager for temporary config changes.
-
-        Parameters
-        ----------
-        cfg : traitlets.config.Config, optional
-            A traitlets Config object with settings for this config class.
-            Cannot be used together with keyword arguments.
-        **kwargs
-            Configuration options to set temporarily (e.g.,
-            short_arrays="compact").  Cannot be used together with cfg
-            parameter.
-
-        Returns
-        -------
-        _NestedConfigContext
-            A context manager that applies the config changes on entry
-            and restores previous values on exit.
-
-        Raises
-        ------
-        ValueError
-            If both cfg and keyword arguments are provided.
-
-        Examples
-        --------
-        Using keyword arguments:
-
-        >>> import unxt as u
-        >>> with u.config.quantity_repr.override(
-        ...     short_arrays="compact", use_short_name=True
-        ... ):
-        ...     q = u.Q([1, 2, 3], "m")
-        ...     print(repr(q))
-        Q([1, 2, 3], unit='m')
-
-        Using a Config object:
-
-        >>> from traitlets.config import Config
-        >>> cfg = Config()
-        >>> cfg.QuantityReprConfig.short_arrays = "compact"
-        >>> cfg.QuantityReprConfig.use_short_name = True
-        >>> with u.config.quantity_repr.override(cfg):
-        ...     q = u.Q([1, 2, 3], "m")
-        ...     print(repr(q))
-        Q([1, 2, 3], unit='m')
-
-        >>> print(str(q))
-        Quantity([1, 2, 3], unit='m')
-
-        """
-        if cfg is not None and kwargs:
-            msg = "Cannot specify both cfg and keyword arguments to override()"
-            raise ValueError(msg)
-
-        if kwargs:
-            unknown_keys = set(kwargs) - QUANTITY_REPR_CONFIG_KEYS
-            if unknown_keys:
-                valid_keys = ", ".join(sorted(QUANTITY_REPR_CONFIG_KEYS))
-                unknown = ", ".join(sorted(unknown_keys))
-                msg = (
-                    f"Unknown QuantityReprConfig override option(s): {unknown}. "
-                    f"Valid options are: {valid_keys}"
-                )
-                raise ValueError(msg)
-
-            # Validate and resolve values through traitlets immediately so
-            # override() fails fast with clear errors.
-            temp_instance = self.__class__()
-            validated_kwargs: dict[str, Any] = {}
-            for key, value in kwargs.items():
-                try:
-                    setattr(temp_instance, key, value)
-                except TraitError as e:
-                    msg = (
-                        "Invalid value for QuantityReprConfig override option "
-                        f"'{key}': {value!r}"
-                    )
-                    raise ValueError(msg) from e
-                # Bypass thread-local override lookup when reading back the
-                # resolved trait value from the temporary instance.
-                validated_kwargs[key] = object.__getattribute__(temp_instance, key)
-            kwargs = validated_kwargs
-
-        if cfg is not None:
-            # Create a temporary instance, apply the config to it, and read the
-            # resolved trait values. This ensures LazyConfigValue objects are
-            # properly resolved to their actual values.
-            temp_instance = self.__class__(config=cfg)
-            # Only override the traits the Config actually specifies. Iterating
-            # every trait would read the class default for traits absent from
-            # ``cfg`` and clobber any globally-configured value on entry.
-            specified: set[str] = set()
-            for klass in type(self).__mro__:
-                section = cfg.get(klass.__name__, None)
-                if section:
-                    specified |= set(section)
-            # Intersect with the *override allowlist*, not all traits:
-            # ``__getattribute__`` only consults these keys, so an entry outside
-            # it could never be observed -- it would just be a dead push.
-            overrides = {
-                name: object.__getattribute__(temp_instance, name)
-                for name in specified & QUANTITY_REPR_CONFIG_KEYS
-            }
-            kwargs = overrides
-
-        return _NestedConfigContext(self, kwargs)
 
 
 # ============================================================================
@@ -327,6 +336,8 @@ class QuantityStrConfig(LocalConfigurable):
 
     """
 
+    _config_keys: ClassVar[frozenset[str]] = QUANTITY_STR_CONFIG_KEYS
+
     short_arrays: ClassVar[object] = Union(
         [Bool(), Enum(("compact",))],
         default_value="compact",
@@ -353,101 +364,6 @@ class QuantityStrConfig(LocalConfigurable):
     indent: ClassVar[object] = Int(
         default_value=4, help="Indentation level for nested structures in str"
     ).tag(config=True)
-
-    def __getattribute__(self, name: str) -> Any:
-        """Get attribute, checking thread-local overrides first."""
-        if name in QUANTITY_STR_CONFIG_KEYS:
-            with contextlib.suppress(AttributeError):
-                local = object.__getattribute__(self, "_local")
-                if hasattr(local, "stack") and local.stack:
-                    for overrides in reversed(local.stack):
-                        if name in overrides:
-                            return overrides[name]
-
-        return object.__getattribute__(self, name)
-
-    def override(
-        self, cfg: Config | None = None, /, **kwargs: Any
-    ) -> "_NestedConfigContext":
-        """Create a context manager for temporary config changes.
-
-        Parameters
-        ----------
-        cfg : traitlets.config.Config, optional
-            A traitlets Config object with settings for this config class.
-            Cannot be used together with keyword arguments.
-        **kwargs
-            Configuration options to set temporarily.
-            Cannot be used together with cfg parameter.
-
-        Returns
-        -------
-        _NestedConfigContext
-            A context manager that applies the config changes on entry
-            and restores previous values on exit.
-
-        Raises
-        ------
-        ValueError
-            If both cfg and keyword arguments are provided.
-
-        """
-        if cfg is not None and kwargs:
-            msg = "Cannot specify both cfg and keyword arguments to override()"
-            raise ValueError(msg)
-
-        if kwargs:
-            unknown_keys = set(kwargs) - QUANTITY_STR_CONFIG_KEYS
-            if unknown_keys:
-                valid_keys = ", ".join(sorted(QUANTITY_STR_CONFIG_KEYS))
-                unknown = ", ".join(sorted(unknown_keys))
-                msg = (
-                    f"Unknown QuantityStrConfig override option(s): {unknown}. "
-                    f"Valid options are: {valid_keys}"
-                )
-                raise ValueError(msg)
-
-            # Validate and resolve values through traitlets immediately so
-            # override() fails fast with clear errors.
-            temp_instance = self.__class__()
-            validated_kwargs: dict[str, Any] = {}
-            for key, value in kwargs.items():
-                try:
-                    setattr(temp_instance, key, value)
-                except TraitError as e:
-                    msg = (
-                        "Invalid value for QuantityStrConfig override option "
-                        f"'{key}': {value!r}"
-                    )
-                    raise ValueError(msg) from e
-                # Bypass thread-local override lookup when reading back the
-                # resolved trait value from the temporary instance.
-                validated_kwargs[key] = object.__getattribute__(temp_instance, key)
-            kwargs = validated_kwargs
-
-        if cfg is not None:
-            # Create a temporary instance, apply the config to it, and read the
-            # resolved trait values. This ensures LazyConfigValue objects are
-            # properly resolved to their actual values.
-            temp_instance = self.__class__(config=cfg)
-            # Only override the traits the Config actually specifies. Iterating
-            # every trait would read the class default for traits absent from
-            # ``cfg`` and clobber any globally-configured value on entry.
-            specified: set[str] = set()
-            for klass in type(self).__mro__:
-                section = cfg.get(klass.__name__, None)
-                if section:
-                    specified |= set(section)
-            # Intersect with the *override allowlist*, not all traits:
-            # ``__getattribute__`` only consults these keys, so an entry outside
-            # it could never be observed -- it would just be a dead push.
-            overrides = {
-                name: object.__getattribute__(temp_instance, name)
-                for name in specified & QUANTITY_STR_CONFIG_KEYS
-            }
-            kwargs = overrides
-
-        return _NestedConfigContext(self, kwargs)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

The `QuantityReprConfig` and `QuantityStrConfig` classes in `unxt._src.config` were near-identical twins: each carried its own copy of `__getattribute__` (the thread-local override lookup) and `override()` (the context-manager builder). The two copies differed only in:

- the key-set constant they referenced (`QUANTITY_REPR_CONFIG_KEYS` vs `QUANTITY_STR_CONFIG_KEYS` — identical 4-name frozensets),
- the class name interpolated into error messages, and
- the `short_arrays` default.

This PR moves both methods into the shared `LocalConfigurable` base, keyed off a per-subclass `_config_keys` allowlist. Each concrete config now declares only its traits, docstring, and `_config_keys`.

The **same two methods had been copied a third and fourth time** into `unxts.parametric`'s `_ParametricLocalConfig`. Now that `LocalConfigurable` provides them, that intermediate base is redundant and is removed — `ParametricQuantityReprConfig` / `ParametricQuantityStrConfig` inherit directly from `LocalConfigurable`. Their now-unused imports (`contextlib`, `Config`, `_NestedConfigContext`) are dropped.

## Behavior

Unchanged. The `override()` cfg-branch still intersects the `Config`-specified names with each class's override allowlist (`specified & keys`); `_local` remains per-instance (set in `LocalConfigurable.__init__`), so repr/str override stacks stay independent.

## Verification

- `ruff check` / `ruff format` clean; all pre-commit hooks pass
- 181 tests pass: `tests/unit/test_config.py`, `tests/unit/test_quantity_printing.py`, `packages/unxts.parametric/tests`, plus the config-module doctests (unxt + parametric)

## Net

**−167 lines** (136 insertions, 303 deletions) across the two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)