### PR TITLE
✨ feat(linalg): add UnitsMatrix `full()` and `diagonal()`

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -199,6 +199,33 @@ class UnitsMatrix:
             raise ValueError(msg)
         self._units = data
 
+    @classmethod
+    def full(cls, shape: int | tuple[int, ...], unit: Any, /) -> "UnitsMatrix":
+        """Return a 1-D or 2-D `UnitsMatrix` with every entry set to ``unit``.
+
+        Parameters
+        ----------
+        shape
+            Target shape — an ``int`` for 1-D or a ``(rows, cols)`` tuple for 2-D.
+        unit
+            The unit broadcast into every entry (an ``AbstractUnit`` or a unit
+            string).
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+
+        >>> UnitsMatrix.full(3, "m")
+        UnitsMatrix("(m, m, m)")
+
+        >>> UnitsMatrix.full((2, 3), "s")
+        UnitsMatrix("((s, s, s), (s, s, s))")
+
+        """
+        data = np.empty(shape, dtype=object)
+        data[...] = _normalize_unit(unit)
+        return cls(data)
+
     # ── Shape / structure ─────────────────────────────────────────────
 
     @property
@@ -233,6 +260,22 @@ class UnitsMatrix:
 
         """
         return UnitsMatrix(self._units.T)
+
+    def diagonal(self) -> "UnitsMatrix":
+        """Return the main diagonal of a 2-D `UnitsMatrix` as a 1-D `UnitsMatrix`.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+
+        >>> UnitsMatrix((("m2", "s"), ("kg", "rad2"))).diagonal()
+        UnitsMatrix("(m2, rad2)")
+
+        """
+        if self._units.ndim != 2:
+            msg = f"diagonal() requires a 2-D UnitsMatrix, got ndim={self._units.ndim}"
+            raise ValueError(msg)
+        return UnitsMatrix(np.diagonal(self._units).copy())
 
     def __pow__(self, exponent: int | float, /) -> "UnitsMatrix":
         r"""Element-wise unit power — each unit raised to ``exponent``.

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -200,6 +200,21 @@ class UnitsMatrix:
         self._units = data
 
     @classmethod
+    def _wrap(cls, data: np.ndarray, /) -> "UnitsMatrix":
+        """Adopt an already-normalized ``object`` array of units directly.
+
+        Internal fast path for methods that already hold a valid unit array
+        (`full`, `diagonal`); skips the redundant per-element normalization and
+        extra allocation that ``__init__`` -> ``_build_object_array`` would do.
+        """
+        if data.ndim not in (1, 2):
+            msg = f"UnitsMatrix only supports 1D or 2D, but got ndim={data.ndim}"
+            raise ValueError(msg)
+        obj = object.__new__(cls)
+        obj._units = data
+        return obj
+
+    @classmethod
     def full(cls, shape: int | tuple[int, ...], unit: Any, /) -> "UnitsMatrix":
         """Return a 1-D or 2-D `UnitsMatrix` with every entry set to ``unit``.
 
@@ -224,7 +239,7 @@ class UnitsMatrix:
         """
         data = np.empty(shape, dtype=object)
         data[...] = _normalize_unit(unit)
-        return cls(data)
+        return cls._wrap(data)
 
     # ── Shape / structure ─────────────────────────────────────────────
 
@@ -275,7 +290,7 @@ class UnitsMatrix:
         if self._units.ndim != 2:
             msg = f"diagonal() requires a 2-D UnitsMatrix, got ndim={self._units.ndim}"
             raise ValueError(msg)
-        return UnitsMatrix(np.diagonal(self._units).copy())
+        return UnitsMatrix._wrap(np.diagonal(self._units).copy())
 
     def __pow__(self, exponent: int | float, /) -> "UnitsMatrix":
         r"""Element-wise unit power — each unit raised to ``exponent``.

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -294,6 +294,20 @@ class TestUnitsMatrix:
         units = UnitsMatrix(((_m, _s), (_kg, _rad)))
         assert repr(units) == 'UnitsMatrix("((m, s), (kg, rad))")'
 
+    def test_full(self):
+        """full() builds a uniform 1-D or 2-D grid; invalid ndim is rejected."""
+        assert UnitsMatrix.full(3, "m") == UnitsMatrix((_m, _m, _m))
+        assert UnitsMatrix.full((2, 2), _s) == UnitsMatrix(((_s, _s), (_s, _s)))
+        with pytest.raises(ValueError, match="1D or 2D"):
+            UnitsMatrix.full((2, 2, 2), "m")
+
+    def test_diagonal(self):
+        """diagonal() returns the 2-D main diagonal; 1-D input is rejected."""
+        um = UnitsMatrix(((_m, _s), (_kg, _rad)))
+        assert um.diagonal() == UnitsMatrix((_m, _rad))
+        with pytest.raises(ValueError, match="2-D"):
+            UnitsMatrix((_m, _s)).diagonal()
+
     def test_unit_from_object_array_1d(self):
         """u.unit() accepts a 1-D numpy object array of AbstractUnit."""
         arr = np.array([_m, _s, _kg], dtype=object)


### PR DESCRIPTION
Follow-up to #807 (`__pow__`/`sqrt()`). Two more structural helpers for `UnitsMatrix`:

- **`full(shape, unit)`** — classmethod building a 1-D or 2-D matrix with every entry set to a single unit (`AbstractUnit` or unit string). Replaces ad-hoc `tuple(u for _ in range(n))` / `np.full(shape, u)` constructions.
- **`diagonal()`** — main diagonal of a 2-D `UnitsMatrix` as a 1-D `UnitsMatrix`, so callers can divide by the diagonal element-wise (`b.unit / E.unit.diagonal()`) instead of an index loop.

### Why
Enables downstream cleanups (coordinax has ~13 hand-rolled uniform-unit-grid and diagonal patterns these replace).

### Tests
`packages/unxts.linalg`: new doctests pass, no new failures (the 8 pre-existing `test_quantity_matrix` failures reproduce on `main` — an unrelated ordering flake). ruff + pyright + ty + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)