### PR TITLE
Backport PRs #761 + #804 on branch versions/v2.0.x (typing guard: pyright + ty)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,26 @@ jobs:
       - name: Lint
         run: uv run --frozen nox -s lint
 
+  # Static type-checking, scoped to the tests/typing fixture (see
+  # [tool.pyright]). Guards the `Quantity(1, "m")` constructor typing, which
+  # pyright — the only checker that reads equinox's converter field-specifier —
+  # would otherwise silently regress. Pyright-scoped by design; not mypy/ty.
+  pyright:
+    name: Pyright
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install
+        run: uv sync --no-default-groups --group nox --locked
+
+      - name: Type-check
+        run: uv run --frozen nox -s pyright
+
   # Documentation build
   #
   # Nothing previously gated Sphinx output: there was no docs job here, and the
@@ -640,6 +660,7 @@ jobs:
         setup,
         format,
         docs,
+        pyright,
         tests-unxt,
         tests-unxt-api,
         tests-unxt-hypothesis,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,20 @@ repos:
       - id: taplo-format
       # - id: taplo-lint
 
+  # Pyright, scoped to the `tests/typing` fixture (see [tool.pyright]). Runs via
+  # `uv run` so it gets an env where `unxt` and its deps resolve -- a bare
+  # pyright could not import the package. Guards the `Quantity(1, "m")`
+  # constructor typing; runs when any Python / lock / config changes.
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright (typing guard)
+        entry: uv run --frozen --group typecheck --extra all pyright
+        language: system
+        pass_filenames: false
+        files: (\.py$|^pyproject\.toml$|^uv\.lock$)
+        require_serial: true
+
   # - repo: https://github.com/abravalheri/validate-pyproject
   #   rev: v0.23
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,19 @@ repos:
         files: (\.py$|^pyproject\.toml$|^uv\.lock$)
         require_serial: true
 
+  # ty, scoped to the `tests/typing` fixture -- the same `Quantity(1, "m")`
+  # constructor guard as pyright, under a second checker. Runs via `uv run` so
+  # `unxt` and its deps resolve; runs when any Python / lock / config changes.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (typing guard)
+        entry: uv run --frozen --group typecheck --extra all ty check
+        language: system
+        pass_filenames: false
+        files: (\.py$|^pyproject\.toml$|^uv\.lock$)
+        require_serial: true
+
   # - repo: https://github.com/abravalheri/validate-pyproject
   #   rev: v0.23
   #   hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,6 +75,17 @@ def precommit(s: nox.Session, /) -> None:
     s.run("prek", "run", "--all-files", *s.posargs)
 
 
+@session(uv_groups=["typecheck"], uv_extras=["all"], reuse_venv=True)
+def pyright(s: nox.Session, /) -> None:
+    """Type-check the typing smoke fixture with pyright.
+
+    Scoped (via ``[tool.pyright]`` ``include``) to ``tests/typing`` -- the guard
+    for the ``Quantity(1, "m")`` constructor typing. Not the whole tree, which
+    is not yet pyright-clean.
+    """
+    s.run("pyright", *s.posargs)
+
+
 def _parse_pylint_paths(package: PackageEnum, /) -> list[str]:
     # Lint each package in isolation so the ``duplicate-code`` checker does not
     # flag the intentional similarity between a shim and its canonical package.

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,6 +86,18 @@ def pyright(s: nox.Session, /) -> None:
     s.run("pyright", *s.posargs)
 
 
+@session(uv_groups=["typecheck"], uv_extras=["all"], reuse_venv=True)
+def ty(s: nox.Session, /) -> None:
+    """Type-check the typing smoke fixture with ty.
+
+    Scoped (via ``[tool.ty.src]`` ``include``) to ``tests/typing`` -- the same
+    ``Quantity(1, "m")`` constructor guard as the ``pyright`` session. Not the
+    whole tree, which ty is not yet clean on. ty (0.0.x) is pinned; expect
+    deliberate periodic bumps.
+    """
+    s.run("ty", "check", *s.posargs)
+
+
 def _parse_pylint_paths(package: PackageEnum, /) -> list[str]:
     # Lint each package in isolation so the ``duplicate-code`` checker does not
     # flag the intentional similarity between a shim and its canonical package.

--- a/packages/unxts.api/src/unxts/api/_src/units.py
+++ b/packages/unxts.api/src/unxts/api/_src/units.py
@@ -5,14 +5,27 @@ Copyright (c) 2023 Galactic Dynamics. All rights reserved.
 
 __all__ = ("unit", "unit_of")
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import plum
 
+if TYPE_CHECKING:
+    # `unit` is liberal in what it accepts (Postel's law): a unit object, a
+    # string, ... -> a unit. Declared here as a plain callable so static
+    # checkers can read the `Any` parameter -- in particular so it works as an
+    # `equinox.field(converter=unit)`, making `Quantity(1, "m")` type-check.
+    # (`plum.dispatch.abstract` erases the signature to an opaque `Function`
+    # that the converter field-specifier cannot introspect.) The `raise` body
+    # keeps pylint from inferring a `None` return for callers (this branch is
+    # type-checking only; the runtime definition is dispatched by plum).
+    def unit(obj: Any, /) -> Any:
+        raise NotImplementedError
 
-@plum.dispatch.abstract
-def unit(obj: Any, /) -> Any:
-    """Construct the units from a units object."""
+else:
+
+    @plum.dispatch.abstract
+    def unit(obj: Any, /) -> Any:
+        """Construct the units from a units object."""
 
 
 @plum.dispatch.abstract

--- a/packages/unxts.parametric/src/unxts/parametric/_src/parametric.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/parametric.py
@@ -9,13 +9,15 @@ import equinox as eqx
 from jaxtyping import Array, Shaped
 from plum import add_promotion_rule, parametric
 
+import unxts.api as uapi
+
 from .base_parametric import AbstractParametricQuantity
 from unxt.quantity import (
     Quantity,
     StaticValue,
     convert_to_quantity_value,
 )
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 @final
@@ -123,7 +125,7 @@ class ParametricQuantity(AbstractParametricQuantity):
     )
     """The value of the `AbstractQuantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,12 @@ dependencies = [
   "packaging>=20.0",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
-  "quax>=0.4.0",
+  "quax>=0.4.2",
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",
   "unxt-api>=2.0.0",
+  "unxts.api>=2.0.0",
   "wadler-lindig>=0.1.5",
   "xmmutablemap>=0.1",
   "zeroth>=1.0.0",
@@ -116,7 +117,7 @@ docs = [
   # Runtime dependencies for notebook execution
   "jax[cpu]>=0.5.3",
   "jaxlib>=0.5.3",
-  "quax>=0.4.0",
+  "quax>=0.4.2",
 ]
 lint = ["prek>=0.3.9", "pylint>=3.3.8"]
 nox = ["nox>=2024.10.9", "nox-uv>=0.6.3"]
@@ -134,6 +135,9 @@ test = [
 ]
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]
 test-mpl = ["pytest-mpl>=0.17.0", "matplotlib>=3.8"]
+# Pinned so the `pyright` guard cannot drift as new pyright releases change
+# diagnostics. Scoped to the `tests/typing` fixture; see [tool.pyright].
+typecheck = ["pyright==1.1.411"]
 workspace = [
   "unxt-api",
   "unxt-hypothesis",
@@ -243,6 +247,16 @@ module = [
   "quaxed.*",
   "unxt.*",
 ]
+
+
+# Pyright is scoped to the typing smoke fixture only -- it guards the
+# `Quantity(1, "m")` constructor typing (see tests/typing/) without asking the
+# whole, not-yet-pyright-clean source tree to pass. Widen `include` when more of
+# the tree is type-checked.
+[tool.pyright]
+include          = ["tests/typing"]
+pythonVersion    = "3.12"           # match `requires-python = ">=3.12"`
+typeCheckingMode = "basic"
 
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,10 @@ test = [
 ]
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]
 test-mpl = ["pytest-mpl>=0.17.0", "matplotlib>=3.8"]
-# Pinned so the `pyright` guard cannot drift as new pyright releases change
-# diagnostics. Scoped to the `tests/typing` fixture; see [tool.pyright].
-typecheck = ["pyright==1.1.411"]
+# Pinned so the typing guards cannot drift as new checker releases change
+# diagnostics. Both scoped to the `tests/typing` fixture; see [tool.pyright]
+# and [tool.ty.src].
+typecheck = ["pyright==1.1.411", "ty==0.0.64"]
 workspace = [
   "unxt-api",
   "unxt-hypothesis",
@@ -257,6 +258,14 @@ module = [
 include          = ["tests/typing"]
 pythonVersion    = "3.12"           # match `requires-python = ">=3.12"`
 typeCheckingMode = "basic"
+
+
+# ty is scoped to the same typing smoke fixture as pyright (the `Quantity(1,
+# "m")` constructor guard). Scoping via config -- rather than a CLI path -- keeps
+# the nox/pre-commit invocation a plain `ty check`. Python version is read from
+# `project.requires-python`. Widen `include` when more of the tree is ty-clean.
+[tool.ty.src]
+include = ["tests/typing"]
 
 
 [tool.pylint]

--- a/src/unxt/_src/quantity/angle.py
+++ b/src/unxt/_src/quantity/angle.py
@@ -5,9 +5,9 @@ __all__ = ("Angle",)
 from typing import final
 
 import equinox as eqx
+import unxts.api as uapi
 from jaxtyping import Array, Real
 
-import unxt_api as uapi
 from .base_angle import AbstractAngle
 from .value import StaticValue, convert_to_quantity_value
 from unxt.units import AbstractUnit

--- a/src/unxt/_src/quantity/quantity.py
+++ b/src/unxt/_src/quantity/quantity.py
@@ -6,11 +6,12 @@ __all__ = ("Q", "Quantity")
 from typing import Any, ClassVar
 
 import equinox as eqx
+import unxts.api as uapi
 from jaxtyping import Array, Shaped
 
 from .base import AbstractQuantity
 from .value import StaticValue, convert_to_quantity_value
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 class Quantity(AbstractQuantity):
@@ -34,7 +35,7 @@ class Quantity(AbstractQuantity):
     )
     """The value of the `Quantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     short_name: ClassVar[str] = "Q"

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -9,6 +9,7 @@ from typing import Any, final
 
 import equinox as eqx
 import numpy as np
+import unxts.api as uapi
 import wadler_lindig as wl
 from jaxtyping import ArrayLike
 from plum import add_promotion_rule
@@ -16,7 +17,7 @@ from plum import add_promotion_rule
 from .base import AbstractQuantity, ArrayLikeSequence, same_unit_label
 from .quantity import Quantity
 from .value import StaticValue
-from unxt.units import AbstractUnit, unit as parse_unit
+from unxt.units import AbstractUnit
 
 
 @final
@@ -66,7 +67,7 @@ class StaticQuantity(AbstractQuantity):
     )
     """The static value of the `AbstractQuantity`."""
 
-    unit: AbstractUnit = eqx.field(static=True, converter=parse_unit)
+    unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
     def __hash__(self) -> int:

--- a/tests/typing/test_construction.py
+++ b/tests/typing/test_construction.py
@@ -1,14 +1,15 @@
 """Static-typing smoke test: quantity constructors accept a unit string.
 
 Runs as a normal pytest (the constructors must not raise) AND under the
-`pyright` nox session (the string-unit argument must type-check). Regression
-guard for the `unit`-field converter: the quantity classes use the ``unit`` API
-function (liberal ``Any`` input, Postel's law) as their ``eqx.field`` converter,
-so ``Quantity(1, "m")`` type-checks while ``.unit`` still reads as a unit.
+`pyright` and `ty` nox sessions (the string-unit argument must type-check).
+Regression guard for the `unit`-field converter: the quantity classes use the
+``unit`` API function (liberal ``Any`` input, Postel's law) as their
+``eqx.field`` converter, so ``Quantity(1, "m")`` type-checks while ``.unit``
+still reads as a unit.
 
-Pyright-scoped: mypy / ty do not implement the `converter` field-specifier
-extension, so they will not validate this. A mypy/ty regression is the trigger
-to revisit a `.pyi` stub.
+pyright and ty both read equinox's `converter` field-specifier, so both
+validate this. mypy does not apply the converter, so it is not run against this
+fixture. A regression here is the trigger to revisit a `.pyi` stub.
 """
 
 from typing import assert_type

--- a/tests/typing/test_construction.py
+++ b/tests/typing/test_construction.py
@@ -1,0 +1,48 @@
+"""Static-typing smoke test: quantity constructors accept a unit string.
+
+Runs as a normal pytest (the constructors must not raise) AND under the
+`pyright` nox session (the string-unit argument must type-check). Regression
+guard for the `unit`-field converter: the quantity classes use the ``unit`` API
+function (liberal ``Any`` input, Postel's law) as their ``eqx.field`` converter,
+so ``Quantity(1, "m")`` type-checks while ``.unit`` still reads as a unit.
+
+Pyright-scoped: mypy / ty do not implement the `converter` field-specifier
+extension, so they will not validate this. A mypy/ty regression is the trigger
+to revisit a `.pyi` stub.
+"""
+
+from typing import assert_type
+
+import astropy.units as apyu
+
+import unxt as u
+
+
+def test_string_unit_constructors_typecheck_and_run() -> None:
+    """A unit string is accepted by the quantity constructors.
+
+    The ``assert_type`` calls are checked statically by pyright (the actual
+    guard); the runtime assertions make it a real behavioural test too -- the
+    string unit must be parsed to the expected unit.
+    """
+    # The README's first line -- and the bug this guards.
+    assert_type(u.Quantity(1, "m"), u.Quantity)
+
+    # ``Angle`` shares the same ``unit``-field converter. StaticQuantity does
+    # too, but its *value* field is separately opaque to pyright (it types
+    # ``value: StaticValue``, rejecting ``Literal[1]``), so a smoke line for it
+    # would fail pyright for a reason unrelated to this unit-field fix -- a
+    # separate follow-up. ParametricQuantity lives in the ``unxts.parametric``
+    # package and is guarded by that package's own suite.
+    assert_type(u.Angle(1, "rad"), u.Angle)
+
+    # Runtime: the string unit is parsed to the right unit on each constructor.
+    assert u.Quantity(1, "m").unit == apyu.Unit("m")
+    assert u.Q(1.0, "m").unit == apyu.Unit("m")
+    assert u.Angle(1, "rad").unit == apyu.Unit("rad")
+
+    # A real unit object is still accepted and round-trips.
+    assert u.Quantity(1, apyu.Unit("m")).unit == apyu.Unit("m")
+
+    # The ``unit`` field reads back as a unit, not ``str``.
+    assert_type(u.Quantity(1, "m").unit, u.AbstractUnit)

--- a/uv.lock
+++ b/uv.lock
@@ -1984,6 +1984,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "nox"
 version = "2026.4.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2731,6 +2740,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3005,7 +3027,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3014,9 +3036,9 @@ dependencies = [
     { name = "packaging" },
     { name = "plum-dispatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/88/af0d77ee4a7b8c29e6486d6684b5aa59251ae4e37c2b3a029df623e8a818/quax-0.4.2.tar.gz", hash = "sha256:80047bb81db74e330e988eb41a06265d982c20c27fe51c0ade8e3a0266998a15", size = 203720, upload-time = "2026-07-27T15:56:21.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/e9/391ffa7a3c58998f47aa21414d74d817d611e4ee54300d2f70977402ccac/quax-0.4.0-py3-none-any.whl", hash = "sha256:1fa3d9ae506f2404bb1de09ecbcbf12205ec8cfd918dfcb1f65f3a8ce1a396e8", size = 58510, upload-time = "2026-07-22T18:02:22.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fd/978ecf09a54a861cedcce949a2f2ff52b059ba14ab41ce7cb31b5da55784/quax-0.4.2-py3-none-any.whl", hash = "sha256:47f6da78b77222b8c849174969f1935433d0842e412e43dce92d96d587f49248", size = 59368, upload-time = "2026-07-27T15:56:20.243Z" },
 ]
 
 [[package]]
@@ -3753,6 +3775,7 @@ dependencies = [
     { name = "quaxed" },
     { name = "traitlets" },
     { name = "unxt-api" },
+    { name = "unxts-api" },
     { name = "wadler-lindig" },
     { name = "xmmutablemap" },
     { name = "zeroth" },
@@ -3926,6 +3949,9 @@ test-mpl = [
     { name = "matplotlib" },
     { name = "pytest-mpl" },
 ]
+typecheck = [
+    { name = "pyright" },
+]
 workspace = [
     { name = "unxt-api" },
     { name = "unxt-hypothesis" },
@@ -3958,11 +3984,12 @@ requires-dist = [
     { name = "packaging", specifier = ">=20.0" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "quax-blocks", specifier = ">=0.4.1" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "traitlets", specifier = ">=5.0.0" },
     { name = "unxt-api", editable = "packages/unxt-api" },
+    { name = "unxts-api", editable = "packages/unxts.api" },
     { name = "unxts-api", marker = "extra == 'all'", editable = "packages/unxts.api" },
     { name = "unxts-api", marker = "extra == 'workspace'", editable = "packages/unxts.api" },
     { name = "unxts-hypothesis", marker = "extra == 'all'", editable = "packages/unxts.hypothesis" },
@@ -4015,7 +4042,7 @@ dev = [
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },
@@ -4047,7 +4074,7 @@ docs = [
     { name = "myst-nb", specifier = ">=1.1.2" },
     { name = "myst-parser", specifier = ">=0.13" },
     { name = "pytz", specifier = ">=2024.2" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.2" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.9.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.0" },
@@ -4098,6 +4125,7 @@ test-mpl = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
 ]
+typecheck = [{ name = "pyright", specifier = "==1.1.411" }]
 workspace = [
     { name = "unxt-api", editable = "packages/unxt-api" },
     { name = "unxt-hypothesis", editable = "packages/unxt-hypothesis" },

--- a/uv.lock
+++ b/uv.lock
@@ -3739,6 +3739,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.64"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/aa/14c9965d3b173105692473897cc89c34cd91241368b2044e43167e1c17ff/ty-0.0.64.tar.gz", hash = "sha256:d12ddbb05f15158bb518af619378b385486450def95fb06f8ab98037febe9f2c", size = 6350966, upload-time = "2026-07-27T18:32:45.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4c/c54937e4ff3fa7b34a99ea3387ec766bf0ad98dc8df8d792e89b388e658e/ty-0.0.64-py3-none-linux_armv6l.whl", hash = "sha256:3830a6675ab43635ced1c4c557f380ac4a49e9414e03975e4e4e8db644c64944", size = 12118357, upload-time = "2026-07-27T18:32:08.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/a839ee2bc78e943d079e6abe199a97b4eeffb7e5c9a57326d69de452186a/ty-0.0.64-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3ff07d7bc32a2135f58afe57393789a32ea2fed1a66216129a8e535e76043903", size = 11790882, upload-time = "2026-07-27T18:32:10.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/19f14357888a7198438926303753cf749428e3d62e8980ff1e9a72a78402/ty-0.0.64-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4f6d1c7f897cca05d12bacbf1435150d5ffa496099515aa6ed303c8b29e1d0bb", size = 11317394, upload-time = "2026-07-27T18:32:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2f/f54462300535ab99b551eda733177be2eef5dbc2997d3fdb357c4ddd760a/ty-0.0.64-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:138d6c37ad4bf8583aa7a9b29d90954151d7856f9910a03eae3eb34b34c57215", size = 11863042, upload-time = "2026-07-27T18:32:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/95/dbecf745520ebe8bd7b02fc55eee6441c9be312ebf6addce605eb52740dd/ty-0.0.64-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ed9719d1b7b66fb8efe073d860208a44c40af1f6cd5c2364aa9b323a1e579b4", size = 11910730, upload-time = "2026-07-27T18:32:17.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/26/12cfd40028e51ceed7b3cb645281c61c02eb64ff9fb0c09231d65c30ff25/ty-0.0.64-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68b23e5169e2137b5f1de7169ab0cebecab6c8eda374c34c1f6394308f58242", size = 12631936, upload-time = "2026-07-27T18:32:19.533Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d0/65ffc2b0a686347193c6f98e9421a7fc2a96fc3cd0b1001cf7cf284baff9/ty-0.0.64-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f41cb07d89d32626fcaf3ed4d262778fcb28b2628b6ed1e172cd7b18820668d8", size = 13171049, upload-time = "2026-07-27T18:32:22.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a4/975a5961842dcd6fa60f0770a102c0bba7509da909ab652919bfcdcd4fc7/ty-0.0.64-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f24e1504ab9e212f92356b82fe088fdeb3a39f9a2f4ff25e505d2e1d0db9056", size = 12826438, upload-time = "2026-07-27T18:32:24.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ef/dfb9b7f9bcc032d3b540b0d1f55f532a336e2fb41b1bd539c05ae81a151a/ty-0.0.64-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86db830cb914bb33bb8247b66ccea58de4496c2391bd42658aba744b439f3290", size = 12440880, upload-time = "2026-07-27T18:32:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/bedac20505e8a8f5501ad73d7d15d8e421a563fef59993909a23036929a4/ty-0.0.64-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:652ee3d6d03bea76cd2fe8949c78bb5970394ebd7c5fd270e9518c0dee1b931d", size = 12782439, upload-time = "2026-07-27T18:32:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/795733f13ceff1378f08b3de0c49d0f518df220ed856b0dfac869f3b7c81/ty-0.0.64-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4838768295774a86e95f9ec5633e739d016adbbb69dcbdc62f3549578a11f624", size = 11814821, upload-time = "2026-07-27T18:32:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3e/9d99cd1e1831003434f508ed9f258a56543194afc3bbe051eba2545fa676/ty-0.0.64-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5a3d700669868599edf39ce5125196682f15a8880cc8c669bc2a83b99984d99b", size = 11928678, upload-time = "2026-07-27T18:32:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3d/448f49a3503fb119a34348a5714bb92001f252fadbbb12d645f2e744b557/ty-0.0.64-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b161f0a82a8e2f2432db3bf7702b4d3924fa9486ba0014f6710a160fc157df0d", size = 12202249, upload-time = "2026-07-27T18:32:34.905Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/75768e562cec990d189dc05807ae72890b20ffbd1e1f43597bb98db63c60/ty-0.0.64-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:39b9dd42908df47c2dc57dda87e656fab97097ffd2618474bbdea986af0d6a9d", size = 12548817, upload-time = "2026-07-27T18:32:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/34/89/44cc276ea6ca0245495014758ffeadde1798fb0b5840c9cf36d8d2ed3250/ty-0.0.64-py3-none-win32.whl", hash = "sha256:d0676ab0e0935795e5843baa28dd5e366dc343d7c0945a996df9eab8e0644885", size = 11545474, upload-time = "2026-07-27T18:32:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7e/d1c8a871a38d17c8f168b9a6975f6247f7660f8334e517656a5e4b4a4858/ty-0.0.64-py3-none-win_amd64.whl", hash = "sha256:dcb9bd31f54097e362b776c26ab4564d4564cdd1355cb883481167a26c03cc3f", size = 12542987, upload-time = "2026-07-27T18:32:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/6d18640d0204cacd69abbaca95ad6a34c6d7e9169e9051d0117b17b827ec/ty-0.0.64-py3-none-win_arm64.whl", hash = "sha256:82cc34c1ad9a8feb6059aef193bebcecc656e548f6fab3d518bcd8b57d198d39", size = 11899263, upload-time = "2026-07-27T18:32:43.366Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3951,6 +3976,7 @@ test-mpl = [
 ]
 typecheck = [
     { name = "pyright" },
+    { name = "ty" },
 ]
 workspace = [
     { name = "unxt-api" },
@@ -4125,7 +4151,10 @@ test-mpl = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
 ]
-typecheck = [{ name = "pyright", specifier = "==1.1.411" }]
+typecheck = [
+    { name = "pyright", specifier = "==1.1.411" },
+    { name = "ty", specifier = "==0.0.64" },
+]
 workspace = [
     { name = "unxt-api", editable = "packages/unxt-api" },
     { name = "unxt-hypothesis", editable = "packages/unxt-hypothesis" },


### PR DESCRIPTION
## Summary

Backports the `Quantity(1, "m")` constructor typing guard to `versions/v2.0.x`. #804 (ty) builds on #761 (pyright), and **neither was on this branch**, so this brings both in one PR (as agreed — a combined backport rather than two stacked ones).

- **#761** — the pyright guard: the quantity classes use the `unit` API function (liberal `Any` input, Postel's law) as their `eqx.field` converter, so `Quantity(1, "m")` type-checks while `.unit` still reads as a unit. Adds the `tests/typing` fixture, the pinned `typecheck` group, `[tool.pyright]`, and the pyright nox session / pre-commit hook / CI job.
- **#804** — extends the same guard to **ty** (Astral): pins `ty==0.0.64`, scopes it via `[tool.ty.src] include`, and adds the ty nox session + pre-commit hook (no dedicated CI job — the `Format` job's `prek` run already gates both hooks).

Cherry-picked from the squash-merge commits (`-x` provenance preserved): `10d003c` (#761) and `b4a22cb` (#804). Both applied cleanly onto v2.0.x.

## Verification (on this branch)

- `nox -s pyright` → 0 errors; `nox -s ty` → All checks passed
- `prek run --all-files` → both `pyright`/`ty` typing-guard hooks pass (this is what the `Format` CI job runs)
- `pytest tests/typing` → passes (the fixture is a real behavioural test too)
- full `pytest tests/` → **980 passed, 49 skipped, 20 xfailed, 0 failures** — the backported converter source changes are runtime-clean on v2.0.x

State matches main's current HEAD: the dedicated `Pyright` CI job is present (its removal is a separate PR, #806, not backported here), and ty is hook-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)