### PR TITLE
♻️ refactor(unitsystems): one registry, and plain class attrs for the ordered views

### DIFF
--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -5,7 +5,7 @@ __all__ = ("UNITSYSTEMS_REGISTRY", "AbstractUnitSystem")
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, ClassVar, get_args, get_type_hints
+from typing import ClassVar, get_args, get_type_hints
 
 import jax.tree_util as jtu
 from astropy.units import PhysicalType, UnitBase as AstropyUnitBase
@@ -20,36 +20,32 @@ from unxt.units import AbstractUnit, unit
 Unit = AstropyUnitBase
 
 
-class _classproperty:  # noqa: N801
-    """Read-only property that also works on the *class*.
-
-    ``AbstractUnitSystem`` subclasses expose ``_base_dimensions`` /
-    ``_base_field_names`` on the class (e.g. the unit-system registry keys off
-    ``cls._base_dimensions``), which a plain ``property`` cannot serve.
-    """
-
-    def __init__(self, fget: Any) -> None:
-        self.fget = fget
-        self.__doc__ = fget.__doc__
-
-    def __get__(self, obj: Any, owner: type | None = None) -> Any:
-        return self.fget(owner if owner is not None else type(obj))
-
-
 _UNITSYSTEMS_REGISTRY: dict[
     tuple[AbstractDimension, ...], type["AbstractUnitSystem"]
 ] = {}
 UNITSYSTEMS_REGISTRY = MappingProxyType(_UNITSYSTEMS_REGISTRY)
 
-#: Index of the registry keyed by the *set* of base dimensions (order-independent),
-#: so ``unitsystem(...)`` construction can match a registered class in O(1) rather
-#: than scanning ``_UNITSYSTEMS_REGISTRY`` and picking the first set-equal entry.
-#: Populated alongside ``_UNITSYSTEMS_REGISTRY`` in ``__init_subclass__``, which
-#: also enforces the one-class-per-dimension-set invariant so this mapping is
-#: unambiguous (never a silent last-write-wins between colliding classes).
-_UNITSYSTEMS_BY_DIMSET: dict[
-    frozenset[AbstractDimension], type["AbstractUnitSystem"]
-] = {}
+
+def registered_unitsystem(
+    dims: tuple[AbstractDimension, ...], /
+) -> "type[AbstractUnitSystem] | None":
+    """Return the registered class spanning exactly ``dims``, else `None`.
+
+    A unit system is identified by *which* dimensions it spans, not the order
+    they are declared in, so the match is by set. ``__init_subclass__`` enforces
+    one class per dimension set, so at most one entry can match.
+
+    The registry holds one entry per distinct dimension set -- a handful in
+    practice -- so this scans rather than maintaining a second frozenset-keyed
+    index in lockstep with ``_UNITSYSTEMS_REGISTRY``. At 7 registered classes
+    the scan is a fraction of a percent of a ``unitsystem(...)`` call, and one
+    registry cannot fall out of sync with itself.
+    """
+    want = frozenset(dims)
+    return next(
+        (cls for d, cls in _UNITSYSTEMS_REGISTRY.items() if frozenset(d) == want),
+        None,
+    )
 
 
 def _is_dataclass_slots_rebuild(
@@ -145,19 +141,11 @@ class AbstractUnitSystem:
     #: ``_base_dimensions`` / ``_base_field_names`` are its keys / values.
     _dimension_to_field: ClassVar[Mapping[AbstractDimension, str]]
 
-    @_classproperty
-    def _base_dimensions(  # pylint: disable=no-self-argument
-        cls,  # noqa: N805
-    ) -> tuple["AbstractDimension", ...]:
-        """Return the base dimensions, in declaration order."""
-        return tuple(cls._dimension_to_field)
+    #: The base dimensions, in declaration order (``_dimension_to_field``'s keys).
+    _base_dimensions: ClassVar[tuple[AbstractDimension, ...]]
 
-    @_classproperty
-    def _base_field_names(  # pylint: disable=no-self-argument
-        cls,  # noqa: N805
-    ) -> tuple[str, ...]:
-        """Return the declared field names, in declaration order."""
-        return tuple(cls._dimension_to_field.values())
+    #: The declared field names, in declaration order (its values).
+    _base_field_names: ClassVar[tuple[str, ...]]
 
     def __init_subclass__(cls) -> None:
         # In Python 3.14+, annotations are stored via __annotate_func__ (PEP
@@ -179,8 +167,8 @@ class AbstractUnitSystem:
         # since those are made after the original class is defined.
         field_names, dims = parse_field_names_and_dimensions(cls)
 
-        # Validate against both registries *before* mutating either, so a
-        # rejected registration leaves no partial entry behind.
+        # Validate *before* mutating the registry, so a rejected registration
+        # leaves no partial entry behind.
         #
         # Exact-signature duplicate: the same ordered dimensions are already
         # registered. `@dataclass(slots=True)` / `make_dataclass(slots=True)`
@@ -198,14 +186,12 @@ class AbstractUnitSystem:
 
         # Same dimension *set*, different field order: a unit system is
         # identified by which dimensions it spans, not their order, so two
-        # classes must not compete for one set. The by-set index is keyed by
-        # frozenset and would otherwise silently let the last registration win,
-        # leaving ``unitsystem(*units)`` dependent on registration order.
+        # classes must not compete for one set. Without this, registration order
+        # would silently decide which class ``unitsystem(*units)`` returns.
         # ``owner._base_dimensions == dims`` is the ``slots=True`` rebuild
         # re-registering the same class (same ordered dims); only a *different*
         # ordering is a conflict.
-        dim_set = frozenset(dims)
-        owner = _UNITSYSTEMS_BY_DIMSET.get(dim_set)
+        owner = registered_unitsystem(dims)
         if owner is not None and owner._base_dimensions != dims:  # noqa: SLF001
             msg = (
                 f"Unit system for dimension set {set(dims)!r} is already "
@@ -214,14 +200,14 @@ class AbstractUnitSystem:
             )
             raise ValueError(msg)
 
-        # All checks passed: store the single dimension -> field-name mapping
-        # (the ``_base_dimensions`` / ``_base_field_names`` tuples derive from
-        # it) and commit to both registries.
+        # All checks passed: store the dimension -> field-name mapping and the
+        # two ordered views onto it, then commit to the registry.
         cls._dimension_to_field = MappingProxyType(
             dict(zip(dims, field_names, strict=True))
         )
+        cls._base_dimensions = dims
+        cls._base_field_names = field_names
         _UNITSYSTEMS_REGISTRY[dims] = cls
-        _UNITSYSTEMS_BY_DIMSET[dim_set] = cls
 
     # ===============================================================
     # USys API

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -145,17 +145,16 @@ def unitsystem(*args: Any) -> AbstractUnitSystem:
 
     # A unit system is identified by its *set* of dimensions, not the argument
     # order. Look up a registered class (a built-in like ``LTMAUnitSystem`` or a
-    # previously-created dynamic one) by that set -- an O(1) hit on the by-set
-    # index -- and build it in that class's own field order. This keeps the
-    # built-ins in their conventional order (galactic stays length, time, mass,
-    # angle) while making construction order-independent.
+    # previously-created dynamic one) by that set and build it in that class's
+    # own field order. This keeps the built-ins in their conventional order
+    # (galactic stays length, time, mass, angle) while making construction
+    # order-independent.
     #
-    # Read the index through the ``base`` module (not a ``from base import``
-    # binding) so that registration -- which mutates ``base._UNITSYSTEMS_BY_DIMSET``
-    # -- and this lookup always agree on the same object, including when a test
-    # swaps the module attribute for an isolated one.
+    # Call through the ``base`` module (not a ``from base import`` binding) so
+    # that registration and this lookup always agree on the same registry,
+    # including when a test swaps the module attribute for an isolated one.
     unit_by_dim = dict(zip(dims, args, strict=True))
-    reg_cls = base._UNITSYSTEMS_BY_DIMSET.get(frozenset(dims))  # noqa: SLF001
+    reg_cls = base.registered_unitsystem(dims)
     if reg_cls is not None:
         return reg_cls(*(unit_by_dim[d] for d in reg_cls._base_dimensions))  # noqa: SLF001
 

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -40,9 +40,6 @@ def clean_unitsystems_registry(monkeypatch):
     monkeypatch.setattr(
         "unxt._src.unitsystems.base._UNITSYSTEMS_REGISTRY", clean_registry
     )
-    # The by-dimension-set index is populated alongside the registry, so isolate
-    # it too or classes defined in this test would leak into the real index.
-    monkeypatch.setattr("unxt._src.unitsystems.base._UNITSYSTEMS_BY_DIMSET", {})
     return clean_registry
 
 
@@ -308,11 +305,10 @@ def test_unitsystem_already_registered():
             absement: Annotated[apyu.Unit, dimension("absement")]
             time: Annotated[apyu.Unit, dimension("time")]
 
-    # Clean up custom unit system from the registry and its by-set index.
-    # Access through ``us_base`` (not import-time bindings) so this stays
-    # consistent with the fixture-aware access used elsewhere.
+    # Clean up custom unit system from the registry. Access through ``us_base``
+    # (not import-time bindings) so this stays consistent with the
+    # fixture-aware access used elsewhere.
     del us_base._UNITSYSTEMS_REGISTRY[MyUnitSystem._base_dimensions]
-    del us_base._UNITSYSTEMS_BY_DIMSET[frozenset(MyUnitSystem._base_dimensions)]
 
 
 @pytest.mark.usefixtures("clean_unitsystems_registry")
@@ -336,25 +332,25 @@ def test_unitsystem_same_dimension_set_different_order_rejected():
             time: Annotated[apyu.Unit, dimension("time")]
             length: Annotated[apyu.Unit, dimension("length")]
 
-    # The rejected class left no partial entry in either registry; the by-set
-    # index still points at the first (only) class for that set. Reference the
-    # live dicts via the module so the fixture's monkeypatched copies are seen
-    # (a top-level ``from ... import`` name would be bound to the original dict).
-    dim_set = frozenset(LengthTime._base_dimensions)
+    # The rejected class left no partial entry; the dimension set still resolves
+    # to the first (only) class registered for it. Reference the live registry
+    # via the module so the fixture's monkeypatched copy is seen (a top-level
+    # ``from ... import`` name would be bound to the original dict).
     assert (dimension("time"), dimension("length")) not in us_base._UNITSYSTEMS_REGISTRY
     assert LengthTime._base_dimensions in us_base._UNITSYSTEMS_REGISTRY
-    assert us_base._UNITSYSTEMS_BY_DIMSET[dim_set] is LengthTime
+    assert us_base.registered_unitsystem(LengthTime._base_dimensions) is LengthTime
 
 
 @pytest.mark.usefixtures("clean_unitsystems_registry")
-def test_construction_consults_isolated_by_dimset_index():
-    """``unitsystem(...)`` reads the fixture-isolated by-set index, not the real one.
+def test_construction_consults_isolated_registry():
+    """``unitsystem(...)`` reads the fixture-isolated registry, not the real one.
 
-    Regression: ``core`` bound ``_UNITSYSTEMS_BY_DIMSET`` at import, so a fixture
-    that rebound only the ``base`` module's name left construction consulting the
-    original index while registration wrote to the isolated one. Register a class
-    under the fixture, then build its dimension set: ``unitsystem`` can only
-    return *that* class if lookup and registration share the isolated dict.
+    Regression: ``core`` bound the by-dimension-set lookup at import, so a
+    fixture that rebound only the ``base`` module's name left construction
+    consulting the original registry while registration wrote to the isolated
+    one. Register a class under the fixture, then build its dimension set:
+    ``unitsystem`` can only return *that* class if lookup and registration share
+    the isolated dict.
     """
 
     @dataclass(frozen=True, slots=True)
@@ -375,8 +371,8 @@ def test_distinct_slotted_class_cannot_overwrite_registration():
     Regression: the duplicate-registration guard once exempted *any* class with
     ``__slots__`` in its ``__dict__`` -- a stand-in for "the dataclass slots
     rebuild" -- so an unrelated class that merely declared ``__slots__`` in its
-    body silently overwrote the incumbent (and its by-set index entry). The
-    guard now admits only the genuine rebuild (shared annotation identity).
+    body silently overwrote the incumbent. The guard now admits only the
+    genuine rebuild (shared annotation identity).
     """
 
     class LengthTime(AbstractUnitSystem):
@@ -390,10 +386,10 @@ def test_distinct_slotted_class_cannot_overwrite_registration():
             length: Annotated[apyu.Unit, dimension("length")]
             time: Annotated[apyu.Unit, dimension("time")]
 
-    # The incumbent is untouched; the impostor left no entry in either registry.
+    # The incumbent is untouched; the impostor left no entry in the registry.
     dims = LengthTime._base_dimensions
     assert us_base._UNITSYSTEMS_REGISTRY[dims] is LengthTime
-    assert us_base._UNITSYSTEMS_BY_DIMSET[frozenset(dims)] is LengthTime
+    assert us_base.registered_unitsystem(dims) is LengthTime
 
 
 def test_parse_dimlike_name_is_deterministic_for_multialias_dimensions():


### PR DESCRIPTION
Part of a ponytail-audit cleanup sweep. One of 7 independent PRs; no ordering dependency on the others.

Two related simplifications in `AbstractUnitSystem`.

## 1. `_classproperty` → plain `ClassVar` attributes

`_classproperty` was a bespoke descriptor whose entire reason to exist was serving `_base_dimensions` / `_base_field_names` on the *class* (a plain `property` cannot). But both are fixed at class creation and derive from `_dimension_to_field`, which `__init_subclass__` already builds — so just assign them there:

```python
cls._dimension_to_field = MappingProxyType(dict(zip(dims, field_names, strict=True)))
cls._base_dimensions = dims
cls._base_field_names = field_names
```

The descriptor class goes, both property definitions go, and each access becomes an attribute load instead of a call that rebuilds a tuple every time. `base_units` measures at **0.49 µs**.

## 2. Drop the parallel `_UNITSYSTEMS_BY_DIMSET` index

It held the same entries as `_UNITSYSTEMS_REGISTRY`, keyed by `frozenset` instead of tuple, so the by-set lookup could be O(1). Two structures mutated in lockstep is precisely what forced the *"validate against **both** registries before mutating **either**, so a rejected registration leaves no partial entry behind"* dance — the invariant only needed defending because the data was duplicated.

Replaced by `registered_unitsystem(dims)`, which scans the one registry.

I checked the premise before cutting rather than assuming, since this trades O(1) for O(n):

- **7** registered classes (bounded by *distinct dimension sets*, not by calls — dynamic systems reuse a registered class)
- index lookup: **0.32 µs** of a **329 µs** `unitsystem(...)` call → **0.1%**
- after: **334 µs** — within noise

So the index was not buying measurable speed, and one registry cannot fall out of sync with itself.

## Tests

Several tests asserted on the removed index. They pin real invariants, so they now express the same ones through `registered_unitsystem()` rather than being deleted:

- the fixture no longer needs to isolate a second dict
- `test_construction_consults_isolated_by_dimset_index` → `test_construction_consults_isolated_registry` (still a genuine regression test: `core` calls `base.registered_unitsystem`, resolving the module global at call time, so a monkeypatched registry is honoured)
- the "rejected class left no partial entry" and "impostor cannot clobber" assertions are unchanged in meaning

## Verification

- `pytest tests/unit src` — 2413 passed (includes sybil doctests over `src`)
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)