### PR TITLE
⚡️ perf(xarray): restore dispatch caching on `attach_units`

### DIFF
--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/conversion.py
@@ -268,35 +268,54 @@ def extract_units(obj: object, /) -> dict:
     raise TypeError(msg)
 
 
-def _reject_unknown_unit_names(
+#: What a unit mapping is allowed to carry as a value.
+_UNIT_VALUE_TYPES: Final = (u.AbstractUnit, str, type(None))
+
+
+def _validate_units(
     units: "Mapping[Hashable, Any]", valid_names: "set[Any]", obj_kind: str
 ) -> None:
-    """Raise if units names something that is not a variable/coordinate.
+    """Reject a unit mapping with unknown names or non-unit values.
 
-    Without this, a typo in a **unit_kwargs name (e.g.
-    quantify(temperatrue="K")) is silently dropped by units.get(name),
+    *Names*: without this, a typo in a ``**unit_kwargs`` name (e.g.
+    ``quantify(temperatrue="K")``) is silently dropped by ``units.get(name)``,
     leaving the data unquantified with no error or warning.
+
+    *Values*: this replaces what the parametrized
+    ``Mapping[Hashable, AbstractUnit | str | None]`` annotation used to do at
+    dispatch time. That annotation made the whole ``attach_units`` plum function
+    non-faithful -- disabling its method caching -- and its failure mode was to
+    fall through to the ``object`` overload, whose message blames the *object*'s
+    type rather than naming the offending unit value.
     """
     # Sort so the message is deterministic: `units` insertion order follows the
     # accessor's ``set(...)`` iteration, which is not stable across processes.
     unknown = sorted(repr(k) for k in units if k not in valid_names)
-    if not unknown:
-        return
-    # ``None`` is the DataArray's own-data key; render it explicitly so the
-    # message stays helpful (and non-empty) when there are no other names.
-    names = ("None (the data)" if n is None else repr(n) for n in valid_names)
-    valid = ", ".join(sorted(names)) or "(none)"
-    msg = (
-        f"got unit(s) for name(s) not in the {obj_kind}: {', '.join(unknown)}. "
-        f"Valid names: {valid}."
+    if unknown:
+        # ``None`` is the DataArray's own-data key; render it explicitly so the
+        # message stays helpful (and non-empty) when there are no other names.
+        names = ("None (the data)" if n is None else repr(n) for n in valid_names)
+        valid = ", ".join(sorted(names)) or "(none)"
+        msg = (
+            f"got unit(s) for name(s) not in the {obj_kind}: {', '.join(unknown)}. "
+            f"Valid names: {valid}."
+        )
+        raise ValueError(msg)
+
+    bad = sorted(
+        f"{'None (the data)' if k is None else repr(k)} -> {type(v).__name__}"
+        for k, v in units.items()
+        if not isinstance(v, _UNIT_VALUE_TYPES)
     )
-    raise ValueError(msg)
+    if bad:
+        msg = (
+            f"unit values must be a unit, a unit string, or None; got {', '.join(bad)}."
+        )
+        raise TypeError(msg)
 
 
 @dispatch
-def attach_units(
-    obj: DataArray, units: Mapping[Hashable, u.AbstractUnit | str | None]
-) -> DataArray:
+def attach_units(obj: DataArray, units: Mapping) -> DataArray:
     """Attach units to a DataArray's variables.
 
     Parameters
@@ -329,7 +348,7 @@ def attach_units(
     {}
 
     """
-    _reject_unknown_unit_names(units, {None} | set(obj.coords), "DataArray")
+    _validate_units(units, {None} | set(obj.coords), "DataArray")
 
     # Handle the data array itself (None key = the DataArray's own data)
     data_unit = units.get(None)
@@ -363,9 +382,7 @@ def attach_units(
 
 
 @dispatch
-def attach_units(
-    obj: Dataset, units: Mapping[Hashable, u.AbstractUnit | str | None]
-) -> Dataset:
+def attach_units(obj: Dataset, units: Mapping) -> Dataset:
     """Attach units to a Dataset's variables.
 
     Parameters
@@ -381,7 +398,7 @@ def attach_units(
         New Dataset with units attached as Quantities.
 
     """
-    _reject_unknown_unit_names(units, set(obj.data_vars) | set(obj.coords), "Dataset")
+    _validate_units(units, set(obj.data_vars) | set(obj.coords), "Dataset")
 
     # Handle all variables in dataset
     new_vars = {}


### PR DESCRIPTION
From a ponytail-audit of the remaining unaudited packages. Same mechanism as #849 and #825, in `unxts.interop.xarray`.

## The problem

Both `attach_units` overloads annotated `units` as `Mapping[Hashable, AbstractUnit | str | None]`. A *subscripted* generic is not "faithful" in plum, so this one annotation disabled method caching for the whole function.

## But the parametrization was load-bearing

I checked before removing it. beartype samples the mapping's values at dispatch, so `attach_units(da, {None: 5})` currently **doesn't match** either typed overload and falls through to `attach_units(obj: object, units: Mapping)`. That's accidental validation, and its message blames the wrong argument:

```
TypeError: Cannot attach units to type: <class 'xarray.core.dataarray.DataArray'>
```

Dropping the annotation naively would have surfaced a raw `NotFoundLookupError: `unit(5)` could not be resolved` from plum internals — worse for a public API.

So the check moves into the code, alongside the sibling name check both overloads already run first. `_reject_unknown_unit_names` becomes `_validate_units` and rejects unknown names *and* non-unit values:

```
TypeError: unit values must be a unit, a unit string, or None; got None (the data) -> int.
TypeError: unit values must be a unit, a unit string, or None; got 'a' -> int.
```

Strictly better than both the old accidental message and the raw plum error — it names the offending key and its type.

## Measured

min-of-5, warmed:

| | before | after | |
|---|---|---|---|
| `attach_units(da, ...)` | 230.2 µs | **151.1 µs** | 1.52× |
| `attach_units(ds, ...)` | 417.9 µs | **338.0 µs** | 1.24× |

For scale: the already-faithful `strip_units(da)` is 38.7 µs and `extract_units(da)` is 18.0 µs on comparable work — the gap was dispatch, not the conversion itself.

## Verification

- `pytest packages/unxts.interop.xarray/tests` — 28 passed; `docs` — 33 passed; `src --doctest-modules` (CI's namespace-aware invocation) — 11 passed
- Error-path probe covering bad int / bad list / bad Dataset value / unknown name / good str / good None / good unit object
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)