### PR TITLE
♻️ refactor(hypothesis): share `draw_if_strategy`, use `.map()` for named_dimensions

### DIFF
--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/_utils.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/_utils.py
@@ -1,0 +1,14 @@
+"""Shared helpers for the `unxts.hypothesis` strategies."""
+
+__all__: tuple[str, ...] = ()
+
+from hypothesis import strategies as st
+
+
+def draw_if_strategy[T](draw: st.DrawFn, v: T | st.SearchStrategy[T], /) -> T:
+    """Draw a value if a strategy is given, else return the value.
+
+    Every public strategy here accepts either a concrete value or a strategy
+    that generates one, so each would otherwise repeat this conditional.
+    """
+    return draw(v) if isinstance(v, st.SearchStrategy) else v

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/dimensions.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/dimensions.py
@@ -153,8 +153,7 @@ DIMENSION_NAMES: Final[tuple[str, ...]] = (
 )
 
 
-@st.composite
-def named_dimensions(draw: st.DrawFn) -> u.AbstractDimension:
+def named_dimensions() -> st.SearchStrategy[u.AbstractDimension]:
     """Generate a named dimension from Astropy's physical type catalogue.
 
     This strategy samples from a finalized, pre-computed set of 134 named
@@ -165,15 +164,10 @@ def named_dimensions(draw: st.DrawFn) -> u.AbstractDimension:
     excludes names that cannot be directly interpreted by unxt (e.g., names
     with parenthetical qualifiers like "electrical charge (EMU)").
 
-    Parameters
-    ----------
-    draw : st.DrawFn
-        Hypothesis draw function (automatically provided by @st.composite).
-
     Returns
     -------
-    unxt.AbstractDimension
-        A randomly selected dimension from the set of named dimensions.
+    st.SearchStrategy[unxt.AbstractDimension]
+        A strategy sampling from the set of named dimensions.
 
     Examples
     --------
@@ -224,5 +218,7 @@ def named_dimensions(draw: st.DrawFn) -> u.AbstractDimension:
     quantities : Generate quantities with a specific dimension.
 
     """
-    name = draw(st.sampled_from(DIMENSION_NAMES))
-    return u.dimension(name)
+    # ``sampled_from(...).map(...)`` is the built-in form of "pick a name, then
+    # convert it"; a ``@st.composite`` wrapper would only re-implement it, and
+    # shrinking still works through the underlying ``sampled_from``.
+    return st.sampled_from(DIMENSION_NAMES).map(u.dimension)

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/quantities.py
@@ -10,15 +10,11 @@ from hypothesis import strategies as st
 from hypothesis.extra.array_api import make_strategies_namespace
 
 import unxt as u
+from ._utils import draw_if_strategy
 from .units import units
 
 # Create array API strategies namespace for JAX
 xps = make_strategies_namespace(jnp)
-
-
-def draw_if_strategy[T](draw: st.DrawFn, v: T | st.SearchStrategy[T], /) -> T:
-    """Draw a value if a strategy is given, else return the value."""
-    return draw(v) if isinstance(v, st.SearchStrategy) else v
 
 
 @st.composite

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/units.py
@@ -8,6 +8,7 @@ import astropy.units as apyu
 from hypothesis import strategies as st
 
 import unxt as u
+from ._utils import draw_if_strategy
 from .dimensions import named_dimensions
 
 
@@ -82,7 +83,7 @@ def derived_units(
 
     """
     # Convert base to a unit if it's a string or draw from strategy
-    base_unit = u.unit(draw(base) if isinstance(base, st.SearchStrategy) else base)
+    base_unit = u.unit(draw_if_strategy(draw, base))
 
     # Collect all possible unit forms
     # 1. Start with the base unit
@@ -218,11 +219,7 @@ def units(
 
     """
     # Convert to Dimension object, drawing if necessary
-    dimension = (
-        u.dimension(draw(dimension))
-        if isinstance(dimension, st.SearchStrategy)
-        else u.dimension(dimension)
-    )
+    dimension = u.dimension(draw_if_strategy(draw, dimension))
 
     # Get the canonical unit for this dimension
     base_unit = dimension._unit  # noqa: SLF001

--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
@@ -5,6 +5,7 @@ __all__ = ("unitsystems",)
 from hypothesis import strategies as st
 
 import unxt as u
+from ._utils import draw_if_strategy
 
 
 @st.composite
@@ -64,9 +65,7 @@ def unitsystems(
 
     """
     # Process each unit argument
-    unit_objs = [
-        u.unit(draw(x) if isinstance(x, st.SearchStrategy) else x) for x in units
-    ]
+    unit_objs = [u.unit(draw_if_strategy(draw, x)) for x in units]
     # Create and return the unit system
     return u.unitsystem(*unit_objs)
 


### PR DESCRIPTION
From a ponytail-audit of `unxts.hypothesis`. Small consistency cleanup — **not** a perf change, see below.

## 1. `draw_if_strategy` was defined once and hand-rolled three times

Every public strategy here accepts either a concrete value or a strategy producing one. `quantities.py` factored that into `draw_if_strategy` and uses it at 8 sites; `units.py` (×2) and `unitsystems.py` open-coded the same conditional. The `units()` one also repeated `u.dimension(...)` on *both* branches:

```diff
-    dimension = (
-        u.dimension(draw(dimension))
-        if isinstance(dimension, st.SearchStrategy)
-        else u.dimension(dimension)
-    )
+    dimension = u.dimension(draw_if_strategy(draw, dimension))
```

The helper moves to `_src/_utils.py` — `quantities.py` imports from `units.py`, so it couldn't stay where it was without a cycle. That's +1 file, which I'd normally avoid for ~4 lines, but three of the four strategy modules consume it and there's no other cycle-free home.

## 2. `named_dimensions` was a `@st.composite` re-implementing `.map()`

It drew one sample and converted it — which is what hypothesis's `.map()` already is:

```python
return st.sampled_from(DIMENSION_NAMES).map(u.dimension)
```

Shrinking still works through the underlying `sampled_from`: `find(named_dimensions(), lambda d: True)` shrinks to `absement`, the first entry in `DIMENSION_NAMES`.

## Not a perf claim

I measured `.example()` before/after (479 µs → 408 µs) and am **discarding that number** — `.example()` builds a whole throwaway test run, so it measures hypothesis's machinery, not the composite wrapper. `named_dimensions` is drawn once per example and its cost is noise next to the engine. This PR is about the duplication only.

## Verification

Every documented strategy position, exercised under `@given`:

```
named_dimensions() direct:  OK
units(named_dimensions()):  OK
units() default arg:        OK        <- evaluated at import
unitsystems(strategy+str):  OK
derived_units(strategy):    OK
quantities(dimension):      OK
shrinks to: absement
```

- `pytest packages/unxts.hypothesis/tests` — 12 passed; `src --doctest-modules` (CI's namespace-aware invocation) — 7 passed
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

## Considered and left alone

`DIMENSION_NAMES` is 134 hand-listed strings that could be derived from astropy at import — but the module docstring says they were "captured here as a finalized tuple" deliberately, and deriving them would make the strategy's corpus drift with the astropy version. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)