### PR TITLE
⚡️ perf(xarray): hoist the value converter and build with `_mk`

### DIFF
--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -17,7 +17,7 @@ from plum import dispatch
 from xarray import DataArray, Dataset, Variable
 
 import unxt as u
-from unxt.quantity import AllowValue
+from unxt.quantity import AllowValue, convert_to_quantity_value
 
 # Name of the attribute used to store units
 UNIT_ATTR: Final = "units"
@@ -71,7 +71,15 @@ def _array_attach_units(
         )
         raise ValueError(msg)
 
-    return u.Q(data, u.unit(unit))
+    # `_mk` is the unchecked constructor: it writes the fields, so neither field
+    # converter runs. The theorem it asks for is that both are redundant *here*,
+    # which holds because this line runs them itself. `convert_to_quantity_value`
+    # is the value field's own converter -- xarray hands over NumPy, so it is
+    # load-bearing and cannot be dropped, only hoisted -- and `u.unit` is the
+    # unit field's, so the converter would re-dispatch it on its own output for
+    # nothing. `Quantity` defines no `__check_init__` and is not an
+    # `AbstractParametricQuantity`, so nothing else is skipped: 55us -> 39us.
+    return u.Q._mk(value=convert_to_quantity_value(data), unit=u.unit(unit))  # noqa: SLF001
 
 
 def _consume_unit_attrs(obj: DataArray | Dataset, /) -> None:


### PR DESCRIPTION
## What

`_array_attach_units` ([conversion.py:74](https://github.com/GalacticDynamics/unxt/blob/main/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py#L74)) is the **only** Quantity construction in the package, and it sits on every `attach_units` / `.quantify()` call. Everything else strips (`u.ustrip`) or reads (`u.unit_of`); `accessors.py` just delegates.

## Why a bare `_mk` would be wrong here

Unlike #829, the value converter is **load-bearing**: xarray hands over `numpy.ndarray`, so skipping it stores a raw ndarray inside the Quantity —

```
u.Q(np_arr, m).value     -> ArrayImpl
u.Q._mk(np_arr, m).value -> ndarray   ← wrong
```

which is precisely what `revalue`'s debug assertion exists to catch.

So the converter is **hoisted, not dropped** — the call site runs it itself, and that is the theorem making `_mk` sound. What's actually saved is the *unit* converter (the call site already passes `u.unit(unit)`, so the field converter re-dispatches `u.unit` on its own output) plus the equinox init machinery. `Quantity` defines no `__check_init__` and is not an `AbstractParametricQuantity`, so nothing else is skipped.

Verified output-identical — type, pytree structure, dtype, `weak_type`, repr — across `ndarray`, `list`, `float`, `np.float64` and 2-D inputs.

## Numbers

| | before | after | |
|---|---|---|---|
| one build | 55.1 µs | 39.0 µs | **1.4x** |
| `attach_units(DataArray)` | 572 µs | 527 µs | 1.09x |
| `attach_units(Dataset, 5 vars)` | 1125 µs | 1013 µs | 1.11x |

Honest framing: the end-to-end share is modest — one construction site, and xarray's own `DataArray`/`Dataset` construction dominates. The floor is `jnp.asarray` at 18.5 µs of the 39.

## One thing to weigh

This is a **cross-package** private access — `unxts.interop.xarray` reaching into unxt's `_mk`, which is documented as "do not reach for directly without [a theorem]". Ruff flags it (SLF001) and I've used a targeted `# noqa` with the theorem stated inline, rather than widening the per-package ignore list.

Worth knowing: the same usage in #829 passed lint *silently*, because `packages/unxts.linalg/src/**` carries a blanket SLF001 exemption for `UnitsMatrix._units`. If you'd rather this coupling not exist for ~10%, say so and I'll close this — the reasoning is written down either way.

## Remaining headroom

Not `_mk`: ~19 µs of the 39 is plum dispatch inside `convert_to_quantity_value` itself — same theme as the `plum` return-conversion work.

## Testing

- `packages/unxts.interop.xarray/tests`: 17 passed
- `packages/unxts.interop.xarray/docs`: 33 passed
- rest of the suite: 3995 passed, 49 skipped, 20 xfailed
- `ruff check` / `format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)