### PR TITLE
➖ dep-rm: drop two unused runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "astropy>=7.0.0",
   "dataclassish>=0.8.0",
   "equinox>=0.13.7",
+  "is-annotated>=1.0",
   "jax>=0.7.2",
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
@@ -472,10 +473,16 @@ unxt_api                = "uapi"
 unxt_hypothesis         = "ust"
 
 [tool.ruff.lint.isort]
-combine-as-imports     = true
+combine-as-imports = true
 extra-standard-library = ["typing_extensions"]
-known-first-party      = ["dataclassish", "optional_dependencies", "quaxed"]
-known-local-folder     = ["unxt", "unxt_api", "unxt_hypothesis"]
+known-first-party = [
+  "dataclassish",
+  "is_annotated",
+  "optional_dependencies",
+  "quaxed",
+  "zeroth",                # used by the unxts.interop.matplotlib subpackage
+]
+known-local-folder = ["unxt", "unxt_api", "unxt_hypothesis"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "astropy>=7.0.0",
   "dataclassish>=0.8.0",
   "equinox>=0.13.7",
-  "is-annotated>=1.0",
   "jax>=0.7.2",
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
@@ -37,8 +36,6 @@ dependencies = [
   "unxt-api>=2.0.0",
   "unxts.api>=2.0.0",
   "wadler-lindig>=0.1.5",
-  "xmmutablemap>=0.1",
-  "zeroth>=1.0.0",
 ]
 description = "Quantities in JAX"
 dynamic = ["version"]
@@ -475,17 +472,10 @@ unxt_api                = "uapi"
 unxt_hypothesis         = "ust"
 
 [tool.ruff.lint.isort]
-combine-as-imports = true
+combine-as-imports     = true
 extra-standard-library = ["typing_extensions"]
-known-first-party = [
-  "dataclassish",
-  "is_annotated",
-  "optional_dependencies",
-  "quaxed",
-  "xmmutablemap",
-  "zeroth",
-]
-known-local-folder = ["unxt", "unxt_api", "unxt_hypothesis"]
+known-first-party      = ["dataclassish", "optional_dependencies", "quaxed"]
+known-local-folder     = ["unxt", "unxt_api", "unxt_hypothesis"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -11,8 +11,6 @@ import jax.tree_util as jtu
 from astropy.units import PhysicalType, UnitBase as AstropyUnitBase
 from astropy.units.physical import _physical_unit_mapping
 
-from is_annotated import isannotated
-
 from .utils import parse_dimlike_name
 from unxt.dims import AbstractDimension, dimension
 from unxt.units import AbstractUnit, unit
@@ -352,8 +350,9 @@ def parse_field_names_and_dimensions(
     field_names = []
     dims = []
     for name, type_hint in type_hints.items():
-        # Check it's Annotated
-        if not isannotated(type_hint):
+        # Check it's Annotated. ``__metadata__`` is the public attribute the
+        # `typing.Annotated` alias carries, and nothing else does.
+        if not hasattr(type_hint, "__metadata__"):
             continue
 
         # Get the arguments to Annotated

--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -11,6 +11,8 @@ import jax.tree_util as jtu
 from astropy.units import PhysicalType, UnitBase as AstropyUnitBase
 from astropy.units.physical import _physical_unit_mapping
 
+from is_annotated import isannotated
+
 from .utils import parse_dimlike_name
 from unxt.dims import AbstractDimension, dimension
 from unxt.units import AbstractUnit, unit
@@ -350,9 +352,8 @@ def parse_field_names_and_dimensions(
     field_names = []
     dims = []
     for name, type_hint in type_hints.items():
-        # Check it's Annotated. ``__metadata__`` is the public attribute the
-        # `typing.Annotated` alias carries, and nothing else does.
-        if not hasattr(type_hint, "__metadata__"):
+        # Check it's Annotated
+        if not isannotated(type_hint):
             continue
 
         # Get the arguments to Annotated

--- a/uv.lock
+++ b/uv.lock
@@ -1281,18 +1281,6 @@ wheels = [
 ]
 
 [[package]]
-name = "is-annotated"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/47/71e305ed9716826ad2104cc6354a1b00147910fb5c8252d2a2b7999fd5df/is_annotated-1.0.1.tar.gz", hash = "sha256:7103a36eb58de43854e8f8425b895051e55250beaa70f58a909a052efa6cd882", size = 8905, upload-time = "2024-08-27T18:18:37.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/21/c7144383ecc537029c70f0d10a6b2cadcb3737be0712635ff811c8fa18e2/is_annotated-1.0.1-py3-none-any.whl", hash = "sha256:98426507e1d174cf61b32f5e5bdebab2d6f29885d2809df2383d0afdbef40a15", size = 3957, upload-time = "2024-08-27T18:18:36.269Z" },
-]
-
-[[package]]
 name = "isort"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3958,7 +3946,6 @@ dependencies = [
     { name = "astropy" },
     { name = "dataclassish" },
     { name = "equinox" },
-    { name = "is-annotated" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
@@ -3972,8 +3959,6 @@ dependencies = [
     { name = "unxt-api" },
     { name = "unxts-api" },
     { name = "wadler-lindig" },
-    { name = "xmmutablemap" },
-    { name = "zeroth" },
 ]
 
 [package.optional-dependencies]
@@ -4168,7 +4153,6 @@ requires-dist = [
     { name = "astropy", marker = "extra == 'backend-astropy'", specifier = ">=7.0.0" },
     { name = "dataclassish", specifier = ">=0.8.0" },
     { name = "equinox", specifier = ">=0.13.7" },
-    { name = "is-annotated", specifier = ">=1.0" },
     { name = "jax", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.7.2" },
@@ -4207,8 +4191,6 @@ requires-dist = [
     { name = "unxts-parametric", marker = "extra == 'parametric'", editable = "packages/unxts.parametric" },
     { name = "unxts-parametric", marker = "extra == 'workspace'", editable = "packages/unxts.parametric" },
     { name = "wadler-lindig", specifier = ">=0.1.5" },
-    { name = "xmmutablemap", specifier = ">=0.1" },
-    { name = "zeroth", specifier = ">=1.0.0" },
 ]
 provides-extras = ["all", "backend-astropy", "cpu", "cuda", "cuda12", "cuda12-local", "interop-gala", "interop-mpl", "interop-xarray", "k8s", "linalg", "parametric", "workspace"]
 
@@ -4946,19 +4928,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
-]
-
-[[package]]
-name = "xmmutablemap"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jax" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/c4043eb00f297956a5447109985f41fabb0adbbf80786a21c2949f798ba4/xmmutablemap-0.2.1.tar.gz", hash = "sha256:38a881b0fcc54352e2751628d11519d023bc6677e978483736f8f51b45c7147f", size = 97896, upload-time = "2025-10-22T01:22:00.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/89/4628be42c56e0063b2158a468fc0de3e21285800f8cab07f2d3be684c763/xmmutablemap-0.2.1-py3-none-any.whl", hash = "sha256:002f97986e1cc343d362e38eae62a0a51ca7b76bd3b1de0f70a8f05dbe2b8c5c", size = 7584, upload-time = "2025-10-22T01:21:58.821Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1281,6 +1281,18 @@ wheels = [
 ]
 
 [[package]]
+name = "is-annotated"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/47/71e305ed9716826ad2104cc6354a1b00147910fb5c8252d2a2b7999fd5df/is_annotated-1.0.1.tar.gz", hash = "sha256:7103a36eb58de43854e8f8425b895051e55250beaa70f58a909a052efa6cd882", size = 8905, upload-time = "2024-08-27T18:18:37.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/21/c7144383ecc537029c70f0d10a6b2cadcb3737be0712635ff811c8fa18e2/is_annotated-1.0.1-py3-none-any.whl", hash = "sha256:98426507e1d174cf61b32f5e5bdebab2d6f29885d2809df2383d0afdbef40a15", size = 3957, upload-time = "2024-08-27T18:18:36.269Z" },
+]
+
+[[package]]
 name = "isort"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3946,6 +3958,7 @@ dependencies = [
     { name = "astropy" },
     { name = "dataclassish" },
     { name = "equinox" },
+    { name = "is-annotated" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
@@ -4153,6 +4166,7 @@ requires-dist = [
     { name = "astropy", marker = "extra == 'backend-astropy'", specifier = ">=7.0.0" },
     { name = "dataclassish", specifier = ">=0.8.0" },
     { name = "equinox", specifier = ">=0.13.7" },
+    { name = "is-annotated", specifier = ">=1.0" },
     { name = "jax", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cuda"], marker = "extra == 'cuda'", specifier = ">=0.7.2" },


### PR DESCRIPTION
Part of a ponytail-audit cleanup sweep. One of 7 independent PRs; no ordering dependency on the others.

## What

Removes two runtime dependencies from `[project.dependencies]`. `src/` is untouched.

**`xmmutablemap`** — declared with **zero** references anywhere in the repo.

**`zeroth`** — unused by `unxt` itself. Its only importer is `packages/unxts.interop.matplotlib`, which already declares its own `zeroth>=1.0.0`, so it keeps working as an independently-installed subpackage. It stays in ruff's `known-first-party` list: dropping it there re-sorted that subpackage's import block and failed the `ruff-check` hook.

**`is-annotated` is kept.** An earlier revision of this PR replaced `isannotated(hint)` with `hasattr(hint, "__metadata__")` and dropped the dependency; that has been reverted.

## Verification

- `pytest tests/unit src` — 2413 passed (includes the sybil doctests over `src`)
- `uv run --isolated --no-dev --extra all` imports `unxts.interop.matplotlib` cleanly, confirming `zeroth` still resolves from the subpackage's own declaration
- Full pre-commit suite passes (ruff, taplo, pyright / ty / mypy typing guards)
- `uv lock` regenerated; `xmmutablemap` dropped. `zeroth` remains in the lock as the matplotlib subpackage's dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
