### PR TITLE
⚡️ perf(quantity): restore dispatch caching on the value converter

### DIFF
--- a/src/unxt/_src/quantity/value.py
+++ b/src/unxt/_src/quantity/value.py
@@ -363,8 +363,14 @@ def convert_to_quantity_value(obj: quax.ArrayValue, /) -> Any:
     return obj
 
 
+# NB: the ``list`` / ``tuple`` members are deliberately *unparametrized*. A
+# subscripted generic is not "faithful" in plum, and one unfaithful signature
+# disables method caching for the whole function -- which here is the
+# ``converter=`` on every quantity's ``value`` field, so it runs on every
+# construction. ``list`` and ``list[Any]`` match exactly the same values;
+# only the caching differs.
 @plum.dispatch
-def convert_to_quantity_value(obj: ArrayLike | list[Any] | tuple[Any, ...], /) -> Array:
+def convert_to_quantity_value(obj: ArrayLike | list | tuple, /) -> Array:
     """Convert an array-like object to a `jax.numpy.ndarray`.
 
     >>> import jax.numpy as jnp
@@ -382,7 +388,7 @@ def convert_to_quantity_value(obj: ArrayLike | list[Any] | tuple[Any, ...], /) -
     # quaxed one), which converts a weak Python scalar into a *weak* ``jax.Array``
     # -- passing an explicit ``dtype`` would force ``weak_type=False`` and make
     # ``Quantity(1.0, ...)`` over-promote relative to native JAX.
-    if not isinstance(out, jax.Array):
+    if not isinstance(out, jax.Array):  # pragma: no cover -- jax-version guard
         out = jax.numpy.asarray(out)
 
     return out


### PR DESCRIPTION
Found by a repo-wide plum-faithfulness sweep while auditing the remaining packages. This one is in **core unxt**, on the quantity construction path.

## The problem

`convert_to_quantity_value` is the `converter=` on every quantity's `value` field — it runs on **every construction**. Its signature was:

```python
def convert_to_quantity_value(obj: ArrayLike | list[Any] | tuple[Any, ...], /) -> Array:
```

A *subscripted* generic is not "faithful" in plum, and one unfaithful signature disables method caching for the whole function, which then re-resolves its methods on every call.

`list` and `list[Any]` match exactly the same values — only the caching differs.

## Verified per-member

Rather than assume which part of the union was at fault, I checked each with a fresh `Dispatcher`:

```
jax.Array                            faithful=True
np.ndarray                           faithful=True
list / tuple                         faithful=True
list[Any] / tuple[Any, ...]          faithful=False
ArrayLike                            faithful=True
ArrayLike|list|tuple                 faithful=True     <- after
ArrayLike|list[Any]|tuple[Any,...]   faithful=False    <- before
```

(My first pass at this probe was wrong twice — once by registering every type onto one accumulating plum `Function`, and once by running without `unxt` imported so `jax.Array` hadn't been marked faithful. Both made the fix look useless. The numbers above are from the corrected probe.)

## Measured

min-of-7, fresh processes, warmed up:

| | before | after | |
|---|---|---|---|
| `ctv(<jax array>)` | 23.6 µs | **15.1 µs** | 1.56× |
| `ctv(1.0)` | 33.6 µs | **23.8 µs** | 1.41× |
| `ctv([1, 2, 3])` | 54.9 µs | **50.9 µs** | 1.08× |
| `Q(1.0, "m")` | 56.7 µs | **45.1 µs** | 1.26× |
| `Q([1, 2, 3], "m")` | 86.8 µs | **74.0 µs** | 1.17× |

## Dispatch unchanged

float / int / bool / list / tuple / `np.ndarray` / `jax.Array` / complex all convert to the same type and dtype as before, and `weak_type` on scalar construction is preserved (`Quantity(Array(1., dtype=float32, weak_type=True), unit='m')`).

## Verification

- `pytest tests/unit src` — 2436 passed, 2 failed
- ⚠️ Those 2 failures (`test_optional_deps.py::test_no_members_alias`, `::test_absent_packages_do_not_alias`) are **pre-existing on a pristine `upstream/main`** — I confirmed in a clean worktree before attributing them. They look related to #846 dropping the `find_spec` fallbacks; unrelated to this PR, but worth a look.
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)