### PR TITLE
♻️ refactor(linalg): hoist the quaxify wrappers, reuse diagonal(), fold matrix conversion onto rows

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
@@ -28,6 +28,9 @@ from ._quantity_matrix import QuantityMatrix
 __all__ = ("matmul", "matvec", "vecdot", "vecmat")
 
 # ``quax.quaxify`` rebuilds a wrapper on every call (~18us), so wrap once here.
+# Import-time wrapping does not race the ``@quax.register`` decorators in
+# ``_register_primitives``: ``quaxify(f)`` only stores ``f`` on an ``eqx.Module``
+# and resolves the registry inside the trace at *call* time.
 _matmul = quax.quaxify(jnp.matmul)
 _matvec = quax.quaxify(jnp.matvec)
 _vecmat = quax.quaxify(jnp.vecmat)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_products.py
@@ -27,6 +27,12 @@ from ._quantity_matrix import QuantityMatrix
 
 __all__ = ("matmul", "matvec", "vecdot", "vecmat")
 
+# ``quax.quaxify`` rebuilds a wrapper on every call (~18us), so wrap once here.
+_matmul = quax.quaxify(jnp.matmul)
+_matvec = quax.quaxify(jnp.matvec)
+_vecmat = quax.quaxify(jnp.vecmat)
+_vecdot = quax.quaxify(jnp.vecdot)
+
 
 def _reject_batched_vector(a: Any, b: Any, /) -> None:
     """Raise if a `QuantityMatrix` operand is a *batched* (logically 1-D) vector.
@@ -78,7 +84,7 @@ def matmul(a: Any, b: Any, /) -> Any:
 
     """
     _reject_batched_vector(a, b)
-    return quax.quaxify(jnp.matmul)(a, b)
+    return _matmul(a, b)
 
 
 def matvec(a: Any, b: Any, /) -> Any:
@@ -108,7 +114,7 @@ def matvec(a: Any, b: Any, /) -> Any:
            [3., 7.]], dtype=float32)
 
     """
-    return quax.quaxify(jnp.matvec)(a, b)
+    return _matvec(a, b)
 
 
 def vecmat(a: Any, b: Any, /) -> Any:
@@ -128,7 +134,7 @@ def vecmat(a: Any, b: Any, /) -> Any:
     Array([4., 6.], dtype=float32)
 
     """
-    return quax.quaxify(jnp.vecmat)(a, b)
+    return _vecmat(a, b)
 
 
 def vecdot(a: Any, b: Any, /) -> Any:
@@ -145,4 +151,4 @@ def vecdot(a: Any, b: Any, /) -> Any:
     Array(8003., dtype=float32)
 
     """
-    return quax.quaxify(jnp.vecdot)(a, b)
+    return _vecdot(a, b)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -290,15 +290,9 @@ class QuantityMatrix(u.AbstractQuantity):
 
         """
         if isinstance(other, QuantityMatrix):
-            ranks = (self.unit.ndim, other.unit.ndim)
-            if ranks == (2, 2):
-                return quax.quaxify(jnp.matmul)(self, other)
-            if ranks == (2, 1):
-                return quax.quaxify(jnp.matvec)(self, other)
-            if ranks == (1, 2):
-                return quax.quaxify(jnp.vecmat)(self, other)
-            if ranks == (1, 1):
-                return quax.quaxify(jnp.vecdot)(self, other)
+            product = _PRODUCT_BY_RANK.get((self.unit.ndim, other.unit.ndim))
+            if product is not None:
+                return product(self, other)
         return super().__matmul__(other)
 
     # ── Quax API ─────────────────────────────────────────────────────
@@ -364,8 +358,7 @@ class QuantityMatrix(u.AbstractQuantity):
         # single primitive (result diagonal is the trailing axis), avoiding an
         # n-op Python loop; units come from the static `UnitsMatrix`.
         diag_value = jnp.diagonal(self.value, axis1=-2, axis2=-1)
-        diag_unit = UnitsMatrix(self.unit._units.diagonal())
-        return QuantityMatrix(value=diag_value, unit=diag_unit)
+        return QuantityMatrix(value=diag_value, unit=self.unit.diagonal())
 
     @property
     def T(self) -> "QuantityMatrix":
@@ -410,6 +403,16 @@ QM = QuantityMatrix
 """Short alias for `QuantityMatrix` (cf. ``Q`` for ``Quantity``)."""
 
 
+#: ``@`` implementation per pair of logical (``unit``) ranks. ``quaxify`` wraps
+#: at ~18us a call, so the wrappers are built once here rather than per ``@``.
+_PRODUCT_BY_RANK = {
+    (2, 2): quax.quaxify(jnp.matmul),
+    (2, 1): quax.quaxify(jnp.matvec),
+    (1, 2): quax.quaxify(jnp.vecmat),
+    (1, 1): quax.quaxify(jnp.vecdot),
+}
+
+
 ##############################################################################
 # Unit-conversion helpers
 
@@ -443,19 +446,14 @@ def _convert_value_matrix(
     `u.uconvert_value` so that **all** conversion types are handled
     correctly — including nonlinear ones like dB, mag, and dex (which
     are logarithmic, not affine).
+
+    A matrix conversion is a stack of row conversions, so this defers to
+    :func:`_convert_value_vector` per row rather than repeating its loop.
     """
-    n = len(to_units)
-    m = len(to_units[0])
     return jnp.stack(
         [
-            jnp.stack(
-                [
-                    u.uconvert_value(to_units[i][j], from_units[i][j], value[..., i, j])
-                    for j in range(m)
-                ],
-                axis=-1,
-            )
-            for i in range(n)
+            _convert_value_vector(value[..., i, :], from_units[i], to_units[i])
+            for i in range(len(to_units))
         ],
         axis=-2,
     )

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -405,6 +405,10 @@ QM = QuantityMatrix
 
 #: ``@`` implementation per pair of logical (``unit``) ranks. ``quaxify`` wraps
 #: at ~18us a call, so the wrappers are built once here rather than per ``@``.
+#: Wrapping at import time is safe even though ``_register_primitives`` has not
+#: run yet: ``quax.quaxify(f)`` only stores ``f`` on an ``eqx.Module`` and does
+#: every registry lookup inside ``_QuaxTrace.process_primitive`` at *call* time,
+#: so no wrap-time snapshot of the registrations exists to go stale.
 _PRODUCT_BY_RANK = {
     (2, 2): quax.quaxify(jnp.matmul),
     (2, 1): quax.quaxify(jnp.matvec),


### PR DESCRIPTION
From a ponytail-audit of `unxts.linalg`. One of 4 independent PRs; no ordering dependency.

## 1. `quax.quaxify` was rebuilt on every call

At **eight** sites — the four `_products` functions and the four branches of `QuantityMatrix.__matmul__` — `quax.quaxify(jnp.matmul)(a, b)` constructed a fresh wrapper per invocation, at **18.45 µs** each. Wrapped once at module level instead, and `__matmul__`'s four-branch ladder becomes a `_PRODUCT_BY_RANK` lookup.

> [!NOTE]
> This is only safe because `quaxify` resolves the registry at **call** time, not wrap time — `_quantity_matrix` is imported *before* `_register_primitives` runs its `@quax.register` decorators, so a wrap-time snapshot would have silently missed every `QuantityMatrix` rule. Verified explicitly (`A @ v`, `A @ A`, `v @ A`, `v @ v` each still return a `QuantityMatrix` with correct values), not just inferred from a green suite.

`A @ v`: **601.0 µs → 65.1 µs**.

## 2. `QuantityMatrix.diag()` reuses `UnitsMatrix.diagonal()`

It was reaching into `self.unit._units.diagonal()` and pushing the result back through full `UnitsMatrix` re-validation — a second implementation of a method that already exists and already takes the `_wrap` fast path. **112.6 µs → 80.0 µs**.

## 3. `_convert_value_matrix` defers to `_convert_value_vector` per row

A matrix conversion *is* a stack of row conversions, so the nested double `jnp.stack` comprehension was a second copy of the vector loop:

```python
return jnp.stack(
    [
        _convert_value_vector(value[..., i, :], from_units[i], to_units[i])
        for i in range(len(to_units))
    ],
    axis=-2,
)
```

> [!NOTE]
> I originally had this finding scoped as "collapse the three `_convert_value*` helpers into one rank-generic function". On inspection both helpers are **directly unit-tested** (8 tests in `test_quantity_matrix.py` calling them with nested unit tuples) and used at two call sites in `_register_primitives`, so deleting them would have meant rewriting those tests to buy ~35 lines. Delegating instead removes the duplicated loop while leaving both names and all 8 tests untouched.

## Verification

- `pytest packages/unxts.linalg/src` — 329 passed; `tests` — 262 passed; `docs` — 111 passed
- Explicit dispatch check on the hoisted wrappers (above), `diag()` values + units, and `_convert_value_matrix` values plus a `(4, 2, 2)` batched shape
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)