### PR TITLE
♻️ refactor(config): share the display traits, derive the option sets, cheapen the override hook

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -28,15 +28,8 @@ from unxt._src.config import (
     LocalConfigurable,
     _find_pyproject,
     _load_toml_config_from_pyproject,
+    _override_keys,
 )
-
-PARAMETRIC_REPR_CONFIG_KEYS: Final = frozenset({"include_params"})
-PARAMETRIC_STR_CONFIG_KEYS: Final = frozenset({"include_params"})
-
-PARAMETRIC_OVERRIDE_CONFIG_KEYS: Final = {
-    "quantity_repr": PARAMETRIC_REPR_CONFIG_KEYS,
-    "quantity_str": PARAMETRIC_STR_CONFIG_KEYS,
-}
 
 
 class ParametricQuantityReprConfig(LocalConfigurable):
@@ -45,10 +38,8 @@ class ParametricQuantityReprConfig(LocalConfigurable):
     ``__getattribute__`` (thread-local override lookup) and ``override()`` (the
     context manager) are inherited from
     :class:`~unxt._src.config.LocalConfigurable`; this class only declares its
-    overridable trait and its ``_config_keys`` allowlist.
+    overridable trait.
     """
-
-    _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_REPR_CONFIG_KEYS
 
     include_params: ClassVar[object] = Bool(
         default_value=False,
@@ -62,8 +53,6 @@ class ParametricQuantityStrConfig(LocalConfigurable):
     See :class:`ParametricQuantityReprConfig` — the override machinery is
     inherited from :class:`~unxt._src.config.LocalConfigurable`.
     """
-
-    _config_keys: ClassVar[frozenset[str]] = PARAMETRIC_STR_CONFIG_KEYS
 
     include_params: ClassVar[object] = Bool(
         default_value=True,
@@ -100,9 +89,7 @@ class ParametricConfig(AbstractUnxtConfig, SingletonConfigurable):
         ParametricQuantityReprConfig,
         ParametricQuantityStrConfig,
     ]
-    _override_config_keys: ClassVar[dict[str, frozenset[str]]] = (
-        PARAMETRIC_OVERRIDE_CONFIG_KEYS
-    )
+    _override_sections: ClassVar[tuple[str, ...]] = ("quantity_repr", "quantity_str")
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize ParametricConfig with nested config instances."""
@@ -122,20 +109,15 @@ _TOML_PATH_TO_CONFIG_CLASS: Final = {
     ("quantity", "str"): "ParametricQuantityStrConfig",
 }
 
-# Mapping from Config class name to (config instance, valid keys)
-_CONFIG_CLASS_TO_INSTANCE: Final[dict[str, tuple[Any, frozenset[str]]]] = {}
+# Mapping from Config class name to config instance
+_CONFIG_CLASS_TO_INSTANCE: Final[dict[str, Any]] = {}
 
 
 def _initialize_config_mapping(cfg: ParametricConfig) -> None:
     """Populate the class-name -> instance mapping (call after singleton init)."""
-    _CONFIG_CLASS_TO_INSTANCE["ParametricQuantityReprConfig"] = (
-        cfg.quantity_repr,
-        PARAMETRIC_REPR_CONFIG_KEYS,
-    )
-    _CONFIG_CLASS_TO_INSTANCE["ParametricQuantityStrConfig"] = (
-        cfg.quantity_str,
-        PARAMETRIC_STR_CONFIG_KEYS,
-    )
+    for name in cfg._override_sections:  # noqa: SLF001
+        instance = getattr(cfg, name)
+        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = instance
 
 
 def _auto_load_project_toml_config(cfg: ParametricConfig, /) -> None:
@@ -159,7 +141,8 @@ def _auto_load_project_toml_config(cfg: ParametricConfig, /) -> None:
     for class_name, class_config in loaded.items():
         if class_name not in _CONFIG_CLASS_TO_INSTANCE:
             continue
-        config_instance, valid_keys = _CONFIG_CLASS_TO_INSTANCE[class_name]
+        config_instance = _CONFIG_CLASS_TO_INSTANCE[class_name]
+        valid_keys = _override_keys(type(config_instance))
         for key, value in class_config.items():
             if key not in valid_keys:
                 continue

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -66,14 +66,11 @@ class LocalConfigurable(Configurable):
         with no override active that is a single dict lookup.
         """
         obj_getattr = object.__getattribute__
-        try:
-            # ``vars()`` on the thread-local, not ``getattr``, to avoid paying
-            # for a second descriptor lookup on the empty-stack fast path.
-            stack = vars(obj_getattr(self, "_local")).get("stack")
-        except AttributeError:
-            # ``_local`` is not set until ``__init__`` runs; traitlets touches
-            # attributes before that, so fall through to normal lookup.
-            return obj_getattr(self, name)
+        # ``_local`` is only set once ``__init__`` runs, and traitlets touches
+        # attributes ~40 times before that; read it out of the instance dict so
+        # those are a dict miss rather than a raised-and-caught AttributeError.
+        local = obj_getattr(self, "__dict__").get("_local")
+        stack = vars(local).get("stack") if local is not None else None
 
         if stack and name in _override_keys(type(self)):
             # Return the most recent override for this attribute

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -5,6 +5,7 @@ time.
 """
 
 __all__ = (
+    "AbstractQuantityDisplayConfig",
     "AbstractUnxtConfig",
     "QuantityReprConfig",
     "QuantityStrConfig",
@@ -13,6 +14,7 @@ __all__ = (
 )
 
 import contextlib
+import functools as ft
 import threading
 import tomllib
 import warnings
@@ -21,9 +23,21 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, ClassVar, Final
 
-from traitlets import Bool, Enum, TraitError, Union
+from traitlets import Bool, Enum, TraitError, Union, default
 from traitlets.config import Config, Configurable, SingletonConfigurable
 from traitlets.traitlets import Int
+
+
+@ft.cache
+def _override_keys(cls: type, /) -> frozenset[str]:
+    """Trait names on ``cls`` eligible for thread-local override.
+
+    Derived from the traits themselves rather than hand-listed, so the two
+    cannot drift apart when a trait is added or renamed. Cached per class:
+    ``class_traits`` walks the MRO, and this is consulted on every attribute
+    read that happens while an override is active.
+    """
+    return frozenset(cls.class_traits(config=True))  # type: ignore[attr-defined]
 
 
 class LocalConfigurable(Configurable):
@@ -31,15 +45,12 @@ class LocalConfigurable(Configurable):
 
     This class provides a mechanism for temporary, thread-local configuration
     changes that can be used in nested contexts (e.g., within a quantity's
-    ``__repr__()``). Concrete subclasses only declare their traits and set
-    ``_config_keys`` (the trait names eligible for override); the override
-    lookup and the ``override()`` context manager live here.
+    ``__repr__()``). Concrete subclasses only declare their traits; the
+    override lookup and the ``override()`` context manager live here.
     """
 
     # Thread-local storage for context manager overrides
     _local: threading.local
-    # Names of the config traits eligible for thread-local override
-    _config_keys: ClassVar[frozenset[str]] = frozenset()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -50,17 +61,32 @@ class LocalConfigurable(Configurable):
         object.__setattr__(self, "_local", threading.local())
 
     def __getattribute__(self, name: str) -> Any:
-        """Get attribute, checking thread-local overrides first."""
-        if name in object.__getattribute__(self, "_config_keys"):
-            with contextlib.suppress(AttributeError):
-                local = object.__getattribute__(self, "_local")
-                # Return the most recent override for this attribute
-                if hasattr(local, "stack") and local.stack:
-                    for overrides in reversed(local.stack):
-                        if name in overrides:
-                            return overrides[name]
+        """Get attribute, checking thread-local overrides first.
 
-        return object.__getattribute__(self, name)
+        This intercepts *every* attribute access on a config object, so the
+        no-override case -- which is every access outside a ``with
+        override(...)`` block -- must stay close to a plain attribute load.
+        Reading the thread-local stack first makes that path a single dict
+        lookup; only once an override is actually active do we pay for the
+        (cached) trait-name set and the stack walk.
+        """
+        obj_getattr = object.__getattribute__
+        try:
+            # ``vars()`` on the thread-local, not ``getattr``, to avoid paying
+            # for a second descriptor lookup on the empty-stack fast path.
+            stack = vars(obj_getattr(self, "_local")).get("stack")
+        except AttributeError:
+            # ``_local`` is not set until ``__init__`` runs; traitlets touches
+            # attributes before that, so fall through to normal lookup.
+            return obj_getattr(self, name)
+
+        if stack and name in _override_keys(type(self)):
+            # Return the most recent override for this attribute
+            for overrides in reversed(stack):
+                if name in overrides:
+                    return overrides[name]
+
+        return obj_getattr(self, name)
 
     def override(
         self, cfg: Config | None = None, /, **kwargs: Any
@@ -115,7 +141,7 @@ class LocalConfigurable(Configurable):
         Quantity([1, 2, 3], unit='m')
 
         """
-        keys = self._config_keys
+        keys = _override_keys(type(self))
         cls_name = type(self).__name__
 
         if cfg is not None and kwargs:
@@ -210,14 +236,53 @@ class _NestedConfigContext:
 
 
 # ============================================================================
-# Quantity `__repr__`
+# Quantity display
 
-QUANTITY_REPR_CONFIG_KEYS: Final = frozenset(
-    {"short_arrays", "use_short_name", "named_unit", "indent"}
-)
+#: The display traits, named once. ``QuantityReprConfig`` / ``QuantityStrConfig``
+#: are the same four options differing only in the ``short_arrays`` default, so
+#: they share this base and each states just its own default and docstring.
+#: The valid-option sets are derived from these traits (see ``_override_keys``),
+#: not hand-listed alongside them.
 
 
-class QuantityReprConfig(LocalConfigurable):
+class AbstractQuantityDisplayConfig(LocalConfigurable):
+    """Display options shared by the quantity ``repr()`` / ``str()`` configs.
+
+    Concrete subclasses set the ``short_arrays`` default -- ``False`` for
+    ``repr()`` (faithful, round-trippable) and ``"compact"`` for ``str()``
+    (readable) -- and are distinct classes so a `traitlets.config.Config` can
+    address them separately by name.
+    """
+
+    short_arrays: ClassVar[object] = Union(
+        [Bool(), Enum(("compact",))],
+        default_value=False,
+        help=(
+            "Controls array display. "
+            "Options: 'compact' (values only), "
+            "True (shape/dtype), False (full repr)"
+        ),
+    ).tag(config=True)
+
+    use_short_name: ClassVar[object] = Bool(
+        default_value=False,
+        help=(
+            "Use a class's short name if available (e.g. Quantity -> Q, "
+            "ParametricQuantity -> PQ)"
+        ),
+    ).tag(config=True)
+
+    named_unit: ClassVar[object] = Bool(
+        default_value=True,
+        help="Display unit as named argument (unit='m') vs positional ('m')",
+    ).tag(config=True)
+
+    indent: ClassVar[object] = Int(
+        default_value=4, help="Indentation level for nested structures"
+    ).tag(config=True)
+
+
+class QuantityReprConfig(AbstractQuantityDisplayConfig):
     """Configuration for quantity ``__repr__()`` display options.
 
     This controls how quantity objects are displayed in ``repr()``. It is
@@ -240,6 +305,8 @@ class QuantityReprConfig(LocalConfigurable):
         If `True`, display unit as a named argument `unit='m'`.
         If `False`, display unit as a positional argument `'m'`.
         Default: `True`
+    indent : int
+        Indentation width for nested structures in repr. Default: 4
 
     Examples
     --------
@@ -253,50 +320,8 @@ class QuantityReprConfig(LocalConfigurable):
 
     """
 
-    _config_keys: ClassVar[frozenset[str]] = QUANTITY_REPR_CONFIG_KEYS
 
-    short_arrays: ClassVar[object] = Union(
-        [Bool(), Enum(("compact",))],
-        default_value=False,
-        help=(
-            "Controls array display in repr. "
-            "Options: 'compact' (values only), "
-            "True (shape/dtype), False (full repr)"
-        ),
-    ).tag(config=True)
-
-    use_short_name: ClassVar[object] = Bool(
-        default_value=False,
-        help=(
-            "Use a class's short name if available (e.g. Quantity -> Q, "
-            "ParametricQuantity -> PQ)"
-        ),
-    ).tag(config=True)
-
-    named_unit: ClassVar[object] = Bool(
-        default_value=True,
-        help="Display unit as named argument (unit='m') vs positional ('m')",
-    ).tag(config=True)
-
-    indent: ClassVar[object] = Int(
-        default_value=4, help="Indentation level for nested structures in repr"
-    ).tag(config=True)
-
-
-# ============================================================================
-# Quantity `__str__`
-
-QUANTITY_STR_CONFIG_KEYS: Final = frozenset(
-    {"short_arrays", "use_short_name", "named_unit", "indent"}
-)
-
-UNXT_OVERRIDE_CONFIG_KEYS: Final = {
-    "quantity_repr": QUANTITY_REPR_CONFIG_KEYS,
-    "quantity_str": QUANTITY_STR_CONFIG_KEYS,
-}
-
-
-class QuantityStrConfig(LocalConfigurable):
+class QuantityStrConfig(AbstractQuantityDisplayConfig):
     """Configuration for quantity ``__str__()`` display options.
 
     This controls how quantity objects are displayed in ``str()``. It is
@@ -336,34 +361,10 @@ class QuantityStrConfig(LocalConfigurable):
 
     """
 
-    _config_keys: ClassVar[frozenset[str]] = QUANTITY_STR_CONFIG_KEYS
-
-    short_arrays: ClassVar[object] = Union(
-        [Bool(), Enum(("compact",))],
-        default_value="compact",
-        help=(
-            "Controls array display in str. "
-            "Options: 'compact' (values only), "
-            "True (shape/dtype), False (full str)"
-        ),
-    ).tag(config=True)
-
-    use_short_name: ClassVar[object] = Bool(
-        default_value=False,
-        help=(
-            "Use a class's short name if available (e.g. Quantity -> Q, "
-            "ParametricQuantity -> PQ)"
-        ),
-    ).tag(config=True)
-
-    named_unit: ClassVar[object] = Bool(
-        default_value=True,
-        help="Display unit as named argument (unit='m') vs positional ('m')",
-    ).tag(config=True)
-
-    indent: ClassVar[object] = Int(
-        default_value=4, help="Indentation level for nested structures in str"
-    ).tag(config=True)
+    @default("short_arrays")
+    def _short_arrays_default(self) -> str:
+        """``str()`` favours readability, so arrays print as bare values."""
+        return "compact"
 
 
 # ============================================================================
@@ -502,9 +503,10 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
 
     # Configurable classes that are part of this config hierarchy
     classes: ClassVar[list[type]] = [QuantityReprConfig, QuantityStrConfig]
-    _override_config_keys: ClassVar[dict[str, frozenset[str]]] = (
-        UNXT_OVERRIDE_CONFIG_KEYS
-    )
+    _override_config_keys: ClassVar[dict[str, frozenset[str]]] = {
+        "quantity_repr": _override_keys(QuantityReprConfig),
+        "quantity_str": _override_keys(QuantityStrConfig),
+    }
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize UnxtConfig with nested config instances."""
@@ -745,14 +747,12 @@ def _initialize_config_mapping(cfg: UnxtConfig) -> None:
 
     This must be called after creating the UnxtConfig instance.
     """
-    _CONFIG_CLASS_TO_INSTANCE["QuantityReprConfig"] = (
-        cfg.quantity_repr,
-        QUANTITY_REPR_CONFIG_KEYS,
-    )
-    _CONFIG_CLASS_TO_INSTANCE["QuantityStrConfig"] = (
-        cfg.quantity_str,
-        QUANTITY_STR_CONFIG_KEYS,
-    )
+    for name in ("quantity_repr", "quantity_str"):
+        instance = getattr(cfg, name)
+        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = (
+            instance,
+            _override_keys(type(instance)),
+        )
 
 
 def _warn_if_legacy_unxt_config(

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -5,7 +5,6 @@ time.
 """
 
 __all__ = (
-    "AbstractQuantityDisplayConfig",
     "AbstractUnxtConfig",
     "QuantityReprConfig",
     "QuantityStrConfig",
@@ -63,12 +62,8 @@ class LocalConfigurable(Configurable):
     def __getattribute__(self, name: str) -> Any:
         """Get attribute, checking thread-local overrides first.
 
-        This intercepts *every* attribute access on a config object, so the
-        no-override case -- which is every access outside a ``with
-        override(...)`` block -- must stay close to a plain attribute load.
-        Reading the thread-local stack first makes that path a single dict
-        lookup; only once an override is actually active do we pay for the
-        (cached) trait-name set and the stack walk.
+        This runs on *every* attribute access, so the stack is read first:
+        with no override active that is a single dict lookup.
         """
         obj_getattr = object.__getattribute__
         try:
@@ -238,12 +233,6 @@ class _NestedConfigContext:
 # ============================================================================
 # Quantity display
 
-#: The display traits, named once. ``QuantityReprConfig`` / ``QuantityStrConfig``
-#: are the same four options differing only in the ``short_arrays`` default, so
-#: they share this base and each states just its own default and docstring.
-#: The valid-option sets are derived from these traits (see ``_override_keys``),
-#: not hand-listed alongside them.
-
 
 class AbstractQuantityDisplayConfig(LocalConfigurable):
     """Display options shared by the quantity ``repr()`` / ``str()`` configs.
@@ -376,8 +365,8 @@ class AbstractUnxtConfig:
 
     A concrete config inherits this alongside
     :class:`~traitlets.config.SingletonConfigurable`, declares the sections it
-    accepts via ``_override_config_keys`` (``{section name: valid option
-    names}``), and creates its nested config objects in ``__init__``. This mixin
+    accepts via ``_override_sections``, and creates its nested config objects
+    in ``__init__``. This mixin
     provides the shared top-level ``override()`` context manager, so packages
     that mirror this config (e.g. ``unxts.parametric``) can reuse the same
     machinery -- their singletons are accepted by :class:`_ConfigContext`
@@ -387,8 +376,9 @@ class AbstractUnxtConfig:
     concrete config keeps its own independent singleton instance.
     """
 
-    # {section_name: frozenset of valid option names}; set by subclasses.
-    _override_config_keys: ClassVar[dict[str, frozenset[str]]] = {}
+    # Names of the nested config sections; set by subclasses. The valid option
+    # names come from each section's own traits (see ``_override_keys``).
+    _override_sections: ClassVar[tuple[str, ...]] = ()
 
     def override(self, **kwargs: Any) -> "_ConfigContext":
         """Create a context manager for temporary config changes.
@@ -407,8 +397,8 @@ class AbstractUnxtConfig:
         for key, value in kwargs.items():
             if "__" in key:
                 config_name, attr_name = key.split("__", 1)
-                if config_name not in self._override_config_keys:
-                    valid_configs = ", ".join(sorted(self._override_config_keys))
+                if config_name not in self._override_sections:
+                    valid_configs = ", ".join(sorted(self._override_sections))
                     msg = (
                         "Unknown config section "
                         f"'{config_name}' in override key '{key}'. "
@@ -416,7 +406,7 @@ class AbstractUnxtConfig:
                     )
                     raise ValueError(msg)
 
-                valid_attrs = self._override_config_keys[config_name]
+                valid_attrs = _override_keys(type(getattr(self, config_name)))
                 if attr_name not in valid_attrs:
                     valid_options = ", ".join(sorted(valid_attrs))
                     msg = (
@@ -444,7 +434,7 @@ class AbstractUnxtConfig:
         ``traitlets``'s own ``update_config`` only touches *this* object's
         traits, but the display settings actually live on the eagerly-built
         nested configs. Forward the config to every nested section this config
-        declares in ``_override_config_keys`` (e.g. ``quantity_repr`` /
+        declares in ``_override_sections`` (e.g. ``quantity_repr`` /
         ``quantity_str`` for ``UnxtConfig``) so ``config.update_config(cfg)``
         with e.g. ``cfg.QuantityReprConfig.short_arrays = "compact"`` takes
         effect instead of silently doing nothing.
@@ -452,7 +442,7 @@ class AbstractUnxtConfig:
         # ``super()`` resolves through the concrete class's MRO to
         # ``Configurable.update_config`` (this mixin is combined with it).
         super().update_config(cfg)  # type: ignore[misc]  # pylint: disable=no-member
-        for name in self._override_config_keys:
+        for name in self._override_sections:
             getattr(self, name).update_config(cfg)
 
 
@@ -503,10 +493,7 @@ class UnxtConfig(AbstractUnxtConfig, SingletonConfigurable):
 
     # Configurable classes that are part of this config hierarchy
     classes: ClassVar[list[type]] = [QuantityReprConfig, QuantityStrConfig]
-    _override_config_keys: ClassVar[dict[str, frozenset[str]]] = {
-        "quantity_repr": _override_keys(QuantityReprConfig),
-        "quantity_str": _override_keys(QuantityStrConfig),
-    }
+    _override_sections: ClassVar[tuple[str, ...]] = ("quantity_repr", "quantity_str")
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize UnxtConfig with nested config instances."""
@@ -738,8 +725,8 @@ def _config_from_toml_data(
     return config
 
 
-# Mapping from Config class name to (config object, valid keys)
-_CONFIG_CLASS_TO_INSTANCE: Final[dict[str, tuple[Any, frozenset[str]]]] = {}
+# Mapping from Config class name to config object
+_CONFIG_CLASS_TO_INSTANCE: Final[dict[str, Any]] = {}
 
 
 def _initialize_config_mapping(cfg: UnxtConfig) -> None:
@@ -747,12 +734,9 @@ def _initialize_config_mapping(cfg: UnxtConfig) -> None:
 
     This must be called after creating the UnxtConfig instance.
     """
-    for name in ("quantity_repr", "quantity_str"):
+    for name in cfg._override_sections:  # noqa: SLF001
         instance = getattr(cfg, name)
-        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = (
-            instance,
-            _override_keys(type(instance)),
-        )
+        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = instance
 
 
 def _warn_if_legacy_unxt_config(
@@ -818,7 +802,8 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -
         if class_name not in _CONFIG_CLASS_TO_INSTANCE:
             continue
 
-        config_instance, valid_keys = _CONFIG_CLASS_TO_INSTANCE[class_name]
+        config_instance = _CONFIG_CLASS_TO_INSTANCE[class_name]
+        valid_keys = _override_keys(type(config_instance))
 
         for key, value in class_config.items():
             if key not in valid_keys:

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -260,7 +260,7 @@ class AbstractQuantityDisplayConfig(LocalConfigurable):
         help=(
             "Controls array display. "
             "Options: 'compact' (values only), "
-            "True (shape/dtype), False (full repr)"
+            "True (shape/dtype), False (full array representation)"
         ),
     ).tag(config=True)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1151,7 +1151,7 @@ def test_update_config_forwards_to_nested_sections() -> None:
     `__init__`; a later `update_config` on the parent never reached them.
     """
     # Assert forwarding into *every* nested section, not just quantity_repr, so
-    # a partial-forwarding regression (e.g. `_override_config_keys` omitting a
+    # a partial-forwarding regression (e.g. `_override_sections` omitting a
     # section) is caught.
     repr_baseline = u.config.quantity_repr.short_arrays
     str_baseline = u.config.quantity_str.short_arrays


### PR DESCRIPTION
Part of a ponytail-audit cleanup sweep. One of 7 independent PRs; no ordering dependency on the others.

Three related cleanups in `_src/config.py`.

## 1. Share the display traits

`QuantityReprConfig` and `QuantityStrConfig` declared the **same four traits** with the same help text, differing only in the `short_arrays` default (`False` vs `"compact"`). They now share `AbstractQuantityDisplayConfig`, and each states only its own default plus its own docstring:

```python
class QuantityStrConfig(AbstractQuantityDisplayConfig):
    @default("short_arrays")
    def _short_arrays_default(self) -> str:
        """``str()`` favours readability, so arrays print as bare values."""
        return "compact"
```

They remain **distinct classes with distinct names** — a `traitlets.config.Config` addresses them by name (`cfg.QuantityReprConfig.short_arrays`), and `_TOML_PATH_TO_CONFIG_CLASS` maps `("quantity", "repr")` → `"QuantityReprConfig"`.

## 2. Derive the option sets instead of hand-listing them

`QUANTITY_REPR_CONFIG_KEYS` / `QUANTITY_STR_CONFIG_KEYS` restated the trait names that traitlets already tracks — two frozensets that could silently drift from the traits they describe. Replaced by:

```python
@ft.cache
def _override_keys(cls: type, /) -> frozenset[str]:
    return frozenset(cls.class_traits(config=True))
```

Verified identical to the hand-written sets. Cached per class, since `class_traits` walks the MRO.

## 3. Cheapen the override hook — **without** removing it

`LocalConfigurable.__getattribute__` intercepts *every* attribute read on a config object. It ran the trait-name membership test **and** entered a `contextlib.suppress` block before checking whether any override was even active — which, outside a `with override(...)` block, it never is.

Reordered so the thread-local stack is read first, making the common path a single dict lookup.

> [!IMPORTANT]
> The hook itself **stays**. My first pass through this file had it down as removable, on the reasoning that the override stack is empty outside a `with` block. That was wrong: the hook is exactly what makes `override()` **thread-local**, and `test_config_context_manager_thread_local` asserts that two concurrent threads observe *different* override values. Only the ordering changed; the semantics are untouched.

## Measurements

Min of 5x200k reps, vs. the branch point (`0f1df47`):

| µs/op | before | after | |
|---|---|---|---|
| config trait read (`config.quantity_repr.short_arrays`) | 1.083 | **0.574** | 1.9x |
| same, inside an active `override()` | 0.632 | **0.326** | 1.9x |
| non-trait read (`config.parent`) | 0.417 | **0.576** | 0.16 µs slower |
| `QuantityReprConfig()` | 21.7 | **23.0** | 1.3 µs slower |
| `override()` enter+exit | 33.0 | **35.6** | 2.6 µs slower |
| `repr()` of a scalar quantity | 153 | **153** | within noise (±3%) |

The non-trait read is a real if small regression: the fast path touches the
thread-local before the name test, so attributes that are *not* traits pay
slightly more. Net is still a win because trait reads are what the display path
actually does.

Construction (and therefore `override()`, which builds one throwaway instance to
validate values) costs ~1.3 µs more from the extra class in the MRO. An earlier
revision of this branch made that *15 µs* worse: reading `_local` first meant the
~40 attribute touches traitlets makes before `__init__` each raised and caught an
`AttributeError`. `bda0021` reads `_local` from the instance dict instead, so
that case is a dict miss. `override()` has no internal callers — it is entered
once per user `with` block.

For reference, a plain traitlets attribute read is 0.135 µs — the residual gap is
the cost of having a Python-level `__getattribute__` at all, which the
thread-locality guarantee requires.

## Verification

- `pytest tests/unit src docs` — 3335 passed (unit tests, sybil doctests over `src`, and the `docs/guides/configuration.md` guide)
- thread-locality re-checked directly: two threads overriding concurrently observe `{'t1': 'compact', 't2': True}` and the global value is restored to `False` afterwards
- defaults confirmed unchanged: `repr` → `False`, `str` → `"compact"`
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
