### PR TITLE
♻️ refactor(parametric): share the TOML apply path and the include_params trait

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/config.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/config.py
@@ -20,7 +20,7 @@ import tomllib
 from pathlib import Path
 from typing import Any, ClassVar, Final
 
-from traitlets import Bool, TraitError
+from traitlets import Bool, default
 from traitlets.config import SingletonConfigurable
 
 from unxt._src.config import (
@@ -28,36 +28,42 @@ from unxt._src.config import (
     LocalConfigurable,
     _find_pyproject,
     _load_toml_config_from_pyproject,
-    _override_keys,
+    apply_config_sections,
+    config_class_mapping,
 )
 
 
-class ParametricQuantityReprConfig(LocalConfigurable):
-    """``include_params`` for ``ParametricQuantity.__repr__`` (default ``False``).
+class AbstractParametricDisplayConfig(LocalConfigurable):
+    """The ``include_params`` display option shared by ``repr()`` and ``str()``.
+
+    Concrete subclasses set the default -- ``False`` for ``repr()`` (which
+    stays close to the constructor call) and ``True`` for ``str()`` (which
+    shows the dimension) -- and are distinct classes so a
+    `traitlets.config.Config` can address them separately by name. Mirrors
+    :class:`~unxt._src.config.AbstractQuantityDisplayConfig`.
 
     ``__getattribute__`` (thread-local override lookup) and ``override()`` (the
     context manager) are inherited from
-    :class:`~unxt._src.config.LocalConfigurable`; this class only declares its
-    overridable trait.
+    :class:`~unxt._src.config.LocalConfigurable`.
     """
 
     include_params: ClassVar[object] = Bool(
         default_value=False,
-        help="Include type parameters in repr for parametric quantities",
+        help="Include type parameters in the display of parametric quantities",
     ).tag(config=True)
 
 
-class ParametricQuantityStrConfig(LocalConfigurable):
-    """``include_params`` for ``ParametricQuantity.__str__`` (default ``True``).
+class ParametricQuantityReprConfig(AbstractParametricDisplayConfig):
+    """``include_params`` for ``ParametricQuantity.__repr__`` (default ``False``)."""
 
-    See :class:`ParametricQuantityReprConfig` — the override machinery is
-    inherited from :class:`~unxt._src.config.LocalConfigurable`.
-    """
 
-    include_params: ClassVar[object] = Bool(
-        default_value=True,
-        help="Include type parameters in str for parametric quantities",
-    ).tag(config=True)
+class ParametricQuantityStrConfig(AbstractParametricDisplayConfig):
+    """``include_params`` for ``ParametricQuantity.__str__`` (default ``True``)."""
+
+    @default("include_params")
+    def _include_params_default(self) -> bool:
+        """``str()`` shows the dimension parameter; ``repr()`` does not."""
+        return True
 
 
 class ParametricConfig(AbstractUnxtConfig, SingletonConfigurable):
@@ -109,16 +115,6 @@ _TOML_PATH_TO_CONFIG_CLASS: Final = {
     ("quantity", "str"): "ParametricQuantityStrConfig",
 }
 
-# Mapping from Config class name to config instance
-_CONFIG_CLASS_TO_INSTANCE: Final[dict[str, Any]] = {}
-
-
-def _initialize_config_mapping(cfg: ParametricConfig) -> None:
-    """Populate the class-name -> instance mapping (call after singleton init)."""
-    for name in cfg._override_sections:  # noqa: SLF001
-        instance = getattr(cfg, name)
-        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = instance
-
 
 def _auto_load_project_toml_config(cfg: ParametricConfig, /) -> None:
     """Auto-load ``[tool.unxts.parametric]`` config without import-time errors."""
@@ -135,24 +131,10 @@ def _auto_load_project_toml_config(cfg: ParametricConfig, /) -> None:
     except (OSError, tomllib.TOMLDecodeError, TypeError, KeyError):
         return
 
-    if not loaded:
-        return
-
-    for class_name, class_config in loaded.items():
-        if class_name not in _CONFIG_CLASS_TO_INSTANCE:
-            continue
-        config_instance = _CONFIG_CLASS_TO_INSTANCE[class_name]
-        valid_keys = _override_keys(type(config_instance))
-        for key, value in class_config.items():
-            if key not in valid_keys:
-                continue
-            try:
-                setattr(config_instance, key, value)
-            except (TraitError, AttributeError):
-                continue
+    if loaded:
+        apply_config_sections(loaded, config_class_mapping(cfg))
 
 
 # Create the global singleton instance
 config = ParametricConfig.instance()
-_initialize_config_mapping(config)
 _auto_load_project_toml_config(config)

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -726,14 +726,58 @@ def _config_from_toml_data(
 _CONFIG_CLASS_TO_INSTANCE: Final[dict[str, Any]] = {}
 
 
+def config_class_mapping(cfg: Any, /) -> dict[str, Any]:
+    """Map each nested section's config-class *name* to its instance on ``cfg``.
+
+    Shared with the satellite packages that mirror this config structure (e.g.
+    ``unxts.parametric``), which key their TOML sections by class name too.
+    """
+    return {
+        type(instance).__name__: instance
+        for instance in (
+            getattr(cfg, name)
+            for name in cfg._override_sections  # noqa: SLF001
+        )
+    }
+
+
+def apply_config_sections(loaded: Any, class_to_instance: dict[str, Any], /) -> bool:
+    """Apply loaded TOML sections to their config instances.
+
+    Returns whether any value was actually applied -- a non-empty section whose
+    keys are all unknown, or whose every ``setattr`` is rejected, must not
+    report success.
+
+    Unknown sections, unknown keys, and values traitlets rejects are all
+    skipped rather than raised: project configuration must never break an
+    import. Shared with the satellite packages that mirror this structure, so
+    the skip policy is defined once.
+    """
+    applied = False
+    for class_name, class_config in loaded.items():
+        instance = class_to_instance.get(class_name)
+        if instance is None:
+            continue
+
+        valid_keys = _override_keys(type(instance))
+        for key, value in class_config.items():
+            if key not in valid_keys:
+                continue
+            try:
+                setattr(instance, key, value)
+            except (TraitError, AttributeError):
+                continue
+            applied = True
+
+    return applied
+
+
 def _initialize_config_mapping(cfg: UnxtConfig) -> None:
     """Initialize the mapping from config class names to instances.
 
     This must be called after creating the UnxtConfig instance.
     """
-    for name in cfg._override_sections:  # noqa: SLF001
-        instance = getattr(cfg, name)
-        _CONFIG_CLASS_TO_INSTANCE[type(instance).__name__] = instance
+    _CONFIG_CLASS_TO_INSTANCE.update(config_class_mapping(cfg))
 
 
 def _warn_if_legacy_unxt_config(
@@ -791,27 +835,7 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -
     if not loaded:
         return False
 
-    # Apply config values using the mapping, tracking whether any value was
-    # actually applied (a non-empty section whose keys are all unknown or whose
-    # every ``setattr`` fails must not report success).
-    applied = False
-    for class_name, class_config in loaded.items():
-        if class_name not in _CONFIG_CLASS_TO_INSTANCE:
-            continue
-
-        config_instance = _CONFIG_CLASS_TO_INSTANCE[class_name]
-        valid_keys = _override_keys(type(config_instance))
-
-        for key, value in class_config.items():
-            if key not in valid_keys:
-                continue
-            try:
-                setattr(config_instance, key, value)
-            except (TraitError, AttributeError):
-                continue
-            applied = True
-
-    return applied
+    return apply_config_sections(loaded, _CONFIG_CLASS_TO_INSTANCE)
 
 
 # Create the global singleton instance


### PR DESCRIPTION
From a ponytail-audit of `unxts.parametric`. One of 3 independent PRs; no ordering dependency. Continues #822's cleanup across the package boundary.

## 1. The TOML apply loop was duplicated verbatim

After #822, unxt's `_auto_load_project_toml_config` and parametric's ended in the *same* 15-line loop — identical `_override_keys` lookup, identical `TraitError`/`AttributeError` skip, identical "unknown section / unknown key" handling. That loop encodes a policy (**project config must never break an import**), and having two copies of a policy is how they drift.

Extracted into `unxt._src.config` as `apply_config_sections`, with `config_class_mapping` for the class-name → instance map. Parametric drops its loop, its `_initialize_config_mapping`, and its `_CONFIG_CLASS_TO_INSTANCE` entirely.

## 2. The two config classes differed only in `default_value`

Same situation #822 fixed inside unxt, so this uses the same shape: an `AbstractParametricDisplayConfig` base holds the `include_params` trait, and `ParametricQuantityStrConfig` overrides the default via `@default`. They remain distinct classes so a `traitlets.config.Config` can still address them separately by name — the reason given in `AbstractQuantityDisplayConfig`'s docstring.

## Verification

The suites don't cover pyproject loading end to end, so I checked it directly: a temp project with non-default sections for **both** packages —

```toml
[tool.unxts.parametric.quantity.repr]
include_params = true
[tool.unxts.parametric.quantity.str]
include_params = false
[tool.unxts.unxt.quantity.repr]
short_arrays = "compact"
use_short_name = true
[tool.unxts.unxt.quantity.str]
indent = 2
```

— all five values load and apply correctly, and `repr(PQ([1,2,3], "m"))` becomes `PQ['length']([1, 2, 3], unit='m')`.

Plus:
- `pytest packages/unxts.parametric/src` — 101 passed; `tests` — 74 passed; `docs` — 52 passed
- `pytest tests/unit src docs` — 3335 passed (this touches `unxt._src.config`)
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)