### PR TITLE
🧹 chore(linalg): drop the strict_zip wrapper and a dead import

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_det.py
@@ -21,7 +21,6 @@ import operator
 
 import jax
 import jax.core
-import jax.dtypes
 import jax.numpy as jnp
 import quax
 from jax import lax

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -13,7 +13,7 @@ from jaxtyping import Array, Shaped
 
 import unxt as u
 from ._units_matrix import UnitsMatrix
-from ._utils import _DMLS, CDict, strict_zip
+from ._utils import _DMLS, CDict
 from unxt.quantity import AllowValue
 
 
@@ -181,7 +181,7 @@ class QuantityMatrix(u.AbstractQuantity):
         # confusing downstream dispatch error.
         bad = [
             k
-            for k, x in strict_zip(keys, vs)
+            for k, x in zip(keys, vs, strict=True)
             if isinstance(x, (QuantityMatrix, UnitsMatrix))
         ]
         if bad:
@@ -192,7 +192,9 @@ class QuantityMatrix(u.AbstractQuantity):
             )
             raise TypeError(msg)
         us = [u.unit_of(x) or _DMLS for x in vs]
-        svs = jnp.stack([u.ustrip(AllowValue, unt, x) for x, unt in strict_zip(vs, us)])
+        svs = jnp.stack(
+            [u.ustrip(AllowValue, unt, x) for x, unt in zip(vs, us, strict=True)]
+        )
         return cls(svs, unit=UnitsMatrix(us))
 
     def __getitem__(self, index: Any, /) -> "u.Q | QuantityMatrix":  # ty: ignore[invalid-method-override]

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_utils.py
@@ -16,11 +16,6 @@ _DMLS = u.unit("")
 PackedUnitOutput: TypeAlias = tuple["u.AbstractUnit | UnitsMatrix | None", ...]
 
 
-def strict_zip(*args: Any) -> zip:
-    """Zip iterables while enforcing equal lengths."""
-    return zip(*args, strict=True)
-
-
 def cdict_units(p: CDict, keys: tuple[str, ...], /) -> PackedUnitOutput:
     """Extract per-key units from a component dictionary.
 


### PR DESCRIPTION
From a ponytail-audit of `unxts.linalg`. One of 4 independent PRs; no ordering dependency. The small one.

**`strict_zip`** was a two-line wrapper around a builtin keyword argument:

```python
def strict_zip(*args: Any) -> zip:
    """Zip iterables while enforcing equal lengths."""
    return zip(*args, strict=True)
```

Inlined at its two call sites in `from_cdict`.

**`import jax.dtypes` in `_det.py`** is unused — only `jax.core` is referenced.

> [!NOTE]
> The neighbouring `to_inexact_dtype` helper *looks* like hand-rolled stdlib, but it isn't: `jax.dtypes.to_inexact_dtype` does not exist as public API (only `jax._src.dtypes.to_inexact_dtype`), so the local implementation stays. I checked this before assuming the import was there to support a replacement.

## Verification

- `pytest packages/unxts.linalg/src` — 329 passed; `tests` — 262 passed; `docs` — 111 passed
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)