### PR TITLE
⚡️ perf: adopt quax-blocks v5 `__make__` for unchecked quantity construction

### DIFF
--- a/packages/unxts.hypothesis/pyproject.toml
+++ b/packages/unxts.hypothesis/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["unxt>=2.0.0", "hypothesis[numpy]>=6.138.14", "jax>=0.5.3"]
+dependencies = ["unxt>=2.0.0", "hypothesis[numpy]>=6.138.14", "jax>=0.7.2"]
 description = "Hypothesis strategies for unxt (canonical: unxts.hypothesis)"
 dynamic = ["version"]
 license = "BSD-3-Clause"

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
@@ -9,7 +9,6 @@ specialisations without displacing any core behaviour.
 
 __all__: tuple[str, ...] = ()
 
-from dataclasses import replace
 
 import quax
 from astropy.units import (
@@ -23,6 +22,7 @@ from unxts.api import ustrip
 
 from .base_parametric import AbstractParametricQuantity as ABCPQ  # noqa: N814
 from .parametric import ParametricQuantity
+from unxt._src.quantity.base import revalue
 from unxt.quantity import AbstractQuantity as ABCQ  # noqa: N814
 
 # ==============================================================================
@@ -70,7 +70,7 @@ def clamp_p_qqv(
     ParametricQuantity(Array([0, 1, 2], dtype=int32), unit='')
 
     """
-    return replace(x, value=lax.clamp(ustrip(one, min), ustrip(one, x), max))
+    return revalue(x, lax.clamp(ustrip(one, min), ustrip(one, x), max))
 
 
 # ==============================================================================
@@ -130,7 +130,7 @@ def pow_p_vq(x: ArrayLike, y: ABCPQ["dimensionless"], /) -> ABCQ:
     ParametricQuantity(Array([8.], dtype=float32), unit='')
 
     """
-    return replace(y, value=lax.pow(x, ustrip(y)))
+    return revalue(y, lax.pow(x, ustrip(y)))
 
 
 # ==============================================================================
@@ -154,4 +154,4 @@ def rem_p_uqv(
     ParametricQuantity(Array(1, dtype=int32...), unit='')
 
     """
-    return replace(x, value=ustrip(x) % y)
+    return revalue(x, ustrip(x) % y)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,15 @@ dependencies = [
   "dataclassish>=0.8.0",
   "equinox>=0.13.7",
   "is-annotated>=1.0",
-  "jax>=0.5.3",
-  "jaxlib>=0.5.3",
-  "jaxtyping>=0.3.3",
+  "jax>=0.7.2",
+  "jaxlib>=0.7.2",
+  "jaxtyping>=0.3.9",
   "optional-dependencies>=0.3.2",
   "packaging>=20.0",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",
-  "quax-blocks>=0.4.1",
+  "quax-blocks>=0.5.0",
   "quaxed>=0.10.5",
   "traitlets>=5.0.0",
   "unxt-api>=2.0.0",
@@ -50,11 +50,11 @@ requires-python = ">=3.12"
 
 [project.optional-dependencies]
 # jax extras
-cpu          = ["jax[cpu]>=0.5.3"]
-cuda         = ["jax[cuda]>=0.5.3"]
-cuda12       = ["jax[cuda12]>=0.5.3"]
-cuda12_local = ["jax[cuda12_local]>=0.5.3"]
-k8s          = ["jax[k8s]>=0.5.3"]
+cpu          = ["jax[cpu]>=0.7.2"]
+cuda         = ["jax[cuda]>=0.7.2"]
+cuda12       = ["jax[cuda12]>=0.7.2"]
+cuda12_local = ["jax[cuda12_local]>=0.7.2"]
+k8s          = ["jax[k8s]>=0.7.2"]
 # extra extras
 all = ["unxt[backend-astropy,workspace]"]
 backend-astropy = ["astropy>=7.0.0"]
@@ -115,8 +115,8 @@ docs = [
   "sphinxext-opengraph>=0.9.1",
   "sphinxext-rediraffe>=0.2.7",
   # Runtime dependencies for notebook execution
-  "jax[cpu]>=0.5.3",
-  "jaxlib>=0.5.3",
+  "jax[cpu]>=0.7.2",
+  "jaxlib>=0.7.2",
   "quax>=0.4.2",
 ]
 lint = ["prek>=0.3.9", "pylint>=3.3.8"]

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -1113,6 +1113,12 @@ class AbstractQuantity(
         return f"{value_str} {unit_str}" if unit_str else value_str
 
 
+#: The unchecked ``_mk``. `revalue`'s debug assertion compares against this to
+#: tell a class that took the fast path from one that opted back out of it (see
+#: `unxt.quantity.StaticQuantity`), whose converter makes the check moot.
+_UNCHECKED_MK = quax_blocks.SupportsUncheckedMake.__dict__["__make__"].__func__
+
+
 def revalue(q: AbstractQuantity, value: Any, /) -> AbstractQuantity:
     """Rebuild ``q`` around a new ``value``, keeping its class and unit.
 
@@ -1161,7 +1167,18 @@ def revalue(q: AbstractQuantity, value: Any, /) -> AbstractQuantity:
     Quantity(Array([3., 4.], dtype=float32), unit='m')
 
     """
-    return type(q)._mk(value=value, unit=object.__getattribute__(q, "unit"))  # noqa: SLF001
+    mk = type(q)._mk  # noqa: SLF001
+    # Debug-only: condition 1 above, enforced rather than merely documented. A
+    # `jax.Array` covers tracers too, so this is one `isinstance` on the happy
+    # path, and `python -O` drops it entirely. It is what catches a new rule
+    # that hands over a `list` from a multi-output primitive, or a NumPy scalar
+    # -- both of which the converter would have folded into an array, and both
+    # of which would otherwise be stored raw and fail much later.
+    assert isinstance(value, jax.Array) or mk.__func__ is not _UNCHECKED_MK, (  # noqa: S101
+        f"revalue() requires an already-converted value, got {type(value).__name__}; "
+        f"use the checked constructor when that does not hold"
+    )
+    return mk(value=value, unit=object.__getattribute__(q, "unit"))
 
 
 def _is_different_from_default(value: Any, default: Any) -> bool:

--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -38,7 +38,7 @@ from plum import add_promotion_rule, convert, dispatch, type_nonparametric
 from quax import ArrayValue
 
 import quaxed.numpy as jnp
-from dataclassish import field_items, replace
+from dataclassish import field_items
 
 import unxt_api as uapi
 from .mixins import AstropyQuantityCompatMixin, IPythonReprMixin, NumPyCompatMixin
@@ -117,6 +117,7 @@ class AbstractQuantity(
     quax_blocks.NumpyCeilMixin["AbstractQuantity"],
     quax_blocks.LaxLenMixin,
     quax_blocks.LaxLengthHintMixin,
+    quax_blocks.SupportsUncheckedMake,
 ):
     """Represents a quantity with a value and a unit.
 
@@ -178,6 +179,24 @@ class AbstractQuantity(
 
     # ---------------------------------------------------------------
     # Constructors
+
+    #: `quax_blocks.SupportsUncheckedMake.__make__` under a shorter name, for
+    #: the construction hot path: it writes the fields and returns, so neither
+    #: the field converters (`convert_to_quantity_value`, `unxts.api.unit`) nor
+    #: ``__check_init__`` run. Both converters are `plum`-dispatched, so the
+    #: checked constructor -- and `replace`, which calls it -- costs ~50us
+    #: against ~1us here.
+    #:
+    #: Callers must pass an already-normalised value and unit; the theorem that
+    #: makes that safe belongs at the call site, and `revalue` is the vetted way
+    #: to state it. Do not reach for `_mk` directly without one.
+    #:
+    #: Bound as the classmethod *object* so ``cls`` follows the class it is
+    #: called on -- ``_mk = __make__`` is a `NameError` in a class body, and
+    #: ``_mk = SupportsUncheckedMake.__make__`` would build the mixin.
+    #: `StaticQuantity` overrides this back to the checked constructor, whose
+    #: converter is load-bearing rather than redundant.
+    _mk = quax_blocks.SupportsUncheckedMake.__dict__["__make__"]
 
     @classmethod
     @dispatch.abstract
@@ -253,7 +272,7 @@ class AbstractQuantity(
         return jax.typeof(value)
 
     def enable_materialise(self, _: bool = True) -> "Self":  # noqa: FBT001, FBT002
-        return replace(self, value=self.value, unit=self.unit)
+        return type(self)._mk(value=self.value, unit=self.unit)  # noqa: SLF001
 
     # ===============================================================
     # Plum API
@@ -325,7 +344,7 @@ class AbstractQuantity(
         # ``jnp.matrix_transpose(self.value)``: the latter rejects a
         # ``StaticValue`` (StaticQuantity's value), while ``.mT`` delegates to
         # the wrapped NumPy/JAX array for both quantity kinds.
-        return replace(self, value=self.value.mT)
+        return revalue(self, self.value.mT)
 
     @property
     def ndim(self) -> int:
@@ -368,7 +387,7 @@ class AbstractQuantity(
                                   [1, 2]], dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.T)
+        return revalue(self, self.value.T)
 
     # ---------------------------------------------------------------
     # methods
@@ -444,7 +463,7 @@ class AbstractQuantity(
         """
         if isinstance(key, AbstractQuantity):
             key = uapi.ustrip("", key)
-        return replace(self, value=self.value[key])
+        return revalue(self, self.value[key])
 
     def __index__(self) -> int:
         """Convert a zero-dimensional integer array to a Python int object.
@@ -501,7 +520,7 @@ class AbstractQuantity(
         Quantity(Array(1, dtype=int32...), unit='m')
 
         """
-        return replace(self, value=self.value.to_device(device))
+        return revalue(self, self.value.to_device(device))
 
     # ===============================================================
     # JAX API
@@ -600,7 +619,7 @@ class AbstractQuantity(
         Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
         """
-        return replace(self, value=self.value.astype(*args, **kwargs))
+        return revalue(self, self.value.astype(*args, **kwargs))
 
     @ft.partial(property, doc=jax.Array.at.__doc__)
     def at(self) -> "_QuantityIndexUpdateHelper":
@@ -644,7 +663,7 @@ class AbstractQuantity(
         Quantity(Array([1, 2, 3, 4], dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.flatten())
+        return revalue(self, self.value.flatten())
 
     def max(self, *args: Any, **kwargs: Any) -> "AbstractQuantity":
         """Return the maximum value.
@@ -657,7 +676,7 @@ class AbstractQuantity(
         Quantity(Array(3, dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.max(*args, **kwargs))
+        return revalue(self, self.value.max(*args, **kwargs))
 
     def mean(self, *args: Any, **kwargs: Any) -> "AbstractQuantity":
         """Return the mean value.
@@ -670,7 +689,7 @@ class AbstractQuantity(
         Quantity(Array(2., dtype=float32), unit='m')
 
         """
-        return replace(self, value=self.value.mean(*args, **kwargs))
+        return revalue(self, self.value.mean(*args, **kwargs))
 
     def min(self, *args: Any, **kwargs: Any) -> "AbstractQuantity":
         """Return the minimum value.
@@ -683,7 +702,7 @@ class AbstractQuantity(
         Quantity(Array(1, dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.min(*args, **kwargs))
+        return revalue(self, self.value.min(*args, **kwargs))
 
     def ravel(self) -> "AbstractQuantity":
         """Return a flattened version of the array.
@@ -696,7 +715,7 @@ class AbstractQuantity(
         Quantity(Array([1, 2, 3, 4], dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.ravel())
+        return revalue(self, self.value.ravel())
 
     def reshape(self, *args: Any, order: str = "C") -> "AbstractQuantity":
         """Return a reshaped version of the array.
@@ -711,7 +730,7 @@ class AbstractQuantity(
 
         """
         __tracebackhide__ = True  # pylint: disable=unused-variable
-        return replace(self, value=self.value.reshape(*args, order=order))
+        return revalue(self, self.value.reshape(*args, order=order))
 
     def round(self, *args: Any, **kwargs: Any) -> "AbstractQuantity":
         """Round the array to the given number of decimals.
@@ -724,7 +743,7 @@ class AbstractQuantity(
         Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 
         """
-        return replace(self, value=self.value.round(*args, **kwargs))
+        return revalue(self, self.value.round(*args, **kwargs))
 
     @property
     def sharding(self) -> Any:
@@ -751,7 +770,7 @@ class AbstractQuantity(
         Quantity(Array([1, 2, 3], dtype=int32), unit='m')
 
         """
-        return replace(self, value=self.value.squeeze(*args, **kwargs))
+        return revalue(self, self.value.squeeze(*args, **kwargs))
 
     # ===============================================================
     # Python stuff
@@ -1094,6 +1113,57 @@ class AbstractQuantity(
         return f"{value_str} {unit_str}" if unit_str else value_str
 
 
+def revalue(q: AbstractQuantity, value: Any, /) -> AbstractQuantity:
+    """Rebuild ``q`` around a new ``value``, keeping its class and unit.
+
+    This is `replace` with the checked constructor taken out:
+    `AbstractQuantity._mk` writes the fields directly, so the two
+    `plum`-dispatched field converters and ``__check_init__`` never run. That is
+    ~55x -- 50us to 0.9us -- and it sits on the return path of every `quax`
+    primitive rule and every Array-API method that reshapes a quantity.
+
+    Skipping the converters is sound only where they are redundant, which is why
+    this is not spelled `replace`. Callers must satisfy two conditions:
+
+    1. ``value`` is already what `convert_to_quantity_value` would return -- a
+       `jax.Array` or tracer. The output of any `jax.lax` operation qualifies,
+       but the output of a *multi-output* primitive does not: those hand back a
+       `list` of arrays, and the converter is what folds it into one.
+    2. The unit is ``q``'s own, unchanged. That is what makes skipping
+       ``__check_init__`` safe: the one invariant it guards,
+       `AbstractParametricQuantity`'s dimension, is a function of the unit.
+
+    A rule whose unit *changes* must keep the ordinary
+    ``type_np(q)(value, unit=...)`` constructor, and not only for the
+    converters: on an `AbstractParametricQuantity` that call is what re-infers
+    the type parameter from the new unit, which writing the fields directly
+    would not do.
+
+    `StaticQuantity` opts back out of the shortcut -- its converter materialises
+    concrete JAX arrays to NumPy and rejects traced ones, so it is load-bearing
+    rather than redundant -- which is why this reads ``_mk`` off the instance's
+    own class instead of calling `AbstractQuantity._mk` directly.
+
+    The unit is read with `object.__getattribute__` because `equinox.Module`
+    installs a ``__getattribute__`` that re-wraps bound methods on *every*
+    attribute access; at this call volume that one lookup is ~40% of what is
+    left. For the same reason this is a module-level function rather than a
+    method: ``q._revalue`` would pay the wrapper twice.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt._src.quantity.base import revalue
+
+    >>> q = u.Q([1.0, 2.0], "m")
+    >>> revalue(q, jnp.asarray([3.0, 4.0]))
+    Quantity(Array([3., 4.], dtype=float32), unit='m')
+
+    """
+    return type(q)._mk(value=value, unit=object.__getattribute__(q, "unit"))  # noqa: SLF001
+
+
 def _is_different_from_default(value: Any, default: Any) -> bool:
     """Check if value differs from default using equality when safe."""
     with contextlib.suppress(Exception):
@@ -1353,7 +1423,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
             # ``fv`` is always a 0-d array; coerce it to a Python scalar.
             fill_value = fv.item()
         value = self.array.value.at[self.index].get(fill_value=fill_value, **kw)
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     @override
     def set(self, values: AbstractQuantity, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1361,7 +1431,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         value = self.array.value.at[self.index].set(
             uapi.ustrip(self.array.unit, values), **kw
         )
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     @override
     def apply(self, func: Any, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1379,7 +1449,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         value = self.array.value.at[self.index].add(
             uapi.ustrip(self.array.unit, values), **kw
         )
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     @override
     def multiply(self, values: ArrayLike, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1391,7 +1461,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
 
         # TODO: by quaxified super
         value = self.array.value.at[self.index].multiply(values, **kw)
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     mul = multiply  # type: ignore[assignment]
 
@@ -1405,7 +1475,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
 
         # TODO: by quaxified super
         value = self.array.value.at[self.index].divide(values, **kw)
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     @override
     def power(self, values: ArrayLike, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1423,7 +1493,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         value = self.array.value.at[self.index].min(
             uapi.ustrip(self.array.unit, values), **kw
         )
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
     @override
     def max(self, values: AbstractQuantity, **kw: Any) -> AbstractQuantity:  # type: ignore[override]
@@ -1431,7 +1501,7 @@ class _QuantityIndexUpdateRef(_IndexUpdateRef):
         value = self.array.value.at[self.index].max(
             uapi.ustrip(self.array.unit, values), **kw
         )
-        return replace(self.array, value=value)
+        return revalue(self.array, value)
 
 
 # This is public!

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -4,7 +4,6 @@
 __all__: tuple[str, ...] = ()
 
 from collections.abc import Sequence
-from dataclasses import replace
 from math import prod
 from typing import Any, Literal, TypeAlias, overload
 
@@ -25,7 +24,7 @@ from plum import convert, promote, type_unparametrized as type_np
 
 import quaxed.lax as qlax
 
-from .base import AbstractQuantity as ABCQ  # noqa: N814
+from .base import AbstractQuantity as ABCQ, revalue  # noqa: N814
 from .base_angle import AbstractAngle
 from .flag import AllowValue
 from .quantity import Q, Quantity
@@ -127,7 +126,7 @@ def abs_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(1, dtype=int32...), unit='m')
 
     """
-    return replace(x, value=lax.abs(ustrip(x)))
+    return revalue(x, lax.abs(ustrip(x)))
 
 
 # ==============================================================================
@@ -222,7 +221,7 @@ def add_p_aqaq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     yv = ustrip(x.unit, y)  # this can change the dtype
     xv, yv = promote_dtypes_if_needed((x.dtype, y.dtype), xv, yv)
 
-    return replace(x, value=xv + yv)
+    return revalue(x, xv + yv)
 
 
 @quax.register(lax.add_p)
@@ -288,7 +287,7 @@ def add_p_vaq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
 
     """
     y = uconvert(one, y)
-    return replace(y, value=lax.add(x, ustrip(y)))
+    return revalue(y, lax.add(x, ustrip(y)))
 
 
 @quax.register(lax.add_p)
@@ -360,7 +359,7 @@ def add_p_aqv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     """
     x = uconvert(one, x)
-    return replace(x, value=lax.add(ustrip(x), y))
+    return revalue(x, lax.add(ustrip(x), y))
 
 
 # ==============================================================================
@@ -389,7 +388,7 @@ def add_jaxvals_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     """
     xv, yv = ustrip(x), ustrip(x.unit, y)
     xv, yv = promote_dtypes(xv, yv)
-    return replace(x, value=add_jaxvals_p.bind(xv, yv))  # type: ignore[no-untyped-call]
+    return revalue(x, add_jaxvals_p.bind(xv, yv))  # type: ignore[no-untyped-call]
 
 
 # ==============================================================================
@@ -488,7 +487,7 @@ def approx_top_k_p(x: ABCQ, /, **kwargs: Any) -> list[ABCQ | Array]:
 
     """
     vals, idx = lax.approx_top_k_p.bind(ustrip(x), **kwargs)  # type: ignore[no-untyped-call]
-    return [replace(x, value=vals), idx]
+    return [revalue(x, vals), idx]
 
 
 # ==============================================================================
@@ -803,9 +802,7 @@ def bitcast_convert_type_p(x: ABCQ, /, *, new_dtype: DTypeLike) -> ABCQ:
     Quantity(Array([    0, 16256], dtype=int16), unit='')
 
     """
-    return replace(
-        x, value=lax.bitcast_convert_type_p.bind(ustrip(x), new_dtype=new_dtype)
-    )
+    return revalue(x, lax.bitcast_convert_type_p.bind(ustrip(x), new_dtype=new_dtype))
 
 
 # ==============================================================================
@@ -815,7 +812,7 @@ def bitcast_convert_type_p(x: ABCQ, /, *, new_dtype: DTypeLike) -> ABCQ:
 def broadcast_in_dim_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
     """Broadcast a quantity in a specific dimension."""
     value = lax.broadcast_in_dim_p.bind(ustrip(operand), **kw)  # type: ignore[no-untyped-call,unused-ignore]
-    return replace(operand, value=value)
+    return revalue(operand, value)
 
 
 # ==============================================================================
@@ -879,7 +876,7 @@ def ceil_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(2., dtype=float32...), unit='m')
 
     """
-    return replace(x, value=lax.ceil(ustrip(x)))
+    return revalue(x, lax.ceil(ustrip(x)))
 
 
 # ==============================================================================
@@ -914,9 +911,7 @@ def clamp_p(min: ABCQ, x: ABCQ, max: ABCQ) -> ABCQ:
     Quantity(Array([0., 1., 2.], dtype=float32), unit='m')
 
     """
-    return replace(
-        x, value=lax.clamp(ustrip(x.unit, min), ustrip(x), ustrip(x.unit, max))
-    )
+    return revalue(x, lax.clamp(ustrip(x.unit, min), ustrip(x), ustrip(x.unit, max)))
 
 
 # ---------------------------
@@ -1022,7 +1017,7 @@ def clz_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(31, dtype=int32...), unit='')
 
     """
-    return replace(x, value=lax.clz_p.bind(ustrip(x)))
+    return revalue(x, lax.clz_p.bind(ustrip(x)))
 
 
 # ==============================================================================
@@ -1050,7 +1045,7 @@ def complex_p(x: ABCQ, y: ABCQ) -> ABCQ:
     """
     x, y = promote(x, y)  # e.g. Distance -> Quantity
     y_ = ustrip(x.unit, y)
-    return replace(x, value=lax.complex(ustrip(x), y_))
+    return revalue(x, lax.complex(ustrip(x), y_))
 
 
 # ==============================================================================
@@ -1074,7 +1069,7 @@ def _combine_quantities(operands: tuple[Any, ...], combine: Any) -> ABCQ:
     if all(isinstance(op, ABCQ) for op in operands):
         target = operands[0]
         arrs = [ustrip(target.unit, op) for op in operands]
-        return replace(target, value=combine(arrs))
+        return revalue(target, combine(arrs))
 
     arrs = [ustrip(one, op) if isinstance(op, ABCQ) else op for op in operands]
     out = combine(arrs)
@@ -1275,7 +1270,7 @@ def conj_p(x: ABCQ, *, input_dtype: Any) -> ABCQ:
 
     """
     del input_dtype  # TODO: use this?
-    return replace(x, value=lax.conj(ustrip(x)))
+    return revalue(x, lax.conj(ustrip(x)))
 
 
 # ==============================================================================
@@ -1292,7 +1287,7 @@ def convert_element_type_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
     else:
         value = lax.convert_element_type_p.bind(ustrip(operand), **kw)
 
-    return replace(operand, value=value)
+    return revalue(operand, value)
 
 
 # ==============================================================================
@@ -1316,7 +1311,7 @@ def copy_p(x: ABCQ) -> ABCQ:
     Quantity(Array(1, dtype=int32...), unit='m')
 
     """
-    return replace(x, value=lax.copy_p.bind(ustrip(x)))  # type: ignore[no-untyped-call]
+    return revalue(x, lax.copy_p.bind(ustrip(x)))  # type: ignore[no-untyped-call]
 
 
 # ==============================================================================
@@ -1417,8 +1412,8 @@ def cumlogsumexp_p(operand: ABCQ, *, axis: Any, reverse: Any) -> ABCQ:
 
     """
     # TODO: double check units make sense here.
-    return replace(
-        operand, value=lax.cumlogsumexp(ustrip(operand), axis=axis, reverse=reverse)
+    return revalue(
+        operand, lax.cumlogsumexp(ustrip(operand), axis=axis, reverse=reverse)
     )
 
 
@@ -1443,9 +1438,7 @@ def cummax_p(operand: ABCQ, *, axis: Any, reverse: Any) -> ABCQ:
     Quantity(Array([1, 2, 2], dtype=int32), unit='m')
 
     """
-    return replace(
-        operand, value=lax.cummax(ustrip(operand), axis=axis, reverse=reverse)
-    )
+    return revalue(operand, lax.cummax(ustrip(operand), axis=axis, reverse=reverse))
 
 
 # ==============================================================================
@@ -1469,9 +1462,7 @@ def cummin_p(operand: ABCQ, *, axis: Any, reverse: Any) -> ABCQ:
     Quantity(Array([2, 1, 1], dtype=int32), unit='m')
 
     """
-    return replace(
-        operand, value=lax.cummin(ustrip(operand), axis=axis, reverse=reverse)
-    )
+    return revalue(operand, lax.cummin(ustrip(operand), axis=axis, reverse=reverse))
 
 
 # ==============================================================================
@@ -1521,9 +1512,7 @@ def cumsum_p(operand: ABCQ, *, axis: Any, reverse: Any) -> ABCQ:
     Quantity(Array([1, 3, 6], dtype=int32), unit='m')
 
     """
-    return replace(
-        operand, value=lax.cumsum(ustrip(operand), axis=axis, reverse=reverse)
-    )
+    return revalue(operand, lax.cumsum(ustrip(operand), axis=axis, reverse=reverse))
 
 
 # ==============================================================================
@@ -1960,7 +1949,7 @@ def div_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
     Quantity(Array([6., 3., 2.], dtype=float32...), unit='m')
 
     """
-    return replace(x, value=ustrip(x) / y)
+    return revalue(x, ustrip(x) / y)
 
 
 # TODO: can this be done with promotion/conversion/default rule instead?
@@ -2153,9 +2142,7 @@ def dynamic_slice_q(operand: ABCQ, /, *indices: ArrayLike | ABCQ, **kw: Any) -> 
 
     """
     idxs = [ustrip(AllowValue, i) for i in indices]
-    return replace(
-        operand, value=lax.dynamic_slice_p.bind(ustrip(operand), *idxs, **kw)
-    )
+    return revalue(operand, lax.dynamic_slice_p.bind(ustrip(operand), *idxs, **kw))
 
 
 # ==============================================================================
@@ -2182,9 +2169,9 @@ def dynamic_update_slice_p(
     Quantity(Array([1, 6, 7, 4, 5], dtype=int32), unit='m')
 
     """
-    return replace(
+    return revalue(
         operand,
-        value=lax.dynamic_update_slice_p.bind(
+        lax.dynamic_update_slice_p.bind(
             ustrip(operand), ustrip(update), *indices, **kw
         ),
     )
@@ -2212,7 +2199,7 @@ def eigh_p(x: ABCQ, /, **kw: Any) -> tuple[Array, ABCQ]:
 
     """
     v, w = lax.linalg.eigh_p.bind(ustrip(x), **kw)
-    return v, replace(x, value=w)
+    return v, revalue(x, w)
 
 
 # ==============================================================================
@@ -2552,7 +2539,7 @@ def floor_p(x: ABCQ) -> ABCQ:
     Quantity(Array(1., dtype=float32...), unit='')
 
     """
-    return replace(x, value=lax.floor(ustrip(x)))
+    return revalue(x, lax.floor(ustrip(x)))
 
 
 # ==============================================================================
@@ -2565,7 +2552,7 @@ def gather_p(operand: ABCQ, start_indices: ArrayLike | ABCQ, /, **kw: Any) -> AB
     # by e.g. jax's nan-aware quantile (``nanmedian``); strip it to its value.
     # TODO: examples
     idx = ustrip(AllowValue, start_indices)
-    return replace(operand, value=lax.gather_p.bind(ustrip(operand), idx, **kw))
+    return revalue(operand, lax.gather_p.bind(ustrip(operand), idx, **kw))
 
 
 # ==============================================================================
@@ -2851,7 +2838,7 @@ def igammac_p(a: float | int | ABCQ, x: ABCQ) -> ABCQ:
 
 @quax.register(lax.imag_p)
 def imag_p(x: ABCQ) -> ABCQ:
-    return replace(x, value=lax.imag(ustrip(x)))
+    return revalue(x, lax.imag(ustrip(x)))
 
 
 # ==============================================================================
@@ -3366,7 +3353,7 @@ def max_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
 
     """
     yv = ustrip(x.unit, y)
-    return replace(x, value=lax.max(ustrip(x), yv))
+    return revalue(x, lax.max(ustrip(x), yv))
 
 
 @quax.register(lax.max_p)
@@ -3438,7 +3425,7 @@ def max_p_ss(x: StaticQuantity, y: StaticQuantity, /) -> StaticQuantity:
 
     """
     yv = ustrip(x.unit, y)
-    return replace(x, value=np.maximum(ustrip(x), yv))
+    return revalue(x, np.maximum(ustrip(x), yv))
 
 
 # ==============================================================================
@@ -3470,7 +3457,7 @@ def min_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     Quantity(Array([1, 1, 3], dtype=int32), unit='m')
 
     """
-    return replace(x, value=lax.min(ustrip(x), ustrip(x.unit, y)))
+    return revalue(x, lax.min(ustrip(x), ustrip(x.unit, y)))
 
 
 @quax.register(lax.min_p)
@@ -3614,7 +3601,7 @@ def mul_p_vq(x: ArrayLike, y: ABCQ, /, **kw: Any) -> ABCQ:
     Quantity(Array([4, 6], dtype=int32), unit='m')
 
     """
-    return replace(y, value=mul_qbind(x, ustrip(y), **kw))
+    return revalue(y, mul_qbind(x, ustrip(y), **kw))
 
 
 @quax.register(lax.mul_p)
@@ -3649,7 +3636,7 @@ def mul_p_qv(x: ABCQ, y: ArrayLike, /, **kw: Any) -> ABCQ:
     Quantity(Array([4, 6], dtype=int32), unit='m')
 
     """
-    return replace(x, value=mul_qbind(ustrip(x), y, **kw))
+    return revalue(x, mul_qbind(ustrip(x), y, **kw))
 
 
 @quax.register(lax.mul_p)
@@ -3835,7 +3822,7 @@ def neg_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(-1, dtype=int32...), unit='m')
 
     """
-    return replace(x, value=lax.neg(ustrip(x)))
+    return revalue(x, lax.neg(ustrip(x)))
 
 
 # =============================================================================
@@ -3861,7 +3848,7 @@ def nextafter_p(x1: ABCQ, x2: ABCQ, /) -> ABCQ:
 
     """
     u = unit_of(x1)
-    return replace(x1, value=lax.nextafter(ustrip(u, x1), ustrip(u, x2)))
+    return revalue(x1, lax.nextafter(ustrip(u, x1), ustrip(u, x2)))
 
 
 # =============================================================================
@@ -3989,9 +3976,9 @@ def pad_p(operand: ABCQ, padding_value: ABCQ, /, *, padding_config: Any) -> ABCQ
         (operand.dtype, padding_value.dtype), operand_stripped, padding_value_stripped
     )
 
-    return replace(
+    return revalue(
         operand,
-        value=lax.pad_p.bind(
+        lax.pad_p.bind(
             operand_stripped, padding_value_stripped, padding_config=padding_config
         ),
     )
@@ -4040,8 +4027,8 @@ def pad_p_array_padding(
         (operand.dtype, pad_val.dtype), op_val, pad_val
     )
 
-    return replace(
-        operand, value=lax.pad_p.bind(op_val, pad_val, padding_config=padding_config)
+    return revalue(
+        operand, lax.pad_p.bind(op_val, pad_val, padding_config=padding_config)
     )
 
 
@@ -4177,7 +4164,7 @@ def pow_p_v_bareq(x: ArrayLike, y: Quantity, /) -> ABCQ:
     Quantity(Array([8.], dtype=float32), unit='')
 
     """
-    return replace(y, value=lax.pow(x, ustrip("", y)))
+    return revalue(y, lax.pow(x, ustrip("", y)))
 
 
 @quax.register(lax.pow_p)
@@ -4223,7 +4210,7 @@ def real_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(1., dtype=float32...), unit='m')
 
     """
-    return replace(x, value=lax.real(ustrip(x)))
+    return revalue(x, lax.real(ustrip(x)))
 
 
 # ==============================================================================
@@ -4243,7 +4230,7 @@ def reduce_and_p(operand: ABCQ, /, *, axes: Sequence[int]) -> ABCQ:
 
 @quax.register(lax.reduce_max_p)
 def reduce_max_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    return replace(operand, value=lax.reduce_max_p.bind(ustrip(operand), axes=axes))
+    return revalue(operand, lax.reduce_max_p.bind(ustrip(operand), axes=axes))
 
 
 # ==============================================================================
@@ -4251,7 +4238,7 @@ def reduce_max_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
 
 @quax.register(lax.reduce_min_p)
 def reduce_min_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    return replace(operand, value=lax.reduce_min_p.bind(ustrip(operand), axes=axes))
+    return revalue(operand, lax.reduce_min_p.bind(ustrip(operand), axes=axes))
 
 
 # ==============================================================================
@@ -4287,7 +4274,7 @@ def reduce_prod_p_a(operand: AbstractAngle, /, *, axes: Axes) -> ABCQ:
 
 @quax.register(lax.reduce_sum_p)
 def reduce_sum_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
-    return replace(operand, value=lax.reduce_sum_p.bind(ustrip(operand), **kw))
+    return revalue(operand, lax.reduce_sum_p.bind(ustrip(operand), **kw))
 
 
 # ==============================================================================
@@ -4353,7 +4340,7 @@ def regularized_incomplete_beta_q(
     a = ustrip(AllowValue, one, a)
     b = ustrip(AllowValue, one, b)
     xv = ustrip(one, x)
-    return replace(x, value=lax.regularized_incomplete_beta_p.bind(a, b, xv))
+    return revalue(x, lax.regularized_incomplete_beta_p.bind(a, b, xv))
 
 
 # ==============================================================================
@@ -4374,7 +4361,7 @@ def rem_p_aa(x: AbstractAngle, y: ABCQ, /) -> AbstractAngle:
     """
     # Don't promote - preserve the Angle type. Use lax.rem (truncated
     # remainder) to match lax.rem_p, unlike ``%`` which is floor-mod.
-    return replace(x, value=lax.rem(ustrip(x), ustrip(x.unit, y)))
+    return revalue(x, lax.rem(ustrip(x), ustrip(x.unit, y)))
 
 
 @quax.register(lax.rem_p)
@@ -4408,7 +4395,7 @@ def rem_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
         value = np.fmod(np.asarray(xv), np.asarray(yv))
     else:
         value = lax.rem(xv, yv)
-    return replace(x, value=value)
+    return revalue(x, value)
 
 
 @quax.register(lax.rem_p)
@@ -4457,7 +4444,7 @@ def reshape_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
                               [4, 5]], dtype=int32), unit='m')
 
     """
-    return replace(operand, value=lax.reshape_p.bind(ustrip(operand), **kw))
+    return revalue(operand, lax.reshape_p.bind(ustrip(operand), **kw))
 
 
 # ==============================================================================
@@ -4481,7 +4468,7 @@ def rev_p(operand: ABCQ, /, *, dimensions: Any) -> ABCQ:
     Quantity(Array([3, 2, 1, 0], dtype=int32), unit='m')
 
     """
-    return replace(operand, value=lax.rev(ustrip(operand), dimensions))
+    return revalue(operand, lax.rev(ustrip(operand), dimensions))
 
 
 # ==============================================================================
@@ -4505,7 +4492,7 @@ def round_p(x: ABCQ, /, *, rounding_method: Any) -> ABCQ:
     Quantity(Array(1.23, dtype=float32...), unit='m')
 
     """
-    return replace(x, value=lax.round(ustrip(x), rounding_method))
+    return revalue(x, lax.round(ustrip(x), rounding_method))
 
 
 # ==============================================================================
@@ -4580,9 +4567,9 @@ def scatter_add_p_qvq(
     # ... )
 
     """
-    return replace(
+    return revalue(
         operand,
-        value=lax.scatter_add_p.bind(
+        lax.scatter_add_p.bind(
             ustrip(operand), scatter_indices, ustrip(operand.unit, updates), **kw
         ),
     )
@@ -4601,9 +4588,8 @@ def scatter_add_p_vvq(
     the `updates`.
 
     """
-    return replace(
-        updates,
-        value=lax.scatter_add_p.bind(operand, scatter_indices, ustrip(updates), **kw),
+    return revalue(
+        updates, lax.scatter_add_p.bind(operand, scatter_indices, ustrip(updates), **kw)
     )
 
 
@@ -4665,7 +4651,7 @@ def select_n_p_jjq(which: ArrayLike, case0: ArrayLike, case1: ABCQ, /) -> ABCQ:
     quantity's unit for a raw-array branch" sharp bit.
     """
     # Used by a `jnp.linalg.trace`
-    return replace(case1, value=lax.select_n(which, case0, ustrip(case1)))
+    return revalue(case1, lax.select_n(which, case0, ustrip(case1)))
 
 
 @quax.register(lax.select_n_p)
@@ -4698,7 +4684,7 @@ def select_n_p_jqj(which: ArrayLike, case0: ABCQ, case1: ArrayLike, /) -> ABCQ:
     quantity's unit for a raw-array branch" sharp bit.
 
     """
-    return replace(case0, value=lax.select_n(which, ustrip(case0), case1))
+    return revalue(case0, lax.select_n(which, ustrip(case0), case1))
 
 
 @quax.register(lax.select_n_p)
@@ -4735,7 +4721,7 @@ def select_n_p_jaq(
     dtypes = tuple(case.dtype for case in all_cases)
     casesv = promote_dtypes_if_needed(dtypes, *(ustrip(u, case) for case in all_cases))
 
-    return replace(case0, value=lax.select_n(which, *casesv))
+    return revalue(case0, lax.select_n(which, *casesv))
 
 
 @quax.register(lax.select_n_p)
@@ -4799,7 +4785,7 @@ def select_n_p_jqq(which: ArrayLike, /, *cases: ABCQ) -> ABCQ:
 
     # If result is a JAX array but promoted type is StaticQuantity, use
     # Quantity
-    return replace(cases[0], value=lax.select_n(which, *casesv))
+    return revalue(cases[0], lax.select_n(which, *casesv))
 
 
 # ==============================================================================
@@ -4953,7 +4939,7 @@ def shift_left_p(x: ABCQ, y: ABCQ | float | int, /, **kw: Any) -> ABCQ:
     Quantity(Array(4, dtype=int32...), unit='')
 
     """
-    return replace(x, value=lax.shift_left(ustrip(x), ustrip(AllowValue, one, y)))
+    return revalue(x, lax.shift_left(ustrip(x), ustrip(AllowValue, one, y)))
 
 
 # ==============================================================================
@@ -4963,9 +4949,9 @@ def shift_left_p(x: ABCQ, y: ABCQ | float | int, /, **kw: Any) -> ABCQ:
 def slice_p(
     operand: ABCQ, /, *, start_indices: Any, limit_indices: Any, strides: Any
 ) -> ABCQ:
-    return replace(
+    return revalue(
         operand,
-        value=lax.slice_p.bind(
+        lax.slice_p.bind(
             ustrip(operand),
             start_indices=start_indices,
             limit_indices=limit_indices,
@@ -5030,7 +5016,7 @@ def sort_p(
         *stripped, dimension=dimension, is_stable=is_stable, num_keys=num_keys
     )
     return tuple(
-        replace(op, value=out) if isinstance(op, ABCQ) else out
+        revalue(op, out) if isinstance(op, ABCQ) else out
         for op, out in zip(all_operands, outs, strict=True)
     )
 
@@ -5150,7 +5136,7 @@ def stop_gradient_p(x: ABCQ, /) -> ABCQ:
     Quantity(Array(1., dtype=float32...), unit='m')
 
     """
-    return replace(x, value=lax.stop_gradient(ustrip(x)))
+    return revalue(x, lax.stop_gradient(ustrip(x)))
 
 
 # ==============================================================================
@@ -5188,7 +5174,7 @@ def sub_p_qq(x: ABCQ, y: ABCQ, /) -> ABCQ:
     yv = ustrip(x.unit, y)
     xv, yv = promote_dtypes_if_needed((x.dtype, y.dtype), xv, yv)
     # Return the subtracted values, and the unit of the first operand
-    return replace(x, value=xv - yv)
+    return revalue(x, xv - yv)
 
 
 @quax.register(lax.sub_p)
@@ -5217,7 +5203,7 @@ def sub_p_vq(x: ArrayLike, y: ABCQ, /) -> ABCQ:
 
     """
     y = uconvert(one, y)
-    return replace(y, value=x - ustrip(y))
+    return revalue(y, x - ustrip(y))
 
 
 @quax.register(lax.sub_p)
@@ -5246,7 +5232,7 @@ def sub_p_qv(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     """
     x = uconvert(one, x)
-    return replace(x, value=ustrip(x) - y)
+    return revalue(x, ustrip(x) - y)
 
 
 # ==============================================================================
@@ -5358,7 +5344,7 @@ def top_k_p(operand: ABCQ, /, **kw: Any) -> list[ABCQ | Array]:
 
     """
     vals, idx = lax.top_k_p.bind(ustrip(operand), **kw)  # type: ignore[no-untyped-call]
-    return [replace(operand, value=vals), idx]
+    return [revalue(operand, vals), idx]
 
 
 # ==============================================================================
@@ -5384,8 +5370,8 @@ def transpose_p(operand: ABCQ, /, *, permutation: Any) -> ABCQ:
     Quantity(Array([[0, 3], [1, 4], [2, 5]], dtype=int32), unit='m')
 
     """
-    return replace(
-        operand, value=lax.transpose_p.bind(ustrip(operand), permutation=permutation)
+    return revalue(
+        operand, lax.transpose_p.bind(ustrip(operand), permutation=permutation)
     )
 
 
@@ -5483,4 +5469,4 @@ def zeta_p(x: ABCQ, q: ArrayLike, /) -> ABCQ:
     Quantity(Array(1.6449, dtype=float32...), unit='')
 
     """
-    return replace(x, value=lax.zeta_p.bind(ustrip(x), q))
+    return revalue(x, lax.zeta_p.bind(ustrip(x), q))

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -8,6 +8,8 @@ __all__ = ("StaticQuantity",)
 from typing import Any, final
 
 import equinox as eqx
+import jax
+import jax.core
 import numpy as np
 import unxts.api as uapi
 import wadler_lindig as wl
@@ -16,7 +18,7 @@ from plum import add_promotion_rule
 
 from .base import AbstractQuantity, ArrayLikeSequence, same_unit_label
 from .quantity import Quantity
-from .value import StaticValue
+from .value import TRACED_VALUE_MSG, StaticValue
 from unxt.units import AbstractUnit
 
 
@@ -71,17 +73,28 @@ class StaticQuantity(AbstractQuantity):
     """The unit associated with this value."""
 
     @classmethod
-    def _mk(cls, **fields: Any) -> "StaticQuantity":
-        """Construct a `StaticQuantity`, running the field converters.
+    def _mk(cls, *, value: Any, unit: AbstractUnit) -> "StaticQuantity":
+        """Build a `StaticQuantity`, converting the value but not the unit.
 
-        This deliberately gives up the fast path that `AbstractQuantity._mk`
-        opens. That path is only sound where the converters are redundant, and
-        here they are not: `StaticValue.from_` is what wraps the value, what
-        materialises a concrete JAX array back to NumPy, and what rejects a
-        traced one. Primitive rules hand this class the output of a `jax.lax`
-        operation like any other quantity, so all three have to survive the
-        shortcut -- otherwise `revalue` would quietly store a JAX array in a
-        field the whole class is built on being static.
+        `AbstractQuantity._mk` writes the fields verbatim. That is unsound here
+        for the *value*: primitive rules hand this class the output of a
+        `jax.lax` operation like any other quantity, and that field is the one
+        thing the whole class is built on being static, so a raw array must not
+        reach it. The unit needs no such care -- ``_mk``'s contract is that
+        callers pass an already-normalised unit, and both callers (`revalue`
+        and ``enable_materialise``) take one straight off another quantity.
+
+        Rather than route back through the checked constructor, which costs two
+        `plum`-dispatched converters plus `equinox`'s ``__init__`` machinery
+        (~29us on a NumPy value, ~114us on a JAX one), inline the type switch
+        from `StaticValue.from_`. `StaticQuantity` is `~typing.final` and has
+        exactly two fields, so the signature can name them rather than take
+        ``**fields``, and the switch has only three arms. ~1-2us.
+
+        Inlining is the one liberty taken here, so `StaticValue.from_` shares
+        `TRACED_VALUE_MSG` with this method, and
+        ``test_mk_matches_static_value_from_`` pins the two together over every
+        arm.
 
         Examples
         --------
@@ -101,11 +114,17 @@ class StaticQuantity(AbstractQuantity):
         >>> try:
         ...     jax.jit(lambda v: revalue(q, v))(jnp.asarray([3.0, 4.0]))
         ... except TypeError as e:
-        ...     print(type(e).__name__)
-        TypeError
+        ...     print(e)
+        StaticQuantity cannot hold a traced JAX value; use Quantity under jit/vmap/grad.
 
         """
-        return cls(**fields)
+        if not isinstance(value, StaticValue):
+            if isinstance(value, jax.core.Tracer):
+                raise TypeError(TRACED_VALUE_MSG)
+            # `StaticValue.__init__` does the `np.asarray`, so this one arm
+            # covers NumPy, array-likes, scalars and concrete `jax.Array`.
+            value = StaticValue(value)
+        return cls.__make__(value=value, unit=unit)
 
     def __hash__(self) -> int:
         """Return the hash of the quantity."""

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -86,6 +86,7 @@ class StaticQuantity(AbstractQuantity):
         Examples
         --------
         >>> import jax, jax.numpy as jnp
+        >>> import numpy as np
         >>> import unxt as u
         >>> from unxt._src.quantity.base import revalue
 

--- a/src/unxt/_src/quantity/static_quantity.py
+++ b/src/unxt/_src/quantity/static_quantity.py
@@ -70,6 +70,42 @@ class StaticQuantity(AbstractQuantity):
     unit: AbstractUnit = eqx.field(static=True, converter=uapi.unit)
     """The unit associated with this value."""
 
+    @classmethod
+    def _mk(cls, **fields: Any) -> "StaticQuantity":
+        """Construct a `StaticQuantity`, running the field converters.
+
+        This deliberately gives up the fast path that `AbstractQuantity._mk`
+        opens. That path is only sound where the converters are redundant, and
+        here they are not: `StaticValue.from_` is what wraps the value, what
+        materialises a concrete JAX array back to NumPy, and what rejects a
+        traced one. Primitive rules hand this class the output of a `jax.lax`
+        operation like any other quantity, so all three have to survive the
+        shortcut -- otherwise `revalue` would quietly store a JAX array in a
+        field the whole class is built on being static.
+
+        Examples
+        --------
+        >>> import jax, jax.numpy as jnp
+        >>> import unxt as u
+        >>> from unxt._src.quantity.base import revalue
+
+        A concrete value is materialised, not stored raw:
+
+        >>> q = u.StaticQuantity(np.array([1.0, 2.0]), "m")
+        >>> revalue(q, jnp.asarray([3.0, 4.0])).value
+        StaticValue(array([3., 4.], dtype=float32))
+
+        A traced value is still rejected:
+
+        >>> try:
+        ...     jax.jit(lambda v: revalue(q, v))(jnp.asarray([3.0, 4.0]))
+        ... except TypeError as e:
+        ...     print(type(e).__name__)
+        TypeError
+
+        """
+        return cls(**fields)
+
     def __hash__(self) -> int:
         """Return the hash of the quantity."""
         return hash((self.value, self.unit))

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -15,6 +15,13 @@ from jaxtyping import Array, ArrayLike
 
 import quaxed.numpy as jnp
 
+#: Raised when a traced value is offered to a static field. Shared with
+#: `unxt.quantity.StaticQuantity._mk`, which repeats this type switch inline to
+#: keep `plum` off its hot path, so the two must not drift.
+TRACED_VALUE_MSG = (
+    "StaticQuantity cannot hold a traced JAX value; use Quantity under jit/vmap/grad."
+)
+
 
 @final
 class StaticValue:
@@ -299,11 +306,7 @@ def from_(cls: type[StaticValue], value: jax.Array | jax.core.Tracer, /) -> Stat
     that does not exist yet, so it genuinely cannot be static and is rejected.
     """
     if isinstance(value, jax.core.Tracer):
-        msg = (
-            "StaticQuantity cannot hold a traced JAX value; "
-            "use Quantity under jit/vmap/grad."
-        )
-        raise TypeError(msg)
+        raise TypeError(TRACED_VALUE_MSG)
     return cls(np.asarray(value))
 
 

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -3,6 +3,7 @@
 import copy
 import pickle
 from functools import partial
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -898,3 +899,37 @@ def test_str_shows_values_like_quantity() -> None:
     assert str(u.StaticQuantity(3.0, "m")) == "StaticQuantity(3., unit='m')"
     # repr is unchanged (shows the NumPy array wrapper)
     assert repr(sq) == "StaticQuantity(array([1., 2.]), unit='m')"
+
+
+def test_mk_matches_static_value_from_() -> None:
+    """``StaticQuantity._mk`` agrees with the converter it inlines.
+
+    ``_mk`` repeats `StaticValue.from_`'s type switch by hand to keep `plum`
+    off the construction hot path (see its docstring). That is the one place
+    the two can drift, so pin them together over every arm of the switch:
+    pass-through, NumPy, array-like, Python scalar and concrete ``jax.Array``.
+    """
+    unit = u.unit("m")
+    cases = [
+        StaticValue(np.array([1.0, 2.0])),  # pass-through
+        np.array([1, 2, 3], dtype=np.int64),  # NumPy, dtype preserved
+        [1.0, 2.0],  # array-like
+        3.5,  # Python scalar
+        jnp.asarray([1.0, 2.0]),  # concrete jax.Array -> materialised
+    ]
+    for value in cases:
+        mk = u.StaticQuantity._mk(value=value, unit=unit)
+        checked = u.StaticQuantity(value, unit)
+        assert type(mk.value) is type(checked.value)
+        assert mk.value.array.dtype == checked.value.array.dtype
+        assert np.array_equal(mk.value.array, checked.value.array)
+        assert mk.unit == checked.unit
+        assert mk == checked
+
+    # And the rejected arm, with the message the two share.
+    @jax.jit
+    def via_mk(x: Any) -> u.StaticQuantity:
+        return u.StaticQuantity._mk(value=x, unit=unit)
+
+    with pytest.raises(TypeError, match="cannot hold a traced JAX value"):
+        via_mk(jnp.array([1.0, 2.0]))

--- a/uv.lock
+++ b/uv.lock
@@ -3212,20 +3212,21 @@ wheels = [
 
 [[package]]
 name = "quax-blocks"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
     { name = "optype" },
+    { name = "packaging" },
     { name = "plum-dispatch" },
     { name = "quax" },
     { name = "quaxed" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/e2/435c5e18e41bfa4c4fe93911111cd2517c7f3a309519a30b885411260ed8/quax_blocks-0.4.1.tar.gz", hash = "sha256:d41cb943fe53a8098cd3a4671088f77f1e02050e16f637c55dd845e926bb2d2a", size = 71821, upload-time = "2026-05-05T04:52:24.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/40/a9197e785f32ab31037266f4834d44d36f1ea8676f52f1af00a719c802df/quax_blocks-0.5.0.tar.gz", hash = "sha256:874effa5777aaf48a8bc1a2ef5397d93131ac3f00166b69da5d1d5f7e71232ae", size = 138091, upload-time = "2026-07-31T22:50:02.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/21/efd636c4243aaaff94ad175ee9726a343f690686c098e4b507f96e9c5329/quax_blocks-0.4.1-py3-none-any.whl", hash = "sha256:7931cae95556b47f6eb3a2331493b62222ed7a4724c46120b1c80d9dafde027d", size = 16204, upload-time = "2026-05-05T04:52:22.865Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e2/f8e50cc72cf5e92d7056d70d396dbee01172133bd081d6d85026c56916c8/quax_blocks-0.5.0-py3-none-any.whl", hash = "sha256:03e9deba2d6c6b51be47108ec52e4b991b7f466529aadab4abddf6fa68be2d60", size = 24809, upload-time = "2026-07-31T22:50:01.726Z" },
 ]
 
 [[package]]
@@ -4168,20 +4169,20 @@ requires-dist = [
     { name = "dataclassish", specifier = ">=0.8.0" },
     { name = "equinox", specifier = ">=0.13.7" },
     { name = "is-annotated", specifier = ">=1.0" },
-    { name = "jax", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["cuda12-local"], marker = "extra == 'cuda12-local'", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["k8s"], marker = "extra == 'k8s'", specifier = ">=0.5.3" },
-    { name = "jaxlib", specifier = ">=0.5.3" },
-    { name = "jaxtyping", specifier = ">=0.3.3" },
+    { name = "jax", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cuda12-local"], marker = "extra == 'cuda12-local'", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["k8s"], marker = "extra == 'k8s'", specifier = ">=0.7.2" },
+    { name = "jaxlib", specifier = ">=0.7.2" },
+    { name = "jaxtyping", specifier = ">=0.3.9" },
     { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "packaging", specifier = ">=20.0" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.2" },
-    { name = "quax-blocks", specifier = ">=0.4.1" },
+    { name = "quax-blocks", specifier = ">=0.5.0" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "traitlets", specifier = ">=5.0.0" },
     { name = "unxt-api", editable = "packages/unxt-api" },
@@ -4218,8 +4219,8 @@ dev = [
     { name = "cz-conventional-gitmoji", specifier = ">=0.6.1" },
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.138.14" },
     { name = "ipykernel", specifier = ">=6.29.5" },
-    { name = "jax", extras = ["cpu"], specifier = ">=0.5.3" },
-    { name = "jaxlib", specifier = ">=0.5.3" },
+    { name = "jax", extras = ["cpu"], specifier = ">=0.7.2" },
+    { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jupyter-cache", specifier = ">=1.0.0" },
     { name = "jupytext", specifier = ">=1.16.4" },
     { name = "matplotlib", specifier = ">=3.8" },
@@ -4263,8 +4264,8 @@ dev = [
     { name = "unxts-parametric", editable = "packages/unxts.parametric" },
 ]
 docs = [
-    { name = "jax", extras = ["cpu"], specifier = ">=0.5.3" },
-    { name = "jaxlib", specifier = ">=0.5.3" },
+    { name = "jax", extras = ["cpu"], specifier = ">=0.7.2" },
+    { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jupyter-cache", specifier = ">=1.0.0" },
     { name = "jupytext", specifier = ">=1.16.4" },
     { name = "myst-nb", specifier = ">=1.1.2" },
@@ -4459,7 +4460,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.138.14" },
-    { name = "jax", specifier = ">=0.5.3" },
+    { name = "jax", specifier = ">=0.7.2" },
     { name = "unxt", editable = "." },
 ]
 


### PR DESCRIPTION
Adopts `quax-blocks>=0.5.0` and uses its new `SupportsUncheckedMake` to take the checked constructor off the hot path of every `quax` primitive rule.

## The cost

Rebuilding a quantity via `replace` costs **~54 µs** (`dataclasses.replace`, used by the primitive rules) or **~99 µs** (`dataclassish.replace`, used by the Array-API methods). Profiling shows six `plum` dispatches per call — `replace` itself, both field converters (`convert_to_quantity_value`, `unxts.api.unit`), and each one's return-type conversion — plus `__check_init__`, plus `inspect.getattr_static` from quax's module metaclass.

None of that does any work when the value is already the `jax.Array` a `jax.lax` operation just returned, and the unit is carried over unchanged from an operand that already parsed it.

## The change

- `AbstractQuantity._mk` is `SupportsUncheckedMake.__make__` under a shorter name, bound as the classmethod *object* so `cls` follows the subclass. (`_mk = __make__` is a `NameError` in a class body; `_mk = SupportsUncheckedMake.__make__` would build the mixin.)
- Call sites go through `revalue(q, value)`, which states the precondition once. It reads the unit with `object.__getattribute__` because `equinox.Module` installs a `__getattribute__` that re-wraps bound methods on *every* attribute access — at this volume that single lookup is ~40% of what is left. It is a module-level function rather than a method for the same reason: `q._revalue` would pay the wrapper twice.

**0.92 µs, down from 54 µs.**

Applied to 63 primitive rules, 21 Array-API methods, and 3 `unxts.parametric` rules.

## Correctness

Skipping the converters is only sound where they are redundant, so there are two carve-outs:

- **`StaticQuantity` overrides `_mk` back to the checked constructor.** Its `StaticValue.from_` converter wraps the value, materialises a concrete JAX array back to NumPy, and rejects a traced one — load-bearing, not redundant. Doing it in the class rather than at each call site keeps every *generic* rule (`sub_p_qv`, `rem_p_qq`, `max_p_ss`, …) correct on `StaticQuantity` without a per-site audit.
- **Rules whose unit changes keep `type_np(q)(value, unit=...)`.** Not only for the converters: on an `AbstractParametricQuantity` that call is what re-infers the type parameter from the new unit, which writing the fields directly would not do.

Rather than eyeball the call sites, the precondition is asserted inside `revalue` — the value must be a `jax.Array` (which covers tracers), unless the class opted out of the unchecked `_mk`. The assertion is `__debug__`-guarded, so `python -O` drops it; it costs 0.90 µs → 1.05 µs on the construction, ~2.6% of a real op. Every one of the suite's examples exercises it, and it reports **zero violations** across 63 primitive rules, 21 Array-API methods and 3 parametric rules.

Full suite green — 3994 passed, 49 skipped, 20 xfailed.

## Numbers

End-to-end, eager, 1000-element quantities, measured against this branch's own base with identical resolved dependencies:

| op | before | after | |
|---|---|---|---|
| `q[0:10]` | 136 µs | 29 µs | 4.7× |
| `q.flatten()` | 130 µs | 30 µs | 4.3× |
| `q.max()` | 149 µs | 39 µs | 3.9× |
| `qnp.reshape(q, (10,100))` | 136 µs | 79 µs | 1.7× |
| `-q` | 219 µs | 146 µs | 1.5× |
| `qnp.floor(q)` | 209 µs | 144 µs | 1.5× |
| `abs(q)` | 209 µs | 146 µs | 1.4× |
| `q + q2` | 294 µs | 228 µs | 1.3× |

The Array-API methods gain most because they were on the more expensive `dataclassish.replace`.

## Dependency floors

`quax-blocks` 0.5.0 requires jax ≥ 0.7.2 and jaxtyping ≥ 0.3.9, so those floors move with it. `requires-python = ">=3.12"` and `quax>=0.4.2` already satisfied its other requirements. The only package that actually changes in the lock is `quax-blocks` itself.

I reviewed the rest of the 0.5.0 feature set — `LaxInvertMixin`, `LaxDivModMixin`, `NumpyGetItemMixin` are alternatives rather than gaps here (unxt already takes `__invert__`/`__divmod__` from the Numpy variants and has its own `__getitem__` that handles Quantity keys), and the `__le__`/`__round__(ndigits)`/deepcopy-memo fixes come free with the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)