### PR TITLE
⚡️ perf(linalg): build QuantityMatrix results with the unchecked `_mk`

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -208,4 +208,7 @@ def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
         raise ValueError(msg)
 
     inv_val = inv_p.bind(x.value)
-    return QuantityMatrix(inv_val, unit=x.unit.inverse())
+    # `_mk`: `inv_val` is a `lax` output and `inverse()` a `UnitsMatrix`, so both
+    # converters are the identity; inversion preserves shape, so the
+    # value/unit pairing `__check_init__` guards is unchanged.
+    return QuantityMatrix._mk(value=inv_val, unit=x.unit.inverse())

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_inv.py
@@ -208,7 +208,4 @@ def _inv_p_QuantityMatrix(x: QuantityMatrix, /) -> QuantityMatrix:
         raise ValueError(msg)
 
     inv_val = inv_p.bind(x.value)
-    # `_mk`: `inv_val` is a `lax` output and `inverse()` a `UnitsMatrix`, so both
-    # converters are the identity; inversion preserves shape, so the
-    # value/unit pairing `__check_init__` guards is unchanged.
     return QuantityMatrix._mk(value=inv_val, unit=x.unit.inverse())

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -252,9 +252,6 @@ class QuantityMatrix(u.AbstractQuantity):
             raise NotImplementedError(msg)
         unit_item = self.unit[idx[n_batch:]]  # () -> whole unit (batch-only index)
         if isinstance(unit_item, UnitsMatrix):
-            # `_mk`: indexing a `jax.Array` yields a `jax.Array`, and the same
-            # trailing index is applied to both value and unit, so their shapes
-            # stay paired by construction.
             return QuantityMatrix._mk(value=value_item, unit=unit_item)
         return u.Q(value_item, unit_item)
 
@@ -362,8 +359,6 @@ class QuantityMatrix(u.AbstractQuantity):
         # single primitive (result diagonal is the trailing axis), avoiding an
         # n-op Python loop; units come from the static `UnitsMatrix`.
         diag_value = jnp.diagonal(self.value, axis1=-2, axis2=-1)
-        # `_mk`: both operands are already normalised and `jnp.diagonal` /
-        # `UnitsMatrix.diagonal` take the same diagonal, so the shapes agree.
         return QuantityMatrix._mk(value=diag_value, unit=self.unit.diagonal())
 
     @property
@@ -402,8 +397,6 @@ class QuantityMatrix(u.AbstractQuantity):
         if self.ndim != 2:
             msg = f"QuantityMatrix.T requires a 2-D matrix, got ndim={self.ndim}"
             raise ValueError(msg)
-        # `_mk`: the value and the units are transposed together, so the pairing
-        # survives; both converters are the identity on the results.
         return QuantityMatrix._mk(
             value=jnp.swapaxes(self.value, -2, -1), unit=self.unit.T
         )
@@ -555,7 +548,4 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
     if x.unit == to_units:
         return x
     value = _convert_value(x.value, x.unit, to_units)
-    # `_mk`: `_convert_value` returns a `jax.Array` of `x`'s shape, and
-    # `to_units` is a `UnitsMatrix` of `x.unit`'s shape (it converted against
-    # it), so the pairing holds.
     return QuantityMatrix._mk(value=value, unit=to_units)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -252,7 +252,10 @@ class QuantityMatrix(u.AbstractQuantity):
             raise NotImplementedError(msg)
         unit_item = self.unit[idx[n_batch:]]  # () -> whole unit (batch-only index)
         if isinstance(unit_item, UnitsMatrix):
-            return QuantityMatrix(value=value_item, unit=unit_item)
+            # `_mk`: indexing a `jax.Array` yields a `jax.Array`, and the same
+            # trailing index is applied to both value and unit, so their shapes
+            # stay paired by construction.
+            return QuantityMatrix._mk(value=value_item, unit=unit_item)
         return u.Q(value_item, unit_item)
 
     def __matmul__(self, other: Any) -> Any:
@@ -359,7 +362,9 @@ class QuantityMatrix(u.AbstractQuantity):
         # single primitive (result diagonal is the trailing axis), avoiding an
         # n-op Python loop; units come from the static `UnitsMatrix`.
         diag_value = jnp.diagonal(self.value, axis1=-2, axis2=-1)
-        return QuantityMatrix(value=diag_value, unit=self.unit.diagonal())
+        # `_mk`: both operands are already normalised and `jnp.diagonal` /
+        # `UnitsMatrix.diagonal` take the same diagonal, so the shapes agree.
+        return QuantityMatrix._mk(value=diag_value, unit=self.unit.diagonal())
 
     @property
     def T(self) -> "QuantityMatrix":
@@ -397,7 +402,11 @@ class QuantityMatrix(u.AbstractQuantity):
         if self.ndim != 2:
             msg = f"QuantityMatrix.T requires a 2-D matrix, got ndim={self.ndim}"
             raise ValueError(msg)
-        return QuantityMatrix(value=jnp.swapaxes(self.value, -2, -1), unit=self.unit.T)
+        # `_mk`: the value and the units are transposed together, so the pairing
+        # survives; both converters are the identity on the results.
+        return QuantityMatrix._mk(
+            value=jnp.swapaxes(self.value, -2, -1), unit=self.unit.T
+        )
 
 
 QM = QuantityMatrix
@@ -546,4 +555,7 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
     if x.unit == to_units:
         return x
     value = _convert_value(x.value, x.unit, to_units)
-    return QuantityMatrix(value=value, unit=to_units)
+    # `_mk`: `_convert_value` returns a `jax.Array` of `x`'s shape, and
+    # `to_units` is a `UnitsMatrix` of `x.unit`'s shape (it converted against
+    # it), so the pairing holds.
+    return QuantityMatrix._mk(value=value, unit=to_units)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -10,26 +10,11 @@ Registers handlers for the following JAX primitives:
 - ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
 - ``lax.reduce_sum_p`` — summation reduction
 
-Every rule here returns via `QuantityMatrix._mk`, the unchecked constructor,
-rather than the ordinary one. `AbstractQuantity._mk` asks that the theorem
-justifying it be stated at the call site; it is the same theorem for all of
-them, so it is stated once here:
-
-1. The *value* is always the output of a `jax.lax` primitive or of arithmetic
-   between two such outputs, hence already a `jax.Array` or tracer — exactly
-   what ``convert_to_quantity_value`` would return. None of these primitives is
-   multi-output, so none hands back the `list` that the converter exists to fold.
-2. The *unit* is always an existing `UnitsMatrix` or the result of `UnitsMatrix`
-   arithmetic, so `unxts.api.unit`'s converter is the identity on it. The one
-   exception is ``dot_general`` 2-D x 2-D, which keeps its output units as a bare
-   object array for a broadcast and so wraps them explicitly.
-3. ``__check_init__``'s invariant -- ``value.shape[-unit.ndim:] == unit.shape``
-   -- is arithmetic here rather than an assumption: the unit structure is built
-   from the very axes of the value it is paired with, and the contraction axes
-   are checked up front by `_check_contract`.
-
-`QuantityMatrix` is not an `AbstractParametricQuantity`, so a rule whose *unit
-changes* is fine too -- there is no type parameter to re-infer from the new unit.
+Every rule returns via the unchecked `QuantityMatrix._mk`: values are always
+`lax` outputs (single-output primitives only), units always existing or derived
+`UnitsMatrix`, and the shape invariant is built from the same axes it pairs
+(contraction axes checked up front by `_check_contract`). ``dot_general`` 2-D x
+2-D is the one exception and wraps its units explicitly.
 """
 
 from functools import lru_cache
@@ -352,7 +337,7 @@ def _dot_general_2d_1d(
     _check_contract(lhs.shape[-1], rhs.shape[-1])
 
     # 1) Output units: ref[i] = lhs.unit[i][0] * rhs.unit[0]
-    out_unit = UnitsMatrix._wrap(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
+    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
 
     # 2) Precompute scale factors: scale[i, j] converts
     #    lhs.unit[i][j]*rhs.unit[j] → ref[i]
@@ -413,7 +398,7 @@ def _dot_general_1d_2d(
     _check_contract(lhs.shape[-1], rhs.shape[-2])
 
     # 1) Output units: ref[k] = lhs.unit[0] * rhs.unit[0][k]
-    out_unit = UnitsMatrix._wrap(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
+    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
 
     # 2) Precompute scale factors: scale[j, k] converts
     #    lhs.unit[j]*rhs.unit[j][k] → ref[k]
@@ -490,8 +475,7 @@ def _dot_general_2d_2d(
     #    C[..., i, k] = Σ_j  scale[i, j, k] * A[..., i, j] * B[..., j, k]
     accum = jnp.einsum("ijk,...ij,...jk->...ik", scale_3d, lhs.value, rhs.value)
 
-    # `out_unit` is a bare object array here (it is kept in that form for the
-    # broadcast above), so it needs the wrap that `_mk` skips.
+    # `out_unit` is a bare object array (kept so for the broadcast above).
     return QuantityMatrix._mk(value=accum, unit=UnitsMatrix._wrap(out_unit))
 
 
@@ -916,7 +900,7 @@ def _jit_fallback_uniform_unit(
             "Call eagerly (outside jit) for heterogeneous-unit QuantityMatrix."
         )
         raise ValueError(msg)
-    return UnitsMatrix._wrap(np.full(out_shape, first, dtype=object))
+    return UnitsMatrix(np.full(out_shape, first, dtype=object))
 
 
 @quax.register(lax.gather_p)
@@ -1037,9 +1021,9 @@ def gather_qm(
         # Eager path: indices are concrete — look up units directly.
         idx_np = np.asarray(start_indices)
         if x.unit.ndim == 1:
-            out_unit = UnitsMatrix._wrap(x.unit._units[idx_np[..., 0]])
+            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0]])
         else:  # x.unit.ndim == 2
-            out_unit = UnitsMatrix._wrap(x.unit._units[idx_np[..., 0], idx_np[..., 1]])
+            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0], idx_np[..., 1]])
 
     return QuantityMatrix._mk(value=result_value, unit=out_unit)
 
@@ -1106,12 +1090,12 @@ def reduce_sum_p_qm(
     if operand.unit.ndim == 2 and logical_axes == {0}:
         # Row reduction → unit = first row's units. Convert every row to that
         # reference row before summing so compatible-but-different units add up.
-        out_unit = UnitsMatrix._wrap(units[0])
+        out_unit = UnitsMatrix(units[0])
         target = tuple(tuple(units[0]) for _ in range(units.shape[0]))
         value = _convert_value_matrix(operand.value, units, target)
     elif operand.unit.ndim == 2 and logical_axes == {1}:
         # Column reduction → unit = first column's units; convert each column.
-        out_unit = UnitsMatrix._wrap(units[:, 0])
+        out_unit = UnitsMatrix(units[:, 0])
         target = tuple(
             tuple(units[i, 0] for _ in range(units.shape[1]))
             for i in range(units.shape[0])

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -10,8 +10,9 @@ Registers handlers for the following JAX primitives:
 - ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
 - ``lax.reduce_sum_p`` — summation reduction
 
-Every rule returns via the unchecked `QuantityMatrix._mk`: values are always
-`lax` outputs (single-output primitives only), units always existing or derived
+Rules that return a `QuantityMatrix` build it with the unchecked `_mk` (the
+scalar-output paths return a plain `u.Q` instead): values are always `lax`
+outputs (single-output primitives only), units always existing or derived
 `UnitsMatrix`, and the shape invariant is built from the same axes it pairs
 (contraction axes checked up front by `_check_contract`). ``dot_general`` 2-D x
 2-D is the one exception and wraps its units explicitly.

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -10,12 +10,9 @@ Registers handlers for the following JAX primitives:
 - ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
 - ``lax.reduce_sum_p`` — summation reduction
 
-Rules that return a `QuantityMatrix` build it with the unchecked `_mk` (the
-scalar-output paths return a plain `u.Q` instead): values are always `lax`
-outputs (single-output primitives only), units always existing or derived
-`UnitsMatrix`, and the shape invariant is built from the same axes it pairs
-(contraction axes checked up front by `_check_contract`). ``dot_general`` 2-D x
-2-D is the one exception and wraps its units explicitly.
+Rules returning a `QuantityMatrix` build it with the unchecked `_mk`: the value
+is always a `lax` output and the unit an already-normalised `UnitsMatrix` built
+from that value's own axes, so both converters and `__check_init__` are no-ops.
 """
 
 from functools import lru_cache

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -9,6 +9,27 @@ Registers handlers for the following JAX primitives:
 - ``lax.transpose_p`` — matrix transpose
 - ``lax.gather_p`` — element-selection gather (e.g. jnp.diag)
 - ``lax.reduce_sum_p`` — summation reduction
+
+Every rule here returns via `QuantityMatrix._mk`, the unchecked constructor,
+rather than the ordinary one. `AbstractQuantity._mk` asks that the theorem
+justifying it be stated at the call site; it is the same theorem for all of
+them, so it is stated once here:
+
+1. The *value* is always the output of a `jax.lax` primitive or of arithmetic
+   between two such outputs, hence already a `jax.Array` or tracer — exactly
+   what ``convert_to_quantity_value`` would return. None of these primitives is
+   multi-output, so none hands back the `list` that the converter exists to fold.
+2. The *unit* is always an existing `UnitsMatrix` or the result of `UnitsMatrix`
+   arithmetic, so `unxts.api.unit`'s converter is the identity on it. The one
+   exception is ``dot_general`` 2-D x 2-D, which keeps its output units as a bare
+   object array for a broadcast and so wraps them explicitly.
+3. ``__check_init__``'s invariant -- ``value.shape[-unit.ndim:] == unit.shape``
+   -- is arithmetic here rather than an assumption: the unit structure is built
+   from the very axes of the value it is paired with, and the contraction axes
+   are checked up front by `_check_contract`.
+
+`QuantityMatrix` is not an `AbstractParametricQuantity`, so a rule whose *unit
+changes* is fine too -- there is no type parameter to re-infer from the new unit.
 """
 
 from functools import lru_cache
@@ -93,7 +114,7 @@ def add_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
 
     """
     y_converted = _convert_value(y.value, y.unit, x.unit)
-    return QuantityMatrix(value=lax.add(x.value, y_converted), unit=x.unit)
+    return QuantityMatrix._mk(value=lax.add(x.value, y_converted), unit=x.unit)
 
 
 @quax.register(lax.sub_p)
@@ -140,7 +161,7 @@ def sub_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
 
     """
     y_converted = _convert_value(y.value, y.unit, x.unit)
-    return QuantityMatrix(value=lax.sub(x.value, y_converted), unit=x.unit)
+    return QuantityMatrix._mk(value=lax.sub(x.value, y_converted), unit=x.unit)
 
 
 # ── mul / div (element-wise) ──────────────────────────────────────────────
@@ -156,7 +177,7 @@ def sub_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /) -> QuantityMatrix:
 @quax.register(lax.mul_p)
 def mul_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
     """Element-wise product of two `QuantityMatrix` objects (units multiply)."""
-    return QuantityMatrix(x.value * y.value, unit=x.unit * y.unit)
+    return QuantityMatrix._mk(value=x.value * y.value, unit=x.unit * y.unit)
 
 
 @quax.register(lax.mul_p)
@@ -166,7 +187,7 @@ def mul_qm_qty(
     """`QuantityMatrix` x uniform-unit Quantity: scale values, multiply units."""
     y_unit = u.unit_of(y)
     y_val = u.ustrip(AllowValue, y_unit, y)
-    return QuantityMatrix(x.value * y_val, unit=x.unit * y_unit)
+    return QuantityMatrix._mk(value=x.value * y_val, unit=x.unit * y_unit)
 
 
 @quax.register(lax.mul_p)
@@ -180,19 +201,19 @@ def mul_qty_qm(
 @quax.register(lax.mul_p)
 def mul_qm_arr(x: QuantityMatrix, y: jax.Array, /, **kw: Any) -> QuantityMatrix:
     """`QuantityMatrix` x dimensionless array: scale values, units unchanged."""
-    return QuantityMatrix(x.value * y, unit=x.unit)
+    return QuantityMatrix._mk(value=x.value * y, unit=x.unit)
 
 
 @quax.register(lax.mul_p)
 def mul_arr_qm(x: jax.Array, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
     """Dimensionless array x `QuantityMatrix`."""
-    return QuantityMatrix(x * y.value, unit=y.unit)
+    return QuantityMatrix._mk(value=x * y.value, unit=y.unit)
 
 
 @quax.register(lax.div_p)
 def div_qm_qm(x: QuantityMatrix, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
     """Element-wise quotient of two `QuantityMatrix` objects (units divide)."""
-    return QuantityMatrix(x.value / y.value, unit=x.unit / y.unit)
+    return QuantityMatrix._mk(value=x.value / y.value, unit=x.unit / y.unit)
 
 
 @quax.register(lax.div_p)
@@ -202,7 +223,7 @@ def div_qm_qty(
     """`QuantityMatrix` / uniform-unit Quantity."""
     y_unit = u.unit_of(y)
     y_val = u.ustrip(AllowValue, y_unit, y)
-    return QuantityMatrix(x.value / y_val, unit=x.unit / y_unit)
+    return QuantityMatrix._mk(value=x.value / y_val, unit=x.unit / y_unit)
 
 
 @quax.register(lax.div_p)
@@ -212,19 +233,19 @@ def div_qty_qm(
     """Uniform-unit Quantity / `QuantityMatrix` (not commutative)."""
     x_unit = u.unit_of(x)
     x_val = u.ustrip(AllowValue, x_unit, x)
-    return QuantityMatrix(x_val / y.value, unit=x_unit / y.unit)
+    return QuantityMatrix._mk(value=x_val / y.value, unit=x_unit / y.unit)
 
 
 @quax.register(lax.div_p)
 def div_qm_arr(x: QuantityMatrix, y: jax.Array, /, **kw: Any) -> QuantityMatrix:
     """`QuantityMatrix` / dimensionless array: scale values, units unchanged."""
-    return QuantityMatrix(x.value / y, unit=x.unit)
+    return QuantityMatrix._mk(value=x.value / y, unit=x.unit)
 
 
 @quax.register(lax.div_p)
 def div_arr_qm(x: jax.Array, y: QuantityMatrix, /, **kw: Any) -> QuantityMatrix:
     """Dimensionless array / `QuantityMatrix` (units invert)."""
-    return QuantityMatrix(x / y.value, unit=_DMLS / y.unit)
+    return QuantityMatrix._mk(value=x / y.value, unit=_DMLS / y.unit)
 
 
 # ── dot_general helpers ───────────────────────────────────────────────────
@@ -331,7 +352,7 @@ def _dot_general_2d_1d(
     _check_contract(lhs.shape[-1], rhs.shape[-1])
 
     # 1) Output units: ref[i] = lhs.unit[i][0] * rhs.unit[0]
-    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
+    out_unit = UnitsMatrix._wrap(np.multiply(lhs.unit._units[:, 0], rhs.unit._units[0]))
 
     # 2) Precompute scale factors: scale[i, j] converts
     #    lhs.unit[i][j]*rhs.unit[j] → ref[i]
@@ -347,7 +368,7 @@ def _dot_general_2d_1d(
     #    w[..., i] = Σ_j  scale[i, j] * A[..., i, j] * v[..., j]
     accum = jnp.einsum("ij,...ij,...j->...i", scale_2d, lhs.value, rhs.value)
 
-    return QuantityMatrix(value=accum, unit=out_unit)
+    return QuantityMatrix._mk(value=accum, unit=out_unit)
 
 
 def _dot_general_1d_2d(
@@ -392,7 +413,7 @@ def _dot_general_1d_2d(
     _check_contract(lhs.shape[-1], rhs.shape[-2])
 
     # 1) Output units: ref[k] = lhs.unit[0] * rhs.unit[0][k]
-    out_unit = UnitsMatrix(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
+    out_unit = UnitsMatrix._wrap(np.multiply(lhs.unit._units[0], rhs.unit._units[0, :]))
 
     # 2) Precompute scale factors: scale[j, k] converts
     #    lhs.unit[j]*rhs.unit[j][k] → ref[k]
@@ -408,7 +429,7 @@ def _dot_general_1d_2d(
     #    w[..., k] = Σ_j  scale[j, k] * v[..., j] * A[..., j, k]
     accum = jnp.einsum("jk,...j,...jk->...k", scale_2d, lhs.value, rhs.value)
 
-    return QuantityMatrix(value=accum, unit=out_unit)
+    return QuantityMatrix._mk(value=accum, unit=out_unit)
 
 
 def _dot_general_2d_2d(
@@ -469,7 +490,9 @@ def _dot_general_2d_2d(
     #    C[..., i, k] = Σ_j  scale[i, j, k] * A[..., i, j] * B[..., j, k]
     accum = jnp.einsum("ijk,...ij,...jk->...ik", scale_3d, lhs.value, rhs.value)
 
-    return QuantityMatrix(value=accum, unit=out_unit)
+    # `out_unit` is a bare object array here (it is kept in that form for the
+    # broadcast above), so it needs the wrap that `_mk` skips.
+    return QuantityMatrix._mk(value=accum, unit=UnitsMatrix._wrap(out_unit))
 
 
 # ── dot_general dispatch ──────────────────────────────────────────────────
@@ -610,7 +633,7 @@ def _wrap_operand(
         )
         raise NotImplementedError(msg)
     unit = UnitsMatrix.full(value.shape[-logical_ndim:], element_unit)
-    return QuantityMatrix(value, unit=unit)
+    return QuantityMatrix._mk(value=value, unit=unit)
 
 
 @quax.register(lax.dot_general_p)
@@ -870,7 +893,7 @@ def transpose_qm(
         )
         raise NotImplementedError(msg)
     transposed_value = lax.transpose(x.value, permutation)
-    return QuantityMatrix(value=transposed_value, unit=x.unit.T)
+    return QuantityMatrix._mk(value=transposed_value, unit=x.unit.T)
 
 
 # ── gather ───────────────────────────────────────────────────────────────
@@ -893,7 +916,7 @@ def _jit_fallback_uniform_unit(
             "Call eagerly (outside jit) for heterogeneous-unit QuantityMatrix."
         )
         raise ValueError(msg)
-    return UnitsMatrix(np.full(out_shape, first, dtype=object))
+    return UnitsMatrix._wrap(np.full(out_shape, first, dtype=object))
 
 
 @quax.register(lax.gather_p)
@@ -1014,11 +1037,11 @@ def gather_qm(
         # Eager path: indices are concrete — look up units directly.
         idx_np = np.asarray(start_indices)
         if x.unit.ndim == 1:
-            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0]])
+            out_unit = UnitsMatrix._wrap(x.unit._units[idx_np[..., 0]])
         else:  # x.unit.ndim == 2
-            out_unit = UnitsMatrix(x.unit._units[idx_np[..., 0], idx_np[..., 1]])
+            out_unit = UnitsMatrix._wrap(x.unit._units[idx_np[..., 0], idx_np[..., 1]])
 
-    return QuantityMatrix(value=result_value, unit=out_unit)
+    return QuantityMatrix._mk(value=result_value, unit=out_unit)
 
 
 # ── reduce_sum ───────────────────────────────────────────────────────────
@@ -1077,18 +1100,18 @@ def reduce_sum_p_qm(
     # Reducing only batch axes leaves the per-element unit structure unchanged.
     if not logical_axes:
         result_value = lax.reduce_sum_p.bind(operand.value, axes=axes, **kwargs)
-        return QuantityMatrix(value=result_value, unit=operand.unit)
+        return QuantityMatrix._mk(value=result_value, unit=operand.unit)
 
     units = operand.unit._units
     if operand.unit.ndim == 2 and logical_axes == {0}:
         # Row reduction → unit = first row's units. Convert every row to that
         # reference row before summing so compatible-but-different units add up.
-        out_unit = UnitsMatrix(units[0])
+        out_unit = UnitsMatrix._wrap(units[0])
         target = tuple(tuple(units[0]) for _ in range(units.shape[0]))
         value = _convert_value_matrix(operand.value, units, target)
     elif operand.unit.ndim == 2 and logical_axes == {1}:
         # Column reduction → unit = first column's units; convert each column.
-        out_unit = UnitsMatrix(units[:, 0])
+        out_unit = UnitsMatrix._wrap(units[:, 0])
         target = tuple(
             tuple(units[i, 0] for _ in range(units.shape[1]))
             for i in range(units.shape[0])
@@ -1103,4 +1126,4 @@ def reduce_sum_p_qm(
         raise NotImplementedError(msg)
 
     result_value = lax.reduce_sum_p.bind(value, axes=axes, **kwargs)
-    return QuantityMatrix(value=result_value, unit=out_unit)
+    return QuantityMatrix._mk(value=result_value, unit=out_unit)


### PR DESCRIPTION
## What

`QuantityMatrix` subclasses `AbstractQuantity`, so it already inherits the unchecked constructor added in #816 — it just never called it. Every quax primitive rule returned through the *checked* constructor, paying two plum-dispatched field converters (`convert_to_quantity_value`, `unxts.api.unit`) plus `__check_init__` on the return path of every operation.

| construction | |
|---|---|
| `QuantityMatrix(v, unit=UnitsMatrix)` | 26.5 µs |
| `QuantityMatrix(v, unit=tuple)` | 109.7 µs |
| `QuantityMatrix._mk(value=v, unit=um)` | **0.73 µs** |

This converts the 22 internal construction sites, all of which hand over a value that is already a `jax.Array` and a unit that is already a `UnitsMatrix` — so both converters are the identity there.

## Why it is sound

`AbstractQuantity._mk` asks that the justifying theorem be stated at the call site. It is the same theorem for every rule in `_register_primitives`, so it is stated once in that module's docstring rather than repeated 18 times, and separately at the four sites outside it:

1. **Value** — always a `jax.lax` output or arithmetic between two such, hence already a `jax.Array`/tracer. None of these primitives is multi-output, so none returns the `list` the converter exists to fold.
2. **Unit** — always an existing `UnitsMatrix` or the result of `UnitsMatrix` arithmetic.
3. **`__check_init__`'s invariant** (`value.shape[-unit.ndim:] == unit.shape`) is arithmetic here, not an assumption: the unit structure is built from the very axes of the value it is paired with, and contraction axes are checked up front by `_check_contract`.

`QuantityMatrix` is **not** an `AbstractParametricQuantity`, so `revalue`'s "unit must be unchanged" caveat does not bind — unit-changing rules are safe too, as there is no type parameter to re-infer.

One site needed care: `dot_general` 2-D × 2-D deliberately keeps its output units as a bare object array for an `(N,1,M)` broadcast, so the `u.unit` converter *was* load-bearing there. That one wraps explicitly, with a comment saying why.

## Numbers

Eager, per operation, min of 3 runs:

| op | before | after | |
|---|---|---|---|
| `A.T` | 36.3 µs | 13.2 µs | **2.7x** |
| `A * B` | 317.8 µs | 144.7 µs | **2.2x** |
| `A * q` | 901.7 µs | 422.2 µs | **2.1x** |
| `A * arr` | 280.8 µs | 146.6 µs | **1.9x** |
| `A.diag()` | 59.5 µs | 34.3 µs | **1.7x** |
| `A / B` | 187.5 µs | 141.8 µs | **1.3x** |
| `A + B` | 669.3 µs | 571.4 µs | **1.2x** |
| `M @ N` | 626.8 µs | 564.3 µs | **1.1x** |

The win is largest where construction overhead dominates. At 16×16 the per-element astropy conversion loops dominate instead (~74 ms) and this change is noise there — except `diag`, 63.4 → 36.6 µs.

## Also here

The remaining `UnitsMatrix(...)` calls in `_register_primitives.py` already hold normalised object arrays, so they take the `_wrap` fast path for consistency with #825 (which covers `_units_matrix.py` but not this file). Honest accounting: **no measurable gain** at these sizes — included for consistency, not speed.

## Relation to open PRs

- #825 uses `_wrap` in `_units_matrix.py` / `_inv.py` / `_quantity_matrix.py`. No overlap in intent; expect a small textual conflict in the latter two, whichever lands second.
- #826 memoizes the `dot_general` scale factors — that targets the conversion loops this PR leaves untouched. Complementary.

## Testing

- `packages/unxts.linalg/tests`: 262 passed
- `packages/unxts.linalg/src` doctests: 329 passed
- rest of the suite: 3995 passed, 49 skipped, 20 xfailed
- `ruff check` / `ruff format` clean

Note: running `pytest packages/unxts.linalg` as a *single* invocation reports 8 failures on `main` as well as on this branch — the known dual-module-identity artifact of collecting the src doctests and tests together. Run separately, both are green. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)