### PR TITLE
⚡️ perf(linalg): restore `u.unit` dispatch caching and use the `_wrap` fast path

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -199,8 +199,7 @@ def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
     # The reciprocal-unit result is only correct when the units are uniform;
     # a matrix inverse mixes entries, so heterogeneous units are not simply
     # reciprocated element-by-element.
-    flat = x.unit._units.ravel()
-    if any(unit_i != flat[0] for unit_i in flat[1:]):
+    if not x.unit.is_uniform:
         msg = (
             "inv on a QuantityMatrix requires uniform units (all entries equal); "
             "the inverse of a heterogeneous-unit matrix is not an element-wise "

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -6,7 +6,6 @@ import equinox as eqx
 import jax
 import jax.core
 import jax.numpy as jnp
-import jax.tree_util as jtu
 import plum
 import quax
 from jaxtyping import Array, Shaped
@@ -490,20 +489,19 @@ def QuantityMatrix_to_quantity(x: QuantityMatrix, /) -> u.Q:
     identical.
 
     """
-    units = jtu.tree_leaves(x.unit.to_tuple())
+    units = x.unit._units.ravel()
 
-    if not units:
+    if units.size == 0:
         msg = "Cannot convert QuantityMatrix with no unit entries."
         raise ValueError(msg)
 
-    first = units[0]
-    if any(unit != first for unit in units[1:]):
+    if not x.unit.is_uniform:
         msg = (
             "Cannot convert QuantityMatrix to Quantity unless all units are identical."
         )
         raise ValueError(msg)
 
-    return u.Q(x.value, first)
+    return u.Q(x.value, units[0])
 
 
 def _convert_value(

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -338,6 +338,7 @@ class UnitsMatrix:
 
         An empty structure gives an empty result:
 
+        >>> import numpy as np
         >>> UnitsMatrix(np.empty(0, dtype=object)) ** 2
         UnitsMatrix("()")
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -254,6 +254,28 @@ class UnitsMatrix:
         return int(self._units.ndim)
 
     @property
+    def is_uniform(self) -> bool:
+        """Whether every entry carries the same unit.
+
+        Several callers need this: ``inv`` rejects a heterogeneous matrix (the
+        inverse mixes entries, so a per-element reciprocal would be wrong), and
+        conversion to a plain `~unxt.Quantity` is only unambiguous when the
+        units agree. An empty structure is vacuously uniform.
+
+        Examples
+        --------
+        >>> from unxts.linalg import UnitsMatrix
+
+        >>> UnitsMatrix((("m", "m"), ("m", "m"))).is_uniform
+        True
+        >>> UnitsMatrix(("m", "s")).is_uniform
+        False
+
+        """
+        flat = self._units.ravel()
+        return flat.size == 0 or all(x == flat[0] for x in flat[1:])
+
+    @property
     def T(self) -> "UnitsMatrix":
         """Compute the all-axis units array transpose.
 
@@ -274,7 +296,7 @@ class UnitsMatrix:
         UnitsMatrix("((m, Hz), (s, cd), (kg, km))")
 
         """
-        return UnitsMatrix(self._units.T)
+        return UnitsMatrix._wrap(self._units.T)
 
     def diagonal(self) -> "UnitsMatrix":
         """Return the main diagonal of a 2-D `UnitsMatrix` as a 1-D `UnitsMatrix`.
@@ -295,10 +317,11 @@ class UnitsMatrix:
     def __pow__(self, exponent: int | float, /) -> "UnitsMatrix":
         r"""Element-wise unit power — each unit raised to ``exponent``.
 
-        For a 1-D (diagonal) ``UnitsMatrix`` the power is applied entry-by-entry
-        in *O(n)*.  For a 2-D ``UnitsMatrix`` with a uniform unit (all entries
-        equal) it is computed once and broadcast in *O(1)*; mixed-unit 2-D
-        structures fall back to an element-wise *O(nm)* loop.
+        Each *distinct* unit's power is computed once and reused, so a uniform
+        structure costs one ``Unit.__pow__`` regardless of size, and a mixed one
+        costs a power per distinct unit rather than per entry. (``Unit.__pow__``
+        is ~18x the cost of a dict hit, so the memo pays for itself well before
+        any entry repeats.)
 
         Examples
         --------
@@ -309,7 +332,7 @@ class UnitsMatrix:
         >>> UnitsMatrix(("m2", "s2")) ** 0.5
         UnitsMatrix("(m, s)")
 
-        2-D uniform-unit case (computed once, broadcast):
+        2-D uniform-unit case (computed once, reused):
 
         >>> UnitsMatrix((("m2", "m2"), ("m2", "m2"))) ** 0.5
         UnitsMatrix("((m, m), (m, m))")
@@ -319,27 +342,22 @@ class UnitsMatrix:
         >>> UnitsMatrix((("m2", "s2"), ("s2", "rad2"))) ** 0.5
         UnitsMatrix("((m, s), (s, rad))")
 
+        An empty structure gives an empty result:
+
+        >>> UnitsMatrix(np.empty(0, dtype=object)) ** 2
+        UnitsMatrix("()")
+
         """
+        cache: dict[Any, Any] = {}
+
+        def powered(un: Any, /) -> Any:
+            if (v := cache.get(un)) is None:
+                v = cache[un] = un**exponent
+            return v
+
         out = np.empty(self._units.shape, dtype=object)
-        if self._units.size == 0:
-            # Empty matrix -> empty result; the 2-D fast path below indexes
-            # flat[0], which would raise on a zero-size array.
-            return UnitsMatrix(out)
-        if self._units.ndim == 1:
-            for i in range(self._units.shape[0]):
-                out[i] = self._units[i] ** exponent
-        else:
-            # 2-D: fast path when all entries share the same unit.
-            flat = self._units.ravel()
-            first = flat[0]
-            if all(x == first for x in flat[1:]):
-                out[:] = first**exponent
-            else:
-                n, m = self._units.shape
-                for i in range(n):
-                    for j in range(m):
-                        out[i, j] = self._units[i, j] ** exponent
-        return UnitsMatrix(out)
+        out.flat[:] = [powered(un) for un in self._units.flat]
+        return UnitsMatrix._wrap(out)
 
     def inverse(self) -> "UnitsMatrix":
         r"""Inverse unit structure — each unit raised to the power -1.
@@ -401,7 +419,7 @@ class UnitsMatrix:
             other_units[...] = other
         else:
             return NotImplemented  # ty: ignore[invalid-return-type]
-        return UnitsMatrix(op(self._units, other_units))
+        return UnitsMatrix._wrap(op(self._units, other_units))
 
     def __mul__(self, other: Any, /) -> "UnitsMatrix":
         """Element-wise unit product (against a unit or another UnitsMatrix).
@@ -511,7 +529,7 @@ class UnitsMatrix:
             yield from self._units
             return
         for row in self._units:
-            yield UnitsMatrix(row)
+            yield UnitsMatrix._wrap(row)
 
     def __getitem__(self, index: Any, /) -> Any:
         """Index into the UnitsMatrix to retrieve a unit or sub-structure.
@@ -534,12 +552,17 @@ class UnitsMatrix:
         if isinstance(result, np.ndarray):
             if result.ndim == 0:  # 0-d array -> extract the contained unit.
                 return result.item()
-            return UnitsMatrix(result)
+            return UnitsMatrix._wrap(result)
         return result
 
 
+# NB: annotate the bare ``tuple``, not ``tuple[Any, ...]``. A *parametric*
+# generic is not "faithful" in plum, and one unfaithful signature disables
+# method caching for the whole ``unit`` function -- library-wide, for every
+# unxt user who merely has this package installed. The two annotations match
+# exactly the same values; only the caching differs (measured 2.0x).
 @plum.dispatch
-def unit(tuple_of_units: tuple[Any, ...], /) -> UnitsMatrix:
+def unit(tuple_of_units: tuple, /) -> UnitsMatrix:
     """Convert a nested tuple of units into a ``UnitsMatrix``.
 
     This allows users to specify units in a convenient nested tuple format when

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -1,5 +1,6 @@
 """Immutable, hashable unit structure for QuantityMatrix."""
 
+import functools
 import operator
 from typing import Any, TypeAlias, TypeVar, final
 
@@ -255,12 +256,7 @@ class UnitsMatrix:
 
     @property
     def is_uniform(self) -> bool:
-        """Whether every entry carries the same unit.
-
-        Several callers need this: ``inv`` rejects a heterogeneous matrix (the
-        inverse mixes entries, so a per-element reciprocal would be wrong), and
-        conversion to a plain `~unxt.Quantity` is only unambiguous when the
-        units agree. An empty structure is vacuously uniform.
+        """Whether every entry carries the same unit; empty is vacuously uniform.
 
         Examples
         --------
@@ -319,9 +315,7 @@ class UnitsMatrix:
 
         Each *distinct* unit's power is computed once and reused, so a uniform
         structure costs one ``Unit.__pow__`` regardless of size, and a mixed one
-        costs a power per distinct unit rather than per entry. (``Unit.__pow__``
-        is ~18x the cost of a dict hit, so the memo pays for itself well before
-        any entry repeats.)
+        costs a power per distinct unit rather than per entry.
 
         Examples
         --------
@@ -348,12 +342,10 @@ class UnitsMatrix:
         UnitsMatrix("()")
 
         """
-        cache: dict[Any, Any] = {}
 
+        @functools.cache
         def powered(un: Any, /) -> Any:
-            if (v := cache.get(un)) is None:
-                v = cache[un] = un**exponent
-            return v
+            return un**exponent
 
         out = np.fromiter(
             map(powered, self._units.flat), dtype=object, count=self._units.size

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_units_matrix.py
@@ -355,15 +355,16 @@ class UnitsMatrix:
                 v = cache[un] = un**exponent
             return v
 
-        out = np.empty(self._units.shape, dtype=object)
-        out.flat[:] = [powered(un) for un in self._units.flat]
-        return UnitsMatrix._wrap(out)
+        out = np.fromiter(
+            map(powered, self._units.flat), dtype=object, count=self._units.size
+        )
+        return UnitsMatrix._wrap(out.reshape(self._units.shape))
 
     def inverse(self) -> "UnitsMatrix":
         r"""Inverse unit structure — each unit raised to the power -1.
 
-        Equivalent to ``self ** -1``; see ``__pow__`` for the shape-aware fast
-        paths (1-D *O(n)*, 2-D uniform-unit *O(1)*, 2-D mixed *O(nm)*).
+        Equivalent to ``self ** -1``; see ``__pow__`` — a single flat pass over
+        the entries, with each *distinct* unit's reciprocal computed once.
 
         Examples
         --------


### PR DESCRIPTION
From a ponytail-audit of `unxts.linalg`. One of 4 independent PRs; no ordering dependency.

## 1. `unit(tuple_of_units: tuple[Any, ...])` was de-optimising `u.unit` **library-wide**

A *parametric* generic is not "faithful" in plum, and **one** unfaithful signature disables method caching for the entire function. So registering this dispatch meant that merely `import unxts.linalg` roughly doubled the cost of every `u.unit(...)` call anywhere in unxt — including for users who never touch a `QuantityMatrix`.

```diff
-def unit(tuple_of_units: tuple[Any, ...], /) -> UnitsMatrix:
+def unit(tuple_of_units: tuple, /) -> UnitsMatrix:
```

The two annotations match **exactly the same values**; only the caching differs. Verified with an isolated A/B (7.37 µs → 3.66 µs) and in situ:

```
u.unit faithful after linalg import: True  (was False)
u.unit("m")   18.74 µs -> 8.63 µs
```

`u.unit` is also the `converter=` on `QuantityMatrix.unit`, so this is on the construction path too.

> [!NOTE]
> This is a *different* mechanism from the `type[X]` unfaithfulness parked on beartype/plum#290 — that one is about `type[X]`, this is parametric generics, and unlike that case the fix here costs nothing and changes no API.

## 2. `_wrap` existed as the fast path, but 4 callers didn't use it

`_wrap`'s own docstring says it "skips the redundant per-element normalization and extra allocation that `__init__` -> `_build_object_array` would do" — yet `T`, `__getitem__`, `__iter__` and `_elementwise` all went the slow way, re-running `_normalize_unit` over an array that was already normalized.

## 3. `__pow__` memoizes per distinct unit

Replaces the three-way branch (1-D loop / 2-D uniform scan / 2-D mixed nested loop) with one flat pass. Uniform structures still cost a single `Unit.__pow__`; mixed ones now cost one per *distinct* unit instead of one per entry; and the zero-size special case falls out for free. (`Unit.__pow__` is 0.890 µs vs 0.050 µs for `Unit.__eq__` and ~0.08 µs for a dict hit, so the memo is never a loss.)

Also adds **`UnitsMatrix.is_uniform`**, replacing three separate copies of the same "are all entries the same unit" scan — in `__pow__`, in `inv` (which rejects heterogeneous matrices), and in the `QuantityMatrix` → `Quantity` conversion.

## Measurements

| | before | after |
|---|---|---|
| `u.unit("m")` (linalg imported) | 18.74 µs | **8.63 µs** |
| `.T` 2×2 | 3.58 µs | **0.29 µs** |
| `.T` 10×10 | 39.60 µs | **0.29 µs** |
| `[0]` (row) | 2.62 µs | **0.34 µs** |
| `** 2` 2×2 | 42.34 µs | **6.49 µs** |
| `** 2` 10×10 (uniform) | 61.29 µs | **24.67 µs** |
| `list(iter(...))` | 4.02 µs | **1.11 µs** |

## Verification

- `pytest packages/unxts.linalg/src` — 333 passed; `packages/unxts.linalg/tests` — 262 passed (the two CI invocations)
- `pytest tests/unit src docs` — 3335 passed, since #1 changes `u.unit` for all of unxt
- `pytest packages/unxts.parametric/tests packages/unxts.api/tests` — 77 passed
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

> [!TIP]
> `pytest packages/unxts.linalg` (src and tests in **one** invocation) reports 8 failures on a clean checkout — sybil's src-doctest collection and the test run import the module under different paths, so `isinstance(UnitsMatrix(...), UnitsMatrix)` is False against two distinct class objects. Pre-existing and unrelated; CI runs the two paths separately, which is what I did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)