### PR TITLE
⬆️ dep-bump(parametric): require astropy>=7.1, matching unxt

### DIFF
--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "astropy>=7.0.0",
+  "astropy>=7.1",
   "plum-dispatch>=2.5.7",
   "unxt>=2.0.0",
   "unxts.api>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4640,7 +4640,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astropy", specifier = ">=7.0.0" },
+    { name = "astropy", specifier = ">=7.1" },
     { name = "plum-dispatch", specifier = ">=2.5.7" },
     { name = "unxt", editable = "." },
     { name = "unxts-api", editable = "packages/unxts.api" },


### PR DESCRIPTION
Split out of #836 as requested — that PR is pure source reorganisation and needs no dependency change. This one is independent of it and can land in either order.

## Why the floor is stale, not just inconsistent

`unxts.parametric` declares `astropy>=7.0.0`. But `base_parametric.py:293` calls `unxt._src.dimensions.name_of` on the `__pdoc__` path — that is, on **every `str()` of a parametric quantity**, where `include_params` defaults to `True`.

Until #830, `name_of` carried an explicit version branch for exactly that call:

```python
elif ASTROPY_LT_71:
    name = dim._name_string_as_ordered_set().split("'")[1]
else:
    name = dim._physical_type[0]
```

#830 deleted the `<7.1` branch and raised **unxt's** floor to `>=7.1`, so `name_of` now reaches `dim._physical_type[0]` unconditionally — the ≥7.1 API. Parametric kept the 7.0 floor while calling the same function, so its declared floor now permits a pairing the code no longer supports.

## Scope of the claim

This is **not a live breakage**: a current `unxt` requires `astropy>=7.1`, and the resolver takes the max of the two floors, so a normal install already gets ≥7.1. What's wrong is the *declaration* — it no longer describes what the code needs. The `--resolution lowest-direct` CI job (ci.yml:566) is the kind of place a stale floor like this surfaces.

I'm citing the removed shim as the evidence rather than asserting the astropy 7.0 behaviour from memory — I don't have 7.0 installed here to demonstrate the failure directly.

## Verification

- `uv lock` regenerated; the only change is parametric's `astropy` specifier
- Full pre-commit suite passes (including the `uv-lock` consistency hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)