### PR TITLE
👷 ci: extend the constructor typing guard to ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,8 +106,7 @@ repos:
     hooks:
       - id: ty
         name: ty (typing guard)
-        entry:
-          uv run --frozen --group typecheck --extra all ty check tests/typing
+        entry: uv run --frozen --group typecheck --extra all ty check
         language: system
         pass_filenames: false
         files: (\.py$|^pyproject\.toml$|^uv\.lock$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,20 @@ repos:
         files: (\.py$|^pyproject\.toml$|^uv\.lock$)
         require_serial: true
 
+  # ty, scoped to the `tests/typing` fixture -- the same `Quantity(1, "m")`
+  # constructor guard as pyright, under a second checker. Runs via `uv run` so
+  # `unxt` and its deps resolve; runs when any Python / lock / config changes.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (typing guard)
+        entry:
+          uv run --frozen --group typecheck --extra all ty check tests/typing
+        language: system
+        pass_filenames: false
+        files: (\.py$|^pyproject\.toml$|^uv\.lock$)
+        require_serial: true
+
   # - repo: https://github.com/abravalheri/validate-pyproject
   #   rev: v0.23
   #   hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -90,12 +90,12 @@ def pyright(s: nox.Session, /) -> None:
 def ty(s: nox.Session, /) -> None:
     """Type-check the typing smoke fixture with ty.
 
-    Scoped by the ``tests/typing`` invocation argument (ty reports diagnostics
-    only in the given paths) -- the same ``Quantity(1, "m")`` constructor guard
-    as the ``pyright`` session. Not the whole tree, which ty is not yet clean on.
-    ty (0.0.x) is pinned; expect deliberate periodic bumps.
+    Scoped (via ``[tool.ty.src]`` ``include``) to ``tests/typing`` -- the same
+    ``Quantity(1, "m")`` constructor guard as the ``pyright`` session. Not the
+    whole tree, which ty is not yet clean on. ty (0.0.x) is pinned; expect
+    deliberate periodic bumps.
     """
-    s.run("ty", "check", "tests/typing", *s.posargs)
+    s.run("ty", "check", *s.posargs)
 
 
 def _parse_pylint_paths(package: PackageEnum, /) -> list[str]:

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,6 +86,18 @@ def pyright(s: nox.Session, /) -> None:
     s.run("pyright", *s.posargs)
 
 
+@session(uv_groups=["typecheck"], uv_extras=["all"], reuse_venv=True)
+def ty(s: nox.Session, /) -> None:
+    """Type-check the typing smoke fixture with ty.
+
+    Scoped by the ``tests/typing`` invocation argument (ty reports diagnostics
+    only in the given paths) -- the same ``Quantity(1, "m")`` constructor guard
+    as the ``pyright`` session. Not the whole tree, which ty is not yet clean on.
+    ty (0.0.x) is pinned; expect deliberate periodic bumps.
+    """
+    s.run("ty", "check", "tests/typing", *s.posargs)
+
+
 def _parse_pylint_paths(package: PackageEnum, /) -> list[str]:
     # Lint each package in isolation so the ``duplicate-code`` checker does not
     # flag the intentional similarity between a shim and its canonical package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,8 @@ test = [
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]
 test-mpl = ["pytest-mpl>=0.17.0", "matplotlib>=3.8"]
 # Pinned so the typing guards cannot drift as new checker releases change
-# diagnostics. Scoped to the `tests/typing` fixture; see [tool.pyright].
+# diagnostics. Both scoped to the `tests/typing` fixture; see [tool.pyright]
+# and [tool.ty.src].
 typecheck = ["pyright==1.1.411", "ty==0.0.64"]
 workspace = [
   "unxt-api",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,9 @@ test = [
 ]
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]
 test-mpl = ["pytest-mpl>=0.17.0", "matplotlib>=3.8"]
-# Pinned so the `pyright` guard cannot drift as new pyright releases change
+# Pinned so the typing guards cannot drift as new checker releases change
 # diagnostics. Scoped to the `tests/typing` fixture; see [tool.pyright].
-typecheck = ["pyright==1.1.411"]
+typecheck = ["pyright==1.1.411", "ty==0.0.64"]
 workspace = [
   "unxt-api",
   "unxt-hypothesis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,14 @@ pythonVersion    = "3.12"           # match `requires-python = ">=3.12"`
 typeCheckingMode = "basic"
 
 
+# ty is scoped to the same typing smoke fixture as pyright (the `Quantity(1,
+# "m")` constructor guard). Scoping via config -- rather than a CLI path -- keeps
+# the nox/pre-commit invocation a plain `ty check`. Python version is read from
+# `project.requires-python`. Widen `include` when more of the tree is ty-clean.
+[tool.ty.src]
+include = ["tests/typing"]
+
+
 [tool.pylint]
 ignore-paths = [".*/_compat.py", ".*/_version.py"]
 messages_control.disable = [

--- a/tests/typing/test_construction.py
+++ b/tests/typing/test_construction.py
@@ -1,14 +1,15 @@
 """Static-typing smoke test: quantity constructors accept a unit string.
 
 Runs as a normal pytest (the constructors must not raise) AND under the
-`pyright` nox session (the string-unit argument must type-check). Regression
-guard for the `unit`-field converter: the quantity classes use the ``unit`` API
-function (liberal ``Any`` input, Postel's law) as their ``eqx.field`` converter,
-so ``Quantity(1, "m")`` type-checks while ``.unit`` still reads as a unit.
+`pyright` and `ty` nox sessions (the string-unit argument must type-check).
+Regression guard for the `unit`-field converter: the quantity classes use the
+``unit`` API function (liberal ``Any`` input, Postel's law) as their
+``eqx.field`` converter, so ``Quantity(1, "m")`` type-checks while ``.unit``
+still reads as a unit.
 
-Pyright-scoped: mypy / ty do not implement the `converter` field-specifier
-extension, so they will not validate this. A mypy/ty regression is the trigger
-to revisit a `.pyi` stub.
+pyright and ty both read equinox's `converter` field-specifier, so both
+validate this. mypy does not apply the converter, so it is not run against this
+fixture. A regression here is the trigger to revisit a `.pyi` stub.
 """
 
 from typing import assert_type

--- a/uv.lock
+++ b/uv.lock
@@ -3739,6 +3739,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.64"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/aa/14c9965d3b173105692473897cc89c34cd91241368b2044e43167e1c17ff/ty-0.0.64.tar.gz", hash = "sha256:d12ddbb05f15158bb518af619378b385486450def95fb06f8ab98037febe9f2c", size = 6350966, upload-time = "2026-07-27T18:32:45.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4c/c54937e4ff3fa7b34a99ea3387ec766bf0ad98dc8df8d792e89b388e658e/ty-0.0.64-py3-none-linux_armv6l.whl", hash = "sha256:3830a6675ab43635ced1c4c557f380ac4a49e9414e03975e4e4e8db644c64944", size = 12118357, upload-time = "2026-07-27T18:32:08.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/a839ee2bc78e943d079e6abe199a97b4eeffb7e5c9a57326d69de452186a/ty-0.0.64-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3ff07d7bc32a2135f58afe57393789a32ea2fed1a66216129a8e535e76043903", size = 11790882, upload-time = "2026-07-27T18:32:10.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/19f14357888a7198438926303753cf749428e3d62e8980ff1e9a72a78402/ty-0.0.64-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4f6d1c7f897cca05d12bacbf1435150d5ffa496099515aa6ed303c8b29e1d0bb", size = 11317394, upload-time = "2026-07-27T18:32:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2f/f54462300535ab99b551eda733177be2eef5dbc2997d3fdb357c4ddd760a/ty-0.0.64-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:138d6c37ad4bf8583aa7a9b29d90954151d7856f9910a03eae3eb34b34c57215", size = 11863042, upload-time = "2026-07-27T18:32:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/95/dbecf745520ebe8bd7b02fc55eee6441c9be312ebf6addce605eb52740dd/ty-0.0.64-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ed9719d1b7b66fb8efe073d860208a44c40af1f6cd5c2364aa9b323a1e579b4", size = 11910730, upload-time = "2026-07-27T18:32:17.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/26/12cfd40028e51ceed7b3cb645281c61c02eb64ff9fb0c09231d65c30ff25/ty-0.0.64-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68b23e5169e2137b5f1de7169ab0cebecab6c8eda374c34c1f6394308f58242", size = 12631936, upload-time = "2026-07-27T18:32:19.533Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d0/65ffc2b0a686347193c6f98e9421a7fc2a96fc3cd0b1001cf7cf284baff9/ty-0.0.64-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f41cb07d89d32626fcaf3ed4d262778fcb28b2628b6ed1e172cd7b18820668d8", size = 13171049, upload-time = "2026-07-27T18:32:22.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a4/975a5961842dcd6fa60f0770a102c0bba7509da909ab652919bfcdcd4fc7/ty-0.0.64-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f24e1504ab9e212f92356b82fe088fdeb3a39f9a2f4ff25e505d2e1d0db9056", size = 12826438, upload-time = "2026-07-27T18:32:24.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ef/dfb9b7f9bcc032d3b540b0d1f55f532a336e2fb41b1bd539c05ae81a151a/ty-0.0.64-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86db830cb914bb33bb8247b66ccea58de4496c2391bd42658aba744b439f3290", size = 12440880, upload-time = "2026-07-27T18:32:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/bedac20505e8a8f5501ad73d7d15d8e421a563fef59993909a23036929a4/ty-0.0.64-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:652ee3d6d03bea76cd2fe8949c78bb5970394ebd7c5fd270e9518c0dee1b931d", size = 12782439, upload-time = "2026-07-27T18:32:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/795733f13ceff1378f08b3de0c49d0f518df220ed856b0dfac869f3b7c81/ty-0.0.64-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4838768295774a86e95f9ec5633e739d016adbbb69dcbdc62f3549578a11f624", size = 11814821, upload-time = "2026-07-27T18:32:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3e/9d99cd1e1831003434f508ed9f258a56543194afc3bbe051eba2545fa676/ty-0.0.64-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5a3d700669868599edf39ce5125196682f15a8880cc8c669bc2a83b99984d99b", size = 11928678, upload-time = "2026-07-27T18:32:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3d/448f49a3503fb119a34348a5714bb92001f252fadbbb12d645f2e744b557/ty-0.0.64-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b161f0a82a8e2f2432db3bf7702b4d3924fa9486ba0014f6710a160fc157df0d", size = 12202249, upload-time = "2026-07-27T18:32:34.905Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/75768e562cec990d189dc05807ae72890b20ffbd1e1f43597bb98db63c60/ty-0.0.64-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:39b9dd42908df47c2dc57dda87e656fab97097ffd2618474bbdea986af0d6a9d", size = 12548817, upload-time = "2026-07-27T18:32:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/34/89/44cc276ea6ca0245495014758ffeadde1798fb0b5840c9cf36d8d2ed3250/ty-0.0.64-py3-none-win32.whl", hash = "sha256:d0676ab0e0935795e5843baa28dd5e366dc343d7c0945a996df9eab8e0644885", size = 11545474, upload-time = "2026-07-27T18:32:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7e/d1c8a871a38d17c8f168b9a6975f6247f7660f8334e517656a5e4b4a4858/ty-0.0.64-py3-none-win_amd64.whl", hash = "sha256:dcb9bd31f54097e362b776c26ab4564d4564cdd1355cb883481167a26c03cc3f", size = 12542987, upload-time = "2026-07-27T18:32:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/6d18640d0204cacd69abbaca95ad6a34c6d7e9169e9051d0117b17b827ec/ty-0.0.64-py3-none-win_arm64.whl", hash = "sha256:82cc34c1ad9a8feb6059aef193bebcecc656e548f6fab3d518bcd8b57d198d39", size = 11899263, upload-time = "2026-07-27T18:32:43.366Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3951,6 +3976,7 @@ test-mpl = [
 ]
 typecheck = [
     { name = "pyright" },
+    { name = "ty" },
 ]
 workspace = [
     { name = "unxt-api" },
@@ -4125,7 +4151,10 @@ test-mpl = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
 ]
-typecheck = [{ name = "pyright", specifier = "==1.1.411" }]
+typecheck = [
+    { name = "pyright", specifier = "==1.1.411" },
+    { name = "ty", specifier = "==0.0.64" },
+]
 workspace = [
     { name = "unxt-api", editable = "packages/unxt-api" },
     { name = "unxt-hypothesis", editable = "packages/unxt-hypothesis" },


### PR DESCRIPTION
## Summary

[#761](https://github.com/GalacticDynamics/unxt/pull/761) added a guard so `Quantity(1, "m")` (string unit) type-checks under **pyright**, scoped to `tests/typing`. This extends the *same* guard to **ty** (Astral), which also reads equinox's `converter` field-specifier.

Empirically verified in the faithful nox env (ty 0.0.64):
- `Quantity(1, "m")` → `Quantity`, `.unit` → `AbstractUnit`
- catches a deliberately-wrong `assert_type` (real guard, not a trivial pass)

## Changes

Scoped to `tests/typing`, mirroring the pyright setup:

- **pin `ty==0.0.64`** in the `typecheck` dependency group (0.0.x churns → pinned and bumped deliberately, same discipline as the pinned `pyright`)
- **`[tool.ty.src] include = ["tests/typing"]`** to scope ty by config — mirrors `[tool.pyright] include`, and keeps the invocation a bare `ty check`
- **nox** `ty` session → `ty check`
- **pre-commit** local `ty` hook, mirroring the pyright hook
- fixture docstring corrected — it claimed ty does *not* implement the converter field-specifier; it does (as of 0.0.64)

### No dedicated CI job (deliberately)

The `Format` job runs `nox -s lint` → `prek run --all-files`, which **already runs this hook** (and the existing pyright hook). A separate `ty` CI job would just double-run the same check, so there isn't one — the hook gates in CI through `Format`.

> Note: the pre-existing dedicated **`Pyright`** CI job is redundant with its pre-commit hook for the same reason. Removed in #806.

Python version is read from `project.requires-python` (no explicit config needed). No source/runtime change.

A companion PR (#805) extends the guard to **mypy** the same way (hook only, no dedicated job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)