### PR TITLE
⬆️ dep-bump(astropy): drop the astropy<7.1 compatibility shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "astropy>=7.0.0",
+  "astropy>=7.1",
   "dataclassish>=0.8.0",
   "equinox>=0.13.7",
   "is-annotated>=1.0",
@@ -27,7 +27,6 @@ dependencies = [
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
   "optional-dependencies>=0.3.2",
-  "packaging>=20.0",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",
@@ -55,7 +54,7 @@ cuda12_local = ["jax[cuda12_local]>=0.7.2"]
 k8s          = ["jax[k8s]>=0.7.2"]
 # extra extras
 all = ["unxt[backend-astropy,workspace]"]
-backend-astropy = ["astropy>=7.0.0"]
+backend-astropy = ["astropy>=7.1"]
 interop-gala = ["unxts.interop.gala"]
 interop-mpl = ["unxts.interop.matplotlib"]
 interop-xarray = ["unxts.interop.xarray"]

--- a/src/unxt/_src/dimensions.py
+++ b/src/unxt/_src/dimensions.py
@@ -383,7 +383,7 @@ def dimension_of(obj: type, /) -> NoReturn:
 
 
 # ===================================================================
-# COMPAT
+# Dimension name
 
 
 @dispatch

--- a/src/unxt/_src/dimensions.py
+++ b/src/unxt/_src/dimensions.py
@@ -8,13 +8,11 @@ __all__ = ("AbstractDimension", "dimension", "dimension_of")
 
 import ast
 import functools as ft
-import importlib.metadata
 import operator
 import re
 from typing import Any, Final, NoReturn, TypeAlias
 
 import astropy.units as apyu
-from packaging.version import Version, parse as parse_version
 from plum import dispatch
 
 import unxt_api as uapi
@@ -387,8 +385,6 @@ def dimension_of(obj: type, /) -> NoReturn:
 # ===================================================================
 # COMPAT
 
-ASTROPY_LT_71 = parse_version(importlib.metadata.version("astropy")) < Version("7.1")
-
 
 @dispatch
 def name_of(dim: AbstractDimension, /) -> str:
@@ -410,13 +406,8 @@ def name_of(dim: AbstractDimension, /) -> str:
     """
     if dim == "unknown":
         ptid = dim._unit._physical_type_id  # noqa: SLF001
-        name = " ".join(
+        return " ".join(
             f"{unit}{power}" if power != 1 else unit for unit, power in ptid
         )
 
-    elif ASTROPY_LT_71:
-        name = dim._name_string_as_ordered_set().split("'")[1]  # noqa: SLF001
-    else:
-        name = dim._physical_type[0]  # noqa: SLF001
-
-    return name
+    return dim._physical_type[0]  # noqa: SLF001

--- a/uv.lock
+++ b/uv.lock
@@ -3963,7 +3963,6 @@ dependencies = [
     { name = "jaxlib" },
     { name = "jaxtyping" },
     { name = "optional-dependencies" },
-    { name = "packaging" },
     { name = "plum-dispatch" },
     { name = "quax" },
     { name = "quax-blocks" },
@@ -4161,9 +4160,9 @@ workspace = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astropy", specifier = ">=7.0.0" },
-    { name = "astropy", marker = "extra == 'all'", specifier = ">=7.0.0" },
-    { name = "astropy", marker = "extra == 'backend-astropy'", specifier = ">=7.0.0" },
+    { name = "astropy", specifier = ">=7.1" },
+    { name = "astropy", marker = "extra == 'all'", specifier = ">=7.1" },
+    { name = "astropy", marker = "extra == 'backend-astropy'", specifier = ">=7.1" },
     { name = "dataclassish", specifier = ">=0.8.0" },
     { name = "equinox", specifier = ">=0.13.7" },
     { name = "is-annotated", specifier = ">=1.0" },
@@ -4176,7 +4175,6 @@ requires-dist = [
     { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jaxtyping", specifier = ">=0.3.9" },
     { name = "optional-dependencies", specifier = ">=0.3.2" },
-    { name = "packaging", specifier = ">=20.0" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.2" },


### PR DESCRIPTION
Split out of #820 — that PR is a behaviour-preserving parser refactor, this one is the dependency-floor judgement call. No ordering dependency between them, though whichever lands second needs a trivial rebase of the import block in `src/unxt/_src/dimensions.py`.

## Drop the astropy < 7.1 compatibility shim

`ASTROPY_LT_71` picked between two spellings of the private attribute `name_of` reads:

```python
ASTROPY_LT_71 = parse_version(importlib.metadata.version("astropy")) < Version("7.1")
...
elif ASTROPY_LT_71:
    name = dim._name_string_as_ordered_set().split("'")[1]
else:
    name = dim._physical_type[0]
```

astropy 7.1.0 shipped 2025-05-20 and 8.0.1 is current, so the floor moves `astropy>=7.0.0` → `>=7.1` (both in `[project.dependencies]` and the `backend-astropy` extra). The shim, the `importlib.metadata` version lookup, and the **`packaging` dependency** all go with it — `packaging` was a direct dependency solely to parse that version.

## Verification

- `pytest tests/unit src` — 2413 passed (includes sybil doctests over `src`)
- `name_of` spot-checked against astropy 7.2.0 on the paths the shim guarded:

  | dimension | name |
  |---|---|
  | `length` | `'length'` |
  | `speed` | `'speed'` |
  | `mass density` | `'mass density'` |
  | `length * (amount of substance)` (unknown) | `'m mol'` |

- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
