### PR TITLE
⚡️ perf(parametric): memoize the type-parameter inference path

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
@@ -31,9 +31,10 @@ def _dimension_of_unit(unit: AbstractUnit) -> AbstractDimension:
     (it carries `type[...]` class overloads, e.g.
     ``dimension_of(ParametricQuantity["length"])``),
     so `plum` cannot cache its method resolution and re-resolves on every call
-    (~60us). `__check_init__` and `__infer_type_parameter__` both run on every
-    `AbstractParametricQuantity` construction -- including every arithmetic
-    result -- so we memoize the unit -> dimension lookup here. Units are hashable
+    (~60us). `__check_init__` runs on every `AbstractParametricQuantity`
+    construction -- including every arithmetic result -- and
+    `__infer_type_parameter__` on every *unparametrized* one, so we memoize the
+    unit -> dimension lookup here. Units are hashable
     and the mapping is immutable, so the cache is sound; this mirrors the
     `dimension_of(AbstractUnit)` implementation
     (``dimension(unit.physical_type)``) while bypassing dispatch.

--- a/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
@@ -18,7 +18,7 @@ from dataclassish import field_items, fields
 from .config import config as parametric_config
 from unxt._src.dimensions import name_of
 from unxt.config import config
-from unxt.dims import AbstractDimension, dimension, dimension_of
+from unxt.dims import AbstractDimension, dimension
 from unxt.quantity import AbstractQuantity, StaticValue
 from unxt.units import AbstractUnit, unit as parse_unit
 
@@ -31,11 +31,20 @@ def _dimension_of_unit(unit: AbstractUnit) -> AbstractDimension:
     (it carries `type[...]` class overloads, e.g.
     ``dimension_of(ParametricQuantity["length"])``),
     so `plum` cannot cache its method resolution and re-resolves on every call
-    (~60us). `__check_init__` runs on every `AbstractParametricQuantity`
-    construction -- including every arithmetic result -- so we memoize the
-    unit -> dimension lookup here. Units are hashable and the mapping is
-    immutable, so the cache is sound; this mirrors the `dimension_of(AbstractUnit)`
-    implementation (``dimension(unit.physical_type)``) while bypassing dispatch.
+    (~60us). `__check_init__` and `__infer_type_parameter__` both run on every
+    `AbstractParametricQuantity` construction -- including every arithmetic
+    result -- so we memoize the unit -> dimension lookup here. Units are hashable
+    and the mapping is immutable, so the cache is sound; this mirrors the
+    `dimension_of(AbstractUnit)` implementation
+    (``dimension(unit.physical_type)``) while bypassing dispatch.
+
+    .. note::
+
+        This memo is a workaround, not a permanent fixture. Once plum makes
+        ``type[...]`` overloads cacheable (beartype/plum#290) `dimension_of`
+        resolves from cache like any other faithful function, and every caller
+        here can drop the memo and call `dimension_of` directly.
+
     """
     return dimension(unit.physical_type)
 
@@ -85,14 +94,14 @@ class AbstractParametricQuantity(AbstractQuantity):
         try:
             dims_ = dimension(dims)
         except ValueError:
-            dims_ = dimension_of(parse_unit(dims))
+            dims_ = _dimension_of_unit(parse_unit(dims))
         return (dims_,)
 
     @classmethod
     @dispatch
     def __init_type_parameter__(cls, unit: AbstractUnit, /) -> tuple[AbstractDimension]:
         """Infer the type parameter from the arguments."""
-        dims = dimension_of(unit)
+        dims = _dimension_of_unit(unit)
         if dims != "unknown":  # pylint: disable=unreachable
             return (dims,)
         return (PhysicalType(unit, unit.to_string(fraction=False)),)
@@ -102,7 +111,7 @@ class AbstractParametricQuantity(AbstractQuantity):
         cls, value: Any, unit: Any, **kwargs: Any
     ) -> tuple[AbstractDimension]:
         """Infer the type parameter from the arguments."""
-        return (dimension_of(parse_unit(unit)),)
+        return (_dimension_of_unit(parse_unit(unit)),)
 
     @classmethod
     @dispatch


### PR DESCRIPTION
From a ponytail-audit of `unxts.parametric`. One of 3 independent PRs; no ordering dependency.

## The gap

`_dimension_of_unit` is an `lru_cache` added *precisely* because `dimension_of` is a non-faithful plum function that re-resolves its methods on every call (~66 µs) — its docstring already explains this in full. But only `__check_init__` used it. `__infer_type_parameter__`, which runs on every **unparametrized** construction (the common user path), still called `dimension_of(parse_unit(unit))` directly.

So the reasoning was written down; it just hadn't been carried to the second call site. This routes it, plus the two parametrization-time `__init_type_parameter__` overloads, through the same memo.

## Measured

min-of-7, fresh processes, warmed up:

| | before | after | |
|---|---|---|---|
| `PQ(1.0, "m")` | 157.3 µs | **78.9 µs** | 2.0× |
| `PQ(1.0, unit("m"))` | 158.6 µs | **83.3 µs** | 1.9× |
| `PQ["length"](1.0, "m")` | 68.9 µs | 72.0 µs | control — skips inference |
| `Q(1.0, "m")` | 49.4 µs | 48.8 µs | control — unaffected |

Inference went from costing 2.3× the parametrized path to being nearly free. `pq + pq` is unchanged (~210 µs): arithmetic goes through `replace()`, which preserves the type parameter and never re-infers.

## Behaviour-preserving

`_dimension_of_unit` is `dimension(unit.physical_type)` — exactly what `dimension_of(AbstractUnit)` dispatches to. Rather than argue that, I compared the resulting `_type_parameter` against `upstream/main` directly, across length / time / mass / speed / dimensionless / angle / unknown units and all three parametrization spellings (`PQ[str]`, `PQ[unit]`, inferred), printing both `str()` and `name_of()`. Output byte-identical.

<details>
<summary>probe output (identical on both)</summary>

```
('m', 'length', 'length')
('s', 'time', 'time')
('kg', 'mass', 'mass')
('m/s', 'speed/velocity', 'speed')
('', 'dimensionless', 'dimensionless')
('m2 / (kg s2)', 'unknown', 'm2 kg-1 s-2')
('deg', 'angle', 'angle')
('[length]', 'length', 'length')
('[m2 kg-1 s-2]', 'unknown', 'm2 kg-1 s-2')
('[unit m]', 'length', 'length')
```
</details>

## The memo is temporary — noted in the source

Added to `_dimension_of_unit`'s docstring:

> This memo is a workaround, not a permanent fixture. Once plum makes `type[...]` overloads cacheable (beartype/plum#290) `dimension_of` resolves from cache like any other faithful function, and every caller here can drop the memo and call `dimension_of` directly.

## Verification

- `pytest packages/unxts.parametric/src` — 101 passed; `tests` — 74 passed; `docs` — 52 passed
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)