### PR TITLE
⚡️ perf: make `StaticValue.from_`'s dispatch faithful so `plum` caches it

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -1563,8 +1563,15 @@ def custom_pdoc_noarray(obj: Any) -> wl.AbstractDoc | None:
 
 
 @StaticValue.from_.dispatch
-def from_(cls: StaticValue, value: AbstractQuantity, /) -> StaticValue:
-    """Disallow conversion of `AbstractQuantity` to a value."""
+def from_(cls: type, value: AbstractQuantity, /) -> StaticValue:
+    """Disallow conversion of `AbstractQuantity` to a value.
+
+    ``cls`` was annotated `StaticValue` rather than a class, so this overload
+    could never match a call -- ``StaticValue.from_(q)`` passes the *class* --
+    and an `AbstractQuantity` fell through to the `object` overload and was
+    quietly turned into a `StaticValue` of its magnitude. A bare `type` both
+    matches and keeps the resolver faithful.
+    """
     msg = (
         f"Cannot convert '{type(value).__name__}' to a value. "
         "For a Quantity, use the `.from_` constructor instead."

--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -281,33 +281,56 @@ class StaticValue:
         return abs(self._jnparray)
 
 
-@StaticValue.from_.dispatch
-def from_(cls: type[StaticValue], value: object, /) -> StaticValue:
-    """Convert a value for `StaticQuantity`."""
-    return cls(np.asarray(value))
+# Every signature below annotates ``cls`` as a bare `type` rather than
+# ``type[StaticValue]``, and none mentions `jax.Array`. Both are deliberate, and
+# both are about `plum`'s *faithfulness*: a resolver is faithful when method
+# choice depends only on the argument types, which is the condition for caching
+# the resolution. `plum` calls any subscripted hint unfaithful (so
+# ``type[StaticValue]`` is, regardless of `StaticValue` itself, which is
+# faithful), and `jax.Array` is unfaithful because `jaxlib`'s ``ArrayMeta``
+# defines a custom ``__instancecheck__``. One unfaithful signature makes the
+# whole resolver unfaithful, so `plum` re-runs resolution -- including
+# beartype-backed ambiguity comparisons between these overloads -- on *every*
+# call. That was 104us for a `StaticValue` and 15us for an array.
+#
+# `StaticValue` is `~typing.final`, so ``cls`` is only ever `StaticValue` and
+# dispatching on it buys nothing anyway.
 
 
 @StaticValue.from_.dispatch
-def from_(cls: type[StaticValue], value: StaticValue, /) -> StaticValue:
-    """Convert a value for `StaticQuantity`."""
+def from_(cls: type, value: object, /) -> StaticValue:
+    """Convert a value for `StaticQuantity`.
+
+    A concrete (eager) `jax.Array` lands here and is materialised to NumPy: it
+    is just data, so it can back a static value. That is what lets ops on a
+    `unxt.quantity.StaticQuantity` stay static, since the primitive rules
+    rebuild around the output of a `jax.lax` call.
+
+    The `np.asarray` is `StaticValue.__init__`'s to do, not ours: doing it here
+    too would hand ``__init__`` an array it then sees as the caller's and
+    defensively copies, so every list, scalar and `jax.Array` would pay for a
+    copy it does not need. This is the same one arm ``StaticQuantity._mk``
+    inlines, for the same reason.
+    """
+    return cls(value)
+
+
+@StaticValue.from_.dispatch
+def from_(cls: type, value: StaticValue, /) -> StaticValue:
+    """Pass through a value that is already static."""
     return value
 
 
 @StaticValue.from_.dispatch
-def from_(cls: type[StaticValue], value: jax.Array | jax.core.Tracer, /) -> StaticValue:
-    """Materialise a concrete JAX array to NumPy, or reject a traced value.
+def from_(cls: type, value: jax.core.Tracer, /) -> StaticValue:
+    """Reject a traced value.
 
-    A concrete (eager) ``jax.Array`` is just data, so it can back a static
-    value -- materialise it. This also lets ops on a ``StaticQuantity`` stay
-    static: the primitive rules rebuild via ``replace(x, value=<jax array>)``,
-    and that concrete array round-trips back to NumPy here instead of raising.
-
-    A *tracer* (under ``jit``/``vmap``/``grad``) is a placeholder for a value
-    that does not exist yet, so it genuinely cannot be static and is rejected.
+    A tracer (under ``jit``/``vmap``/``grad``) is a placeholder for a value that
+    does not exist yet, so it genuinely cannot be static. Dispatching on
+    `jax.core.Tracer` rather than testing inside the `jax.Array` overload keeps
+    `jax.Array` -- which `plum` considers unfaithful -- out of every signature.
     """
-    if isinstance(value, jax.core.Tracer):
-        raise TypeError(TRACED_VALUE_MSG)
-    return cls(np.asarray(value))
+    raise TypeError(TRACED_VALUE_MSG)
 
 
 # ==================================================================

--- a/tests/unit/test_static_quantity.py
+++ b/tests/unit/test_static_quantity.py
@@ -56,6 +56,33 @@ def test_static_value_deepcopy_preserves_type_and_dtype() -> None:
     assert np.array_equal(np.asarray(shallow), np.asarray(sv))
 
 
+def test_static_value_copies_numpy_input() -> None:
+    """A NumPy input is copied, so neither side can mutate the other's data.
+
+    ``StaticValue.__init__`` copies only when ``np.asarray`` handed back a view
+    of the caller's buffer, which it detects with ``isinstance(array,
+    np.ndarray)``. `StaticValue.from_` and ``StaticQuantity._mk`` therefore hand
+    it the caller's object untouched rather than converting first, which would
+    make every input look like a shared buffer and copy needlessly. That is a
+    cost, not a semantic, so it is not what this test can catch -- what it
+    catches is dropping the defensive copy on the way past.
+    """
+    arr = np.array([1.0, 2.0])
+    sv = StaticValue.from_(arr)
+
+    assert not np.shares_memory(sv.array, arr)
+    assert arr.flags.writeable, "must not freeze the caller's array"
+    assert not sv.array.flags.writeable
+
+    arr[0] = 99.0
+    assert np.array_equal(sv.array, np.array([1.0, 2.0]))
+
+    # A non-ndarray has no buffer to share, so it is converted exactly once.
+    from_list = StaticValue.from_([1.0, 2.0])
+    assert np.array_equal(from_list.array, np.array([1.0, 2.0]))
+    assert not from_list.array.flags.writeable
+
+
 def test_static_value_getattr_preserves_dtype() -> None:
     """Attributes/methods forwarded through ``__getattr__`` keep the real dtype.
 
@@ -933,3 +960,44 @@ def test_mk_matches_static_value_from_() -> None:
 
     with pytest.raises(TypeError, match="cannot hold a traced JAX value"):
         via_mk(jnp.array([1.0, 2.0]))
+
+
+def test_static_value_from_resolver_is_faithful() -> None:
+    """``StaticValue.from_`` must stay `plum`-faithful, so resolution is cached.
+
+    A resolver is faithful when method choice depends only on argument *types*;
+    that is `plum`'s condition for caching the resolution instead of redoing it
+    every call. It only takes one unfaithful signature to lose it for the whole
+    function, and the two easy ways back in are annotating ``cls`` as
+    ``type[StaticValue]`` (`plum` treats *any* subscripted hint as unfaithful)
+    and naming `jax.Array` (unfaithful because ``jaxlib``'s ``ArrayMeta``
+    defines a custom ``__instancecheck__``).
+
+    Losing it is silent and costs ~18x on this function, so pin it here.
+    """
+    from_ = StaticValue.__dict__["from_"].__func__
+
+    # Force any pending registrations to resolve; `is_faithful` is only
+    # meaningful afterwards.
+    from_(StaticValue, np.array([1.0]))
+
+    unfaithful = [
+        str(m.signature) for m in from_._resolver.methods if not m.signature.is_faithful
+    ]
+    assert not unfaithful, f"unfaithful signatures: {unfaithful}"
+    assert from_._resolver.is_faithful
+
+
+def test_static_value_from_rejects_quantity() -> None:
+    """A quantity is not a value, and must be refused rather than flattened.
+
+    Regression: the guard annotated ``cls`` as `StaticValue` instead of a class,
+    so it never matched -- ``StaticValue.from_`` passes the *class* -- and a
+    quantity fell through to the ``object`` overload, silently becoming a
+    `StaticValue` of its magnitude with the unit dropped.
+    """
+    with pytest.raises(TypeError, match="Cannot convert 'Quantity' to a value"):
+        StaticValue.from_(u.Quantity(1.0, "m"))
+
+    with pytest.raises(TypeError, match="Cannot convert 'StaticQuantity' to a value"):
+        StaticValue.from_(u.StaticQuantity(np.array(1.0), "m"))


### PR DESCRIPTION
> #816 has merged; this is rebased onto `main` and is now a single commit.

## The premise didn't survive contact

The ask was to mark `StaticValue` faithful. It turns out **`StaticValue` is already faithful**, and marking it would be a no-op:

```python
>>> from plum import is_faithful
>>> is_faithful(StaticValue)
True
```

`plum` grants faithfulness by default to any class whose metaclass keeps the standard `__instancecheck__` (`_type.py:340`), and `StaticValue` is a plain `@final` class. So `__faithful__ = True` changes nothing.

The 104 µs was real, though — it was the two things wrapped *around* `StaticValue` in the signatures.

## What was actually unfaithful

A resolver is faithful when method choice depends only on argument *types*; that is `plum`'s condition for caching resolution instead of redoing it. One unfaithful signature loses it for the whole function. All four here were unfaithful:

```
faithful=False   Signature(type[StaticValue], object)
faithful=False   Signature(type[StaticValue], StaticValue)
faithful=False   Signature(type[StaticValue], jax.Array | jax._src.core.Tracer)
faithful=False   Signature(StaticValue, AbstractQuantity)
```

- **`cls: type[StaticValue]`** — `plum` treats *every* subscripted hint as unfaithful regardless of what it wraps (`_type.py:327` returns `False` for any non-union subscripted hint). `StaticValue` is `final`, so `cls` is only ever `StaticValue` and dispatching on it buys nothing. A bare `type` is faithful and just as correct.
- **`jax.Array`** — unfaithful because `jaxlib`'s `ArrayMeta` defines a custom `__instancecheck__` (a nanobind method in `_jax.so`). Only the *tracer* half of that overload actually needed dispatch, and `jax.core.Tracer` **is** faithful, so splitting the arm keeps `jax.Array` out of every signature entirely. A concrete array now falls to the `object` overload, which materialises it exactly as before.

With the resolver faithful, `plum` populates `_cache` and resolution happens once per type-tuple rather than per call. The pathological case was a `StaticValue` argument, which matches two overloads and so triggered full beartype-backed ambiguity comparison — 88k `beartype.door` calls per 2000 invocations — every single time.

## Measurements

| | before | after | |
|---|---|---|---|
| `StaticValue.from_(StaticValue)` | 94.3 µs | 5.1 µs | **18×** |
| `StaticValue.from_(jax.Array)` | 98.6 µs | 7.3 µs | **14×** |
| `StaticValue.from_(np.ndarray)` | 14.7 µs | 6.3 µs | 2.3× |
| `StaticQuantity(v, "m")` (checked ctor) | 31.1 µs | 21.4 µs | 1.45× |

`from_`'s `object` overload also stopped doing its own `np.asarray` ([review](https://github.com/GalacticDynamics/unxt/pull/818#discussion_r3694204283)). `StaticValue.__init__` copies when `np.asarray` hands back a view of the caller's buffer, detected via `isinstance(array, np.ndarray)` — so converting first made *every* input look like a shared buffer and copy needlessly: `jax.Array` (n=1000) 1.97 µs → 1.11 µs, scalar 0.99 µs → 0.51 µs, `np.ndarray` unchanged at ~1.2 µs (that copy is the real one). `StaticQuantity._mk` already inlined this arm the same way. `test_static_value_copies_numpy_input` pins the copy semantics, which were previously untested.

End-to-end `StaticQuantity` ops are unchanged, because #816's `_mk` already bypasses `from_`. This PR speeds up everything that still goes through the checked constructor: `StaticQuantity(...)`, `.from_(...)`, and the `eqx.field` converter.

## A latent bug this uncovered

The guard refusing to flatten a quantity into a value annotated `cls` as `StaticValue` rather than a class, so it could never match — `StaticValue.from_` passes the *class*. An `AbstractQuantity` fell through to the `object` overload:

```python
>>> StaticValue.from_(u.Q(1.0, "m"))      # before
StaticValue(array(1., dtype=float32))     # unit silently dropped
```

It raises now, as its docstring always said it would. Fixed as part of making that signature faithful, since the annotation was the cause of both.

## Why `_mk` keeps its inlined switch

#816 inlined this type switch into `StaticQuantity._mk` precisely because `from_` was slow, so the obvious follow-up is to delegate again and drop the duplication. I measured it — it does not pay:

| | inlined (#816) | delegating to the fast `from_` |
|---|---|---|
| `_mk(StaticValue)` | 0.88 µs | 6.88 µs |
| `_mk(jax.Array)` | 2.07 µs | 8.72 µs |
| `sq[0:2]` | 3.5 µs | 9.4 µs |

Even a 5 µs `from_` is far above `__make__`'s ~0.8 µs, so the inlining stays, pinned by `test_mk_matches_static_value_from_` from #816.

## Regression tests

Faithfulness is silent when lost — nothing fails, things just get slow — so `test_static_value_from_resolver_is_faithful` asserts every signature stays faithful and names the two easy ways back in. `test_static_value_from_rejects_quantity` covers the guard.

Full suite: 3998 passed, 49 skipped, 20 xfailed.

## Follow-up worth taking (not in this PR)

The same root cause sits on the **main `Quantity` path**. `convert_to_quantity_value` dispatches on `ArrayLike | list[Any] | tuple[Any, ...]`, which is unfaithful twice over — `ArrayLike` contains `jax.Array`, and `list[Any]`/`tuple[Any, ...]` are subscripted. I measured the fix:

| | as-is | `jax.Array` faithful | + unsubscripted `list`/`tuple` |
|---|---|---|---|
| `convert_to_quantity_value(v)` | 28.1 µs | 22.5 µs | **12.8 µs** |
| `u.Q(v, "m")` | 54.5 µs | 39.7 µs | **30.7 µs** |
| `u.Q([1,2,3], "m")` | 93.5 µs | 79.4 µs | **62.4 µs** |

**1.8× on every `Quantity` construction.** I left it out because the `list[Any]` → `list` half is easy but the other half requires setting `jax.Array.__faithful__ = True` — monkeypatching a dependency's class from unxt. That is a real design call (and needs its own empirical check that `ArrayMeta.__instancecheck__` really is type-based), not something to slip into a PR about `StaticValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)