### PR TITLE
🐛 fix(tests): assert float associativity within the real error bound

### DIFF
--- a/tests/unit/test_quantity.py
+++ b/tests/unit/test_quantity.py
@@ -1017,6 +1017,12 @@ def test_is_unit_convertible():
 # Property-based tests using unxt-hypothesis
 
 
+# Full-range float32 lets a 3-term sum overflow to inf, which no tolerance can
+# rescue. Cap the magnitude so sums stay finite.
+_1e30 = float(np.float32(1e30))  # exactly representable, as `width=32` requires
+_no_overflow_floats = st.floats(min_value=-_1e30, max_value=_1e30, width=32)
+
+
 class TestQuantityProperties:
     """Property-based tests for Quantity using hypothesis strategies."""
 
@@ -1036,12 +1042,21 @@ class TestQuantityProperties:
         assert result1.unit == result2.unit
 
     @settings(max_examples=20, deadline=None)
-    @given(q1=ust.quantities("m"), q2=ust.quantities("m"), q3=ust.quantities("m"))
+    @given(
+        q1=ust.quantities("m", elements=_no_overflow_floats),
+        q2=ust.quantities("m", elements=_no_overflow_floats),
+        q3=ust.quantities("m", elements=_no_overflow_floats),
+    )
     def test_addition_associative(self, q1, q2, q3):
         """Test that addition is associative: (q1 + q2) + q3 == q1 + (q2 + q3)."""
         result1 = (q1 + q2) + q3
         result2 = q1 + (q2 + q3)
-        assert jnp.allclose(result1.value, result2.value)
+        # Float addition is only associative up to rounding, and the error is
+        # set by the operand magnitudes, not by the (possibly cancelled) result
+        # -- so `rtol` on the result is the wrong test. Each of the two roundings
+        # is bounded by eps/2 * sum(|operands|); 4x that is ample slack.
+        atol = 4 * np.finfo(np.float32).eps * sum(abs(q.value) for q in (q1, q2, q3))
+        assert jnp.allclose(result1.value, result2.value, rtol=0, atol=atol)
         assert result1.unit == result2.unit
 
     @settings(max_examples=20, deadline=None)


### PR DESCRIPTION
## What

`tests/unit/test_quantity.py::TestQuantityProperties::test_addition_associative` asserted `jnp.allclose(result1.value, result2.value)` — i.e. that float32 addition is associative to `allclose`'s default *result-relative* `rtol`. That is false in general.

Catastrophic cancellation shrinks the result while the rounding error stays tied to the **operand** magnitudes, so `rtol` on the result measures the wrong quantity. Hypothesis finds counterexamples:

```
q1 = 1.8769297e+16 m,  q2 = 2.7746855e+16 m,  q3 = -4.6301405e+16 m
(q1 + q2) + q3 = 2.1474836e+14
q1 + (q2 + q3) = 2.1474622e+14      relative difference ~1e-5
```

Pre-existing; surfaced during a full-suite run, unrelated to any in-flight work.

## Fix

Assert the property that is actually true. Each of the two roundings is bounded by `eps/2 * sum(|operands|)`, so compare with `rtol=0, atol=4 * eps * sum(|operands|)`:

```python
atol = 4 * np.finfo(np.float32).eps * sum(abs(q.value) for q in (q1, q2, q3))
assert jnp.allclose(result1.value, result2.value, rtol=0, atol=atol)
```

Also bound the drawn elements to ±1e30. Full-range float32 lets a three-term sum overflow to `inf`, which no tolerance can rescue — a second latent failure mode in the same test.

## Why not the alternatives

- **Drop associativity, keep only commutativity.** Associativity *is* a real property once stated with the correct bound, and dropping it would leave the test a duplicate of `test_addition_commutative`'s unit check.
- **Bound the magnitude range alone.** Cancellation is scale-invariant — bounding to ±100 does not stop the relative error from blowing up. Only a positive-only range would, and that neuters the test.

## Should `ust.quantities` grow a bounded-magnitude strategy?

Checked the siblings: **no**. `test_addition_associative` is the only property in the class that is false for floats — commutativity, `q + 0`, `q + (-q)`, and `q1 * q2` are either exact or compare identical computations. And ~8 tests in this file already bound magnitude through the existing `elements=st.floats(..., width=32)` kwarg, so a new public helper in `unxts.hypothesis` would be a one-caller abstraction. Worth revisiting if a third file needs the same bound.

## Verification

- 3000 hypothesis examples (including the counterexample above) pass, with all results finite.
- A perturbation just past the bound is still rejected, so the assertion is not vacuous.
- `tests/unit/test_quantity.py`: 98 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)