### PR TITLE
👷 ci: drop the redundant Pyright job (prek already runs the hook)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,25 +66,10 @@ jobs:
       - name: Lint
         run: uv run --frozen nox -s lint
 
-  # Static type-checking, scoped to the tests/typing fixture (see
-  # [tool.pyright]). Guards the `Quantity(1, "m")` constructor typing, which
-  # pyright — the only checker that reads equinox's converter field-specifier —
-  # would otherwise silently regress. Pyright-scoped by design; not mypy/ty.
-  pyright:
-    name: Pyright
-    runs-on: ubuntu-latest
-    needs: [setup]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install
-        run: uv sync --no-default-groups --group nox --locked
-
-      - name: Type-check
-        run: uv run --frozen nox -s pyright
+  # Static type-checking (pyright, scoped to the tests/typing fixture -- the
+  # `Quantity(1, "m")` constructor guard) is NOT a dedicated job: the `Format`
+  # job runs `nox -s lint` -> `prek run --all-files`, which already runs the
+  # `pyright (typing guard)` pre-commit hook. A separate job would double-run it.
 
   # Documentation build
   #
@@ -660,7 +645,6 @@ jobs:
         setup,
         format,
         docs,
-        pyright,
         tests-unxt,
         tests-unxt-api,
         tests-unxt-hypothesis,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Lint
         run: uv run --frozen nox -s lint
 
-  # Static type-checking (pyright, scoped to the tests/typing fixture -- the
-  # `Quantity(1, "m")` constructor guard) is NOT a dedicated job: the `Format`
-  # job runs `nox -s lint` -> `prek run --all-files`, which already runs the
-  # `pyright (typing guard)` pre-commit hook. A separate job would double-run it.
+  # Static type-checking (pyright, scoped to tests/typing -- the `Quantity(1,
+  # "m")` constructor guard) is enforced by the `pyright (typing guard)`
+  # pre-commit hook, which the `format` job runs in CI. It is deliberately not a
+  # dedicated job -- that would just double-run the hook.
 
   # Documentation build
   #


### PR DESCRIPTION
## Summary

[#761](https://github.com/GalacticDynamics/unxt/pull/761) added **both** a `pyright (typing guard)` pre-commit hook **and** a dedicated `Pyright` CI job for the `tests/typing` constructor guard. They double-run the same check: the `Format` job runs `nox -s lint` → `prek run --all-files`, which already runs the pyright hook.

This removes the dedicated `Pyright` job (and its `CI Pass` `needs` entry). The hook keeps gating in CI through `Format` — and locally on commit. The `pyright` nox session stays for local `nox -s pyright` runs.

Verified locally: `prek run --all-files` reports `pyright (typing guard)........Passed`.

## Context

Companion to the ty (#804) and mypy (#805) guard PRs, which add their checkers the same way — pre-commit hook only, no dedicated CI job. This aligns pyright with that pattern so all three type-checkers gate purely through `Format`/prek.

No source/runtime change; one file (`.github/workflows/ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)