### PR TITLE
⬆️ dep-bump: require `optional-dependencies>=0.4.1`, drop the `find_spec` fallbacks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 """Doctest configuration."""
 
-import importlib.util
 import os
 from collections.abc import Callable, Iterable, Sequence
 from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
@@ -15,6 +14,7 @@ from sybil.parsers.abstract.codeblock import PythonDocTestOrCodeBlockParser
 from sybil.parsers.abstract.doctest import DocTestStringParser
 
 from optional_dependencies import OptionalDependencyEnum, auto
+from optional_dependencies.utils import chain_checks, get_version, is_installed
 
 optionflags = ELLIPSIS | NORMALIZE_WHITESPACE
 
@@ -31,9 +31,11 @@ optionflags = ELLIPSIS | NORMALIZE_WHITESPACE
 # here makes *loading this conftest* fail, which pytest reports as a usage
 # error (exit code 4) before any test runs -- so it takes down every sibling
 # package job, not just the hypothesis-using ones.
-if importlib.util.find_spec("hypothesis") is not None:
+try:
     import hypothesis
-
+except ImportError:
+    pass
+else:
     hypothesis.settings.register_profile("unxt", deadline=None)
     hypothesis.settings.load_profile("unxt")
 
@@ -109,33 +111,23 @@ def pytest_collect_file(file_path: Path, parent: object) -> object:
 
 
 class OptDeps(OptionalDependencyEnum):
-    """External backends for ``unxt``.
+    """External backends and interop sub-packages for ``unxt``.
 
-    Only genuine third-party backends belong here. ``OptionalDependencyEnum``
-    keys each member on its installed version, so any two members that share a
-    version silently collapse into a single enum alias. unxt's own ``unxts.*``
-    sub-packages are released together and so usually share a version (bug-fix
-    releases can make them diverge), so their presence is checked with
-    ``_is_installed`` (an import-spec lookup via ``find_spec``) instead (see
-    ``unxt._interop.optional_deps`` for the same reasoning).
+    Declared locally (rather than importing the equivalent enum from ``unxt``)
+    so that ``conftest`` never imports ``unxt`` before ``pytest_generate_tests``
+    sets ``UNXT_ENABLE_RUNTIME_TYPECHECKING``.
     """
 
     ASTROPY = auto()
-    GALA = auto()
+    UNXTS_INTEROP_MATPLOTLIB = auto()
+    UNXTS_LINALG = auto()
+    UNXTS_PARAMETRIC = auto()
 
-
-def _is_installed(module: str) -> bool:
-    """Return whether ``module`` has a discoverable import spec.
-
-    Uses :func:`importlib.util.find_spec` (reports installed / findable, not that
-    importing would succeed). Defined locally (rather than importing the
-    equivalent helper from ``unxt``) so that ``conftest`` never imports ``unxt``
-    before ``pytest_generate_tests`` sets ``UNXT_ENABLE_RUNTIME_TYPECHECKING``.
-    """
-    try:
-        return importlib.util.find_spec(module) is not None
-    except (ImportError, ValueError):
-        return False
+    #: The gala interop extra is only usable with an importable gala backend;
+    #: gala is skipped where it cannot build (e.g. Windows).
+    UNXTS_INTEROP_GALA = chain_checks(
+        get_version("unxts.interop.gala"), is_installed("gala")
+    )
 
 
 collect_ignore_glob = []
@@ -143,19 +135,16 @@ if not OptDeps.ASTROPY.installed:
     collect_ignore_glob.append("src/unxt/_interop/unxt_interop_astropy/*")
 # The package docs are collected through the docs/packages/<name> symlinks, so
 # ignore that (symlink) path, not the real package path.
-# `unxts.interop.gala` is an optional extra, so it may be absent; and even when
-# it is present its `gala` dependency may be unimportable (gala is skipped where
-# it cannot build, e.g. Windows). Ignore its docs unless both are available.
-if not (_is_installed("unxts.interop.gala") and OptDeps.GALA.installed):
+if not OptDeps.UNXTS_INTEROP_GALA.installed:
     collect_ignore_glob.append("docs/packages/unxts.interop.gala/*")
     collect_ignore_glob.append("packages/unxts.interop.gala/docs/*")
-if not _is_installed("unxts.interop.matplotlib"):
+if not OptDeps.UNXTS_INTEROP_MATPLOTLIB.installed:
     collect_ignore_glob.append("docs/packages/unxts.interop.matplotlib/*")
     collect_ignore_glob.append("packages/unxts.interop.matplotlib/docs/*")
-if not _is_installed("unxts.linalg"):
+if not OptDeps.UNXTS_LINALG.installed:
     collect_ignore_glob.append("docs/packages/unxts.linalg/*")
     collect_ignore_glob.append("packages/unxts.linalg/docs/*")
-if not _is_installed("unxts.parametric"):
+if not OptDeps.UNXTS_PARAMETRIC.installed:
     collect_ignore_glob.append("docs/packages/unxts.parametric/*")
     collect_ignore_glob.append("packages/unxts.parametric/docs/*")
 

--- a/packages/unxt-api/pyproject.toml
+++ b/packages/unxt-api/pyproject.toml
@@ -36,7 +36,7 @@ requires      = ["hatch-vcs", "hatchling"]
 
 [dependency-groups]
 test = [
-  "optional-dependencies>=0.3.2",
+  "optional-dependencies>=0.4.1",
   "pytest>=8.4.2",
   "pytest-arraydiff>=0.6.1",
   "pytest-cov>=6.2.1",

--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -41,7 +41,7 @@ requires      = ["hatch-vcs", "hatchling"]
 # cycle); as a dev/test-group dependency the cycle is dev-only and uv resolves
 # it within the workspace.
 test = [
-  "optional-dependencies>=0.3.2",
+  "optional-dependencies>=0.4.1",
   "pytest>=8.4.2",
   "pytest-arraydiff>=0.6.1",
   "pytest-cov>=6.2.1",

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -42,7 +42,7 @@ requires      = ["hatch-vcs", "hatchling"]
 
 [dependency-groups]
 test = [
-  "optional-dependencies>=0.3.2",
+  "optional-dependencies>=0.4.1",
   "pytest>=8.4.2",
   "pytest-arraydiff>=0.6.1",
   "pytest-cov>=6.2.1",

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -41,7 +41,7 @@ requires      = ["hatch-vcs", "hatchling"]
 
 [dependency-groups]
 test = [
-  "optional-dependencies>=0.3.2",
+  "optional-dependencies>=0.4.1",
   "pytest>=8.4.2",
   "pytest-arraydiff>=0.6.1",
   "pytest-cov>=6.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "jax>=0.7.2",
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
-  "optional-dependencies>=0.3.2",
+  "optional-dependencies>=0.4.1",
   "plum-dispatch>=2.7.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",

--- a/src/unxt/_interop/__init__.py
+++ b/src/unxt/_interop/__init__.py
@@ -3,21 +3,17 @@
 
 __all__: tuple[str, ...] = ()
 
-from .optional_deps import OptDeps, is_installed
+from .optional_deps import OptDeps
 
 # Register interoperability
 if OptDeps.ASTROPY.installed:
     from . import unxt_interop_astropy
 
-# Require both the interop package and the gala backend to be importable.
-# `unxts.interop.gala` is an optional extra, and even when it is installed its
-# `gala` dependency is skipped where gala cannot build (e.g. Windows), so the
-# interop package can be present without an importable gala.
-if is_installed("unxts.interop.gala") and OptDeps.GALA.installed:
+if OptDeps.UNXTS_INTEROP_GALA.installed:  # implies an importable gala backend
     import unxts.interop.gala  # registers gala <-> unxt unitsystem conversions
 
-if is_installed("unxts.interop.matplotlib"):
+if OptDeps.UNXTS_INTEROP_MATPLOTLIB.installed:
     import unxts.interop.matplotlib  # registers the matplotlib unit converter
 
-if is_installed("unxts.interop.xarray"):
+if OptDeps.UNXTS_INTEROP_XARRAY.installed:
     import unxts.interop.xarray  # registers the `.unxt` xarray accessor

--- a/src/unxt/_interop/__init__.py
+++ b/src/unxt/_interop/__init__.py
@@ -5,15 +5,21 @@ __all__: tuple[str, ...] = ()
 
 from .optional_deps import OptDeps
 
-# Register interoperability
-if OptDeps.ASTROPY.installed:
+# Register interoperability.
+#
+# `no branch`: each gate is an import-time environment check, so within one
+# process only the arm matching the installed extras can ever run -- the other
+# is exercised by a CI job with a different env, in a separate coverage run.
+# `OptDeps` itself is what decides these, and it is covered directly by
+# `tests/unit/test_optional_deps.py`.
+if OptDeps.ASTROPY.installed:  # pragma: no branch
     from . import unxt_interop_astropy
 
-if OptDeps.UNXTS_INTEROP_GALA.installed:  # implies an importable gala backend
+if OptDeps.UNXTS_INTEROP_GALA.installed:  # pragma: no branch  # implies gala
     import unxts.interop.gala  # registers gala <-> unxt unitsystem conversions
 
-if OptDeps.UNXTS_INTEROP_MATPLOTLIB.installed:
+if OptDeps.UNXTS_INTEROP_MATPLOTLIB.installed:  # pragma: no branch
     import unxts.interop.matplotlib  # registers the matplotlib unit converter
 
-if OptDeps.UNXTS_INTEROP_XARRAY.installed:
+if OptDeps.UNXTS_INTEROP_XARRAY.installed:  # pragma: no branch
     import unxts.interop.xarray  # registers the `.unxt` xarray accessor

--- a/src/unxt/_interop/optional_deps.py
+++ b/src/unxt/_interop/optional_deps.py
@@ -1,44 +1,28 @@
 """Optional dependencies. Internal use only."""
 
-__all__ = ("OptDeps", "is_installed")
-
-import importlib.util
+__all__ = ("OptDeps",)
 
 from optional_dependencies import OptionalDependencyEnum, auto
+from optional_dependencies.utils import chain_checks, get_version, is_installed
 
 
 class OptDeps(OptionalDependencyEnum):  # type: ignore[misc]  # pylint: disable=invalid-enum-extension
-    """Optional external backends for ``unxt``.
+    """Optional backends and interop sub-packages for ``unxt``.
 
-    Only genuine third-party backends belong here. :class:`OptDeps` keys each
-    member on its installed *version*, so any two members that share a version
-    silently collapse into a single enum alias. Version is therefore an unsafe
-    key for distinguishing packages: unxt's own ``unxts.*`` sub-packages are
-    released together and so usually share a version (independent bug-fix
-    releases can make them diverge), so their presence is detected with
-    :func:`is_installed` (an import-spec lookup via ``find_spec``) instead,
-    resolving each module by name independent of version.
+    ``optional-dependencies`` >= 0.4.1 keys members on an identity-based
+    wrapper, so members resolving to the same version (or both uninstalled) no
+    longer collapse into an alias. unxt's own ``unxts.*`` sub-packages are
+    released together and so usually share a version; before that fix they had
+    to be detected separately.
     """
 
     ASTROPY = auto()
-    GALA = auto()
+    UNXTS_INTEROP_MATPLOTLIB = auto()
+    UNXTS_INTEROP_XARRAY = auto()
 
-
-def is_installed(module: str) -> bool:
-    """Return whether ``module`` has a discoverable import spec.
-
-    Uses :func:`importlib.util.find_spec`, so it reports whether the module is
-    installed / findable -- not whether importing it would succeed (its own
-    dependencies may be missing; e.g. ``unxts.interop.gala`` has a spec even
-    where ``gala`` itself cannot be imported, which is why the gala guard also
-    checks ``OptDeps.GALA.installed``).
-
-    Used to detect unxt's optional interop sub-packages (``unxts.interop.*``),
-    which cannot be reliably told apart by :class:`OptDeps` -- its members alias
-    whenever they share a version, which the co-released ``unxts.*`` packages
-    usually do (though independent bug-fix releases can make them diverge).
-    """
-    try:
-        return importlib.util.find_spec(module) is not None
-    except (ImportError, ValueError):
-        return False
+    #: The gala interop extra is only usable with an importable gala backend:
+    #: the extra can be installed while gala itself is not, since gala is
+    #: skipped where it cannot build (e.g. Windows).
+    UNXTS_INTEROP_GALA = chain_checks(
+        get_version("unxts.interop.gala"), is_installed("gala")
+    )

--- a/tests/unit/test_optional_deps.py
+++ b/tests/unit/test_optional_deps.py
@@ -2,66 +2,33 @@
 
 import pytest
 
-from unxt._interop.optional_deps import OptDeps, is_installed
+from unxt._interop.optional_deps import OptDeps
 
 
-class TestOptDepsExcludesNamespacePackages:
-    """`OptDeps` must not contain unxt's own version-colliding `unxts.*`."""
+def test_no_members_alias() -> None:
+    """Every declared member is its own member, not an alias of an earlier one.
 
-    def test_optdeps_has_no_unxts_members(self) -> None:
-        """Guard against reintroducing ``unxts.*`` packages into ``OptDeps``.
-
-        ``OptionalDependencyEnum`` keys each member on its installed *version*,
-        so any two members that share a version silently collapse into one enum
-        alias. unxt's own ``unxts.*`` packages are released together and so
-        typically share a version; that is the concrete aliasing this PR fixed
-        (matplotlib/xarray aliasing gala). They must be detected with
-        ``is_installed`` instead of being ``OptDeps`` members.
-
-        Asserting on the aliasing directly (``len(__members__) == len(OptDeps)``)
-        is version/environment-dependent, so assert the underlying invariant: no
-        member is a ``unxts.*`` package.
-        """
-        offenders = [n for n in OptDeps.__members__ if n.startswith("UNXTS")]
-        assert not offenders, (
-            "unxts.* packages must not be OptDeps members (they alias by shared "
-            f"version); detect them with is_installed() instead. Found: {offenders}"
-        )
+    ``optional-dependencies`` < 0.4.1 keyed members on their resolved version,
+    so co-released packages (unxt's own ``unxts.*``) and any two uninstalled
+    packages silently collapsed into a single member -- reporting the wrong
+    package's state. 0.4.1 keys on an identity wrapper instead.
+    """
+    assert len(OptDeps.__members__) == len(list(OptDeps))
 
 
-class TestIsInstalled:
-    """`is_installed` detects modules by import-spec discovery (`find_spec`)."""
+@pytest.mark.parametrize(
+    ("member", "module"),
+    [
+        (OptDeps.UNXTS_INTEROP_GALA, "unxts.interop.gala"),
+        (OptDeps.UNXTS_INTEROP_MATPLOTLIB, "unxts.interop.matplotlib"),
+        (OptDeps.UNXTS_INTEROP_XARRAY, "unxts.interop.xarray"),
+    ],
+)
+def test_detects_interop_package_independently(member: OptDeps, module: str) -> None:
+    """Same-versioned interop packages are each detected on their own.
 
-    def test_returns_true_for_an_installed_module(self) -> None:
-        """A module with a discoverable import spec reports as installed."""
-        assert is_installed("unxt") is True
-        assert is_installed("importlib.util") is True
-
-    def test_returns_false_for_absent_module(self) -> None:
-        """A module without a discoverable spec reports as not installed."""
-        assert is_installed("unxts.interop.does_not_exist") is False
-        assert is_installed("unxt._this_module_does_not_exist_xyz") is False
-
-    def test_returns_false_when_find_spec_raises(self) -> None:
-        """A malformed path (parent is not a package) is caught, not raised.
-
-        ``importlib.util.find_spec("os.foo")`` raises ``ModuleNotFoundError``
-        because ``os`` is a module, not a package; ``is_installed`` swallows it.
-        """
-        assert is_installed("os.nonexistent_sub") is False
-
-    @pytest.mark.parametrize(
-        "module",
-        ["unxts.interop.gala", "unxts.interop.matplotlib", "unxts.interop.xarray"],
-    )
-    def test_detects_interop_package_independently(self, module: str) -> None:
-        """Same-versioned interop packages are each detected on their own.
-
-        This is the behaviour the version-keyed enum could not provide: the
-        import spec is resolved per-module, so packages sharing a version never
-        collapse together. The interop packages are optional extras;
-        ``pytest.importorskip`` skips the case where the module can't be
-        imported (e.g. the extra isn't installed).
-        """
-        pytest.importorskip(module)
-        assert is_installed(module) is True
+    These are optional extras, so ``importorskip`` skips the case where the
+    module isn't installed.
+    """
+    pytest.importorskip(module)
+    assert member.installed is True

--- a/tests/unit/test_optional_deps.py
+++ b/tests/unit/test_optional_deps.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from optional_dependencies import OptionalDependencyEnum, auto
+from optional_dependencies.utils import is_installed
+
 from unxt._interop.optional_deps import OptDeps
 
 
@@ -9,17 +12,35 @@ def test_no_members_alias() -> None:
     """Every declared member is its own member, not an alias of an earlier one.
 
     ``optional-dependencies`` < 0.4.1 keyed members on their resolved version,
-    so co-released packages (unxt's own ``unxts.*``) and any two uninstalled
-    packages silently collapsed into a single member -- reporting the wrong
-    package's state. 0.4.1 keys on an identity wrapper instead.
+    so co-released packages (unxt's own ``unxts.*``) silently collapsed into a
+    single member, reporting the wrong package's state. 0.4.1 keys on an
+    identity wrapper instead.
     """
     assert len(OptDeps.__members__) == len(list(OptDeps))
+
+
+def test_absent_packages_do_not_alias() -> None:
+    """Two *uninstalled* members stay distinct.
+
+    The other half of the pre-0.4.1 aliasing: every absent package resolved to
+    the same ``NOT_INSTALLED`` sentinel, so the second one folded into the
+    first. Asserted on a throwaway enum because it needs packages that are
+    guaranteed absent, which ``OptDeps`` (deliberately) has none of.
+    """
+
+    class Absent(OptionalDependencyEnum):
+        NO_SUCH_PACKAGE_A = auto()
+        NO_SUCH_PACKAGE_B = auto()
+
+    assert not Absent.NO_SUCH_PACKAGE_A.installed
+    assert not Absent.NO_SUCH_PACKAGE_B.installed
+    assert Absent.NO_SUCH_PACKAGE_A is not Absent.NO_SUCH_PACKAGE_B
+    assert len(Absent.__members__) == len(list(Absent))
 
 
 @pytest.mark.parametrize(
     ("member", "module"),
     [
-        (OptDeps.UNXTS_INTEROP_GALA, "unxts.interop.gala"),
         (OptDeps.UNXTS_INTEROP_MATPLOTLIB, "unxts.interop.matplotlib"),
         (OptDeps.UNXTS_INTEROP_XARRAY, "unxts.interop.xarray"),
     ],
@@ -32,3 +53,15 @@ def test_detects_interop_package_independently(member: OptDeps, module: str) -> 
     """
     pytest.importorskip(module)
     assert member.installed is True
+
+
+def test_gala_member_requires_the_gala_backend() -> None:
+    """``UNXTS_INTEROP_GALA`` carries *both* halves of the gala condition.
+
+    The member is built with ``chain_checks`` because the interop extra can be
+    installed while gala itself is not -- gala is skipped where it cannot build
+    (e.g. the Windows CI job), and that is the env where dropping the second
+    check would show up as a wrongly-`True` member.
+    """
+    expected = is_installed("unxts.interop.gala") and is_installed("gala")
+    assert OptDeps.UNXTS_INTEROP_GALA.installed is expected

--- a/uv.lock
+++ b/uv.lock
@@ -2411,14 +2411,14 @@ wheels = [
 
 [[package]]
 name = "optional-dependencies"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/9a/01c2aaee8ec00abe3dd51368c8a8c341b4352c1b23859d862edd62bd7ae5/optional_dependencies-0.4.0.tar.gz", hash = "sha256:8c2a764021ec47466a9c0375608d6976aa7f0d87f9a611e511ae70861edbd921", size = 68226, upload-time = "2025-09-03T03:32:23.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/42/8344ac009b7ba239b5bd82387aa5ab459dd7f706b80d73692ca6e31a2c95/optional_dependencies-0.4.1.tar.gz", hash = "sha256:8f71acbef015b08945e78fa531630290375d089d06de1d475567634991cb8160", size = 85720, upload-time = "2026-08-07T00:31:45.722Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/1c/c03aa5a23a3320f8b2875e1ddf6db679412533d95da2ebee15bfe611c1e3/optional_dependencies-0.4.0-py3-none-any.whl", hash = "sha256:aa5e4c2939681cf6b5f38de9ed7cdd60647526076452c29fbe170335fe34bf4a", size = 8551, upload-time = "2025-09-03T03:32:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a3/7810502242eba30a288c0e79c5a395c1ec6ed41a4eab6e5b3c8e3cf4ee20/optional_dependencies-0.4.1-py3-none-any.whl", hash = "sha256:f1ceb198a9154f6bdbf6295df663b4b91edebe5dc3d8678c03df3fbb985c1545", size = 10132, upload-time = "2026-08-07T00:31:44.53Z" },
 ]
 
 [[package]]
@@ -4174,7 +4174,7 @@ requires-dist = [
     { name = "jax", extras = ["k8s"], marker = "extra == 'k8s'", specifier = ">=0.7.2" },
     { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jaxtyping", specifier = ">=0.3.9" },
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "plum-dispatch", specifier = ">=2.7.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.2" },
@@ -4356,7 +4356,7 @@ requires-dist = [{ name = "unxts-api", editable = "packages/unxts.api" }]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -4421,7 +4421,7 @@ requires-dist = [{ name = "plum-dispatch", specifier = ">=2.5.7" }]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -4608,7 +4608,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -4648,7 +4648,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },


### PR DESCRIPTION
## What

[`optional-dependencies` 0.4.1](https://pypi.org/project/optional-dependencies/) fixes the member-aliasing bug that forced unxt to detect its own `unxts.*` sub-packages outside of `OptDeps`. This adopts the fix and deletes the workaround.

## Why

`OptionalDependencyEnum` used to key each member on its resolved *version*. `enum` folds any member whose value compares equal to an earlier one into an alias — silently — so:

- unxt's `unxts.*` sub-packages are released together and usually share a version, so `UNXTS_INTEROP_MATPLOTLIB`/`UNXTS_INTEROP_XARRAY` aliased `UNXTS_INTEROP_GALA` and reported the wrong package's state;
- any two *uninstalled* members shared the `NOT_INSTALLED` sentinel and collapsed the same way.

So they were detected with a hand-rolled `is_installed()` (an `importlib.util.find_spec` lookup), duplicated in `unxt._interop.optional_deps` and in `conftest`. 0.4.1 keys members on an identity wrapper, so neither collapse happens.

## Changes

- `optional-dependencies>=0.3.2` → `>=0.4.1` in the root and the four package `pyproject.toml`s.
- The `unxts.*` interop packages become ordinary `OptDeps` members; both copies of `is_installed` are deleted.
- The two-part gala guard folds into its member with the library's own `chain_checks` — the interop extra can be installed without an importable `gala` (gala is skipped where it cannot build, e.g. Windows), so `UNXTS_INTEROP_GALA` now carries both conditions and call sites are a plain `.installed` check. `OptDeps.GALA` had no other user and is gone.
- The `conftest` hypothesis probe becomes `try/except ImportError`, removing the last `importlib` use in that file.
- `tests/unit/test_optional_deps.py`: the old test asserted `unxts.*` must **not** be `OptDeps` members (the workaround's invariant). Inverted to assert no member aliases — `len(__members__) == len(list(OptDeps))` — plus per-package detection cases.

## Verification

- `pytest tests/ docs`: `1900 passed, 49 skipped, 20 xfailed`
- `pre-commit run --all-files`: clean (incl. pyright/ty/mypy typing guards)
- Confirmed against 0.4.1 directly that co-versioned members and two `NOT_INSTALLED` members each stay distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)