### PR TITLE
♻️ refactor(interop): drop redundant Astropy `unit`/`unit_of` overloads

### DIFF
--- a/src/unxt/_interop/unxt_interop_astropy/units.py
+++ b/src/unxt/_interop/unxt_interop_astropy/units.py
@@ -14,43 +14,11 @@ from .custom_types import APYUnits
 # Register dispatches
 
 
-@plum.dispatch
-def unit(obj: apyu.UnitBase | apyu.Unit, /) -> APYUnits:
-    """Construct the units from an Astropy unit.
-
-    Examples
-    --------
-    >>> import astropy.units as apyu
-    >>> import unxt as u
-    >>> u.unit(apyu.km)
-    Unit("km")
-
-    """
-    return apyu.Unit(obj)
-
-
-# Note: ``unit(apyu.Quantity)`` lives in ``unxt._src.units`` (core), not here, so
-# it is registered before the built-in unit systems are constructed at import
-# time (astropy is unxt's unit backend, not an optional interop).
-
-
-# -------------------------------------------------------------------
-
-
-@plum.dispatch
-def unit_of(obj: apyu.UnitBase | apyu.Unit, /) -> APYUnits:
-    """Return the units of an object.
-
-    Examples
-    --------
-    >>> import astropy.units as apyu
-    >>> import unxt as u
-
-    >>> u.unit_of(apyu.km)
-    Unit("km")
-
-    """
-    return obj
+# Note: ``unit``/``unit_of`` for Astropy units live in ``unxt._src.units``
+# (core), not here: astropy is unxt's unit backend, not an optional interop, so
+# ``AbstractUnit`` already covers ``apyu.UnitBase``. The same goes for
+# ``unit(apyu.Quantity)``, which must be registered before the built-in unit
+# systems are constructed at import time.
 
 
 @plum.dispatch

--- a/src/unxt/_src/units.py
+++ b/src/unxt/_src/units.py
@@ -35,6 +35,12 @@ def unit(obj: AbstractUnit, /) -> AbstractUnit:
     >>> u.unit(m) is m
     True
 
+    Astropy units are passed through unchanged:
+
+    >>> import astropy.units as apyu
+    >>> u.unit(apyu.km)
+    Unit("km")
+
     """
     return obj
 
@@ -106,6 +112,10 @@ def unit_of(obj: AbstractUnit, /) -> AbstractUnit:
 
     >>> u.unit_of(m)
     Unit("m")
+
+    >>> import astropy.units as apyu
+    >>> u.unit_of(apyu.km)
+    Unit("km")
 
     """
     return obj


### PR DESCRIPTION
## Summary

`unxt._interop.unxt_interop_astropy.units` registers

```python
unit(obj: apyu.UnitBase | apyu.Unit)
unit_of(obj: apyu.UnitBase | apyu.Unit)
```

but core's `AbstractUnit` (`apyu.UnitBase | apyu.FunctionUnitBase`) already covers `apyu.UnitBase`. Because `UnitBase | Unit` normalizes to plain `UnitBase`, the interop signature is *strictly more specific* than the core one, so plum resolved every plain-unit call to the interop methods — the core `unit`/`unit_of` implementations only ever saw `FunctionUnit` arguments.

Found while profiling `u.unit()`; this is the redundancy cleanup, not the perf fix (that one is upstream in plum).

## Why it's safe

The two implementations are behaviourally identical. Core returns `obj`; interop returns `apyu.Unit(obj)`, and `apyu.Unit(x) is x` for every `UnitBase` flavour:

| input | type | `Unit(x) is x` |
|---|---|---|
| `apyu.Unit("m")` | `IrreducibleUnit` | ✅ |
| `apyu.km` | `PrefixUnit` | ✅ |
| `apyu.Unit("km/s")` | `CompositeUnit` | ✅ |
| `apyu.deg` | `Unit` | ✅ |
| `apyu.dimensionless_unscaled` | `CompositeUnit` | ✅ |
| `apyu.Unit(2.5 * apyu.m)` | `CompositeUnit` (scaled) | ✅ |

Dropping the interop copies routes plain units to core's identity implementation, which is what the interop version was effectively doing anyway.

## Notes

- `unit_of(apyu.Quantity)` is **not** redundant (core has no `unit_of` for `Quantity`) and is kept.
- The astropy-input doctests from the deleted docstrings are moved onto the core methods so doctest coverage is retained.
- Resolved methods after this change:
  - `unit`: `UnitBase | FunctionUnit`, `str`, `Quantity` — all core
  - `unit_of`: `Any`, `UnitBase | FunctionUnit`, `AbstractQuantity`, `Quantity` (interop)

## Testing

`3982 passed, 49 skipped, 20 xfailed`, full pre-commit (incl. pyright/ty/mypy typing guards) clean. Verified identity, `Quantity`, function-unit (`dex`/`mag`) and `dataclassish.fields` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)