### PR TITLE
docs: prefer Array API spellings (pow, matrix_transpose) over legacy aliases

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -384,7 +384,7 @@ class QuantityMatrix(u.AbstractQuantity):
         >>> aT.unit.to_string()
         '((m, kg), (s, rad))'
 
-        Also accessible via ``jax.numpy.transpose``:
+        Also accessible via ``jax.numpy.matrix_transpose``:
 
         >>> aT2 = qnp.matrix_transpose(a)
         >>> aT2.value

--- a/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/register_primitives.py
@@ -92,7 +92,7 @@ def pow_p_qq(x: ABCQ, y: ABCPQ["dimensionless"], /) -> ABCQ:
 
     >>> q1 = u.Q(2.0, "m")
     >>> p = PQ(3, "")
-    >>> jnp.power(q1, p)
+    >>> jnp.pow(q1, p)
     Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**p
     Quantity(Array(8., dtype=float32...), unit='m3')
@@ -126,7 +126,7 @@ def pow_p_vq(x: ArrayLike, y: ABCPQ["dimensionless"], /) -> ABCQ:
 
     >>> x = jnp.array([2.0])
     >>> p = PQ(3, "")
-    >>> jnp.power(x, p)
+    >>> jnp.pow(x, p)
     ParametricQuantity(Array([8.], dtype=float32), unit='')
 
     """

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -2865,7 +2865,7 @@ def integer_pow_p(x: ABCQ, *, y: Any) -> ABCQ:
 
     """
     if isinstance(x, StaticQuantity):
-        value = np.power(ustrip(x), y)
+        value = np.pow(ustrip(x), y)
     else:
         value = lax.integer_pow(ustrip(x), y)
     return type_np(x)(value=value, unit=x.unit**y)
@@ -4092,13 +4092,13 @@ def pow_p_qf(x: ABCQ, y: ArrayLike, /) -> ABCQ:
 
     >>> q1 = u.quantity.Quantity(2.0, "m")
     >>> y = jnp.array(3)
-    >>> jnp.power(q1, y)
+    >>> jnp.pow(q1, y)
     Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**y
     Quantity(Array(8., dtype=float32...), unit='m3')
 
     >>> q1 = u.Q(2.0, "m")
-    >>> jnp.power(q1, y)
+    >>> jnp.pow(q1, y)
     Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**y
     Quantity(Array(8., dtype=float32...), unit='m3')
@@ -4123,7 +4123,7 @@ def pow_p_q_bareq(x: ABCQ, y: Quantity, /) -> ABCQ:
 
     >>> q1 = u.quantity.Quantity(2.0, "m")
     >>> p = u.Q(3, "")
-    >>> jnp.power(q1, p)
+    >>> jnp.pow(q1, p)
     Quantity(Array(8., dtype=float32...), unit='m3')
     >>> q1**p
     Quantity(Array(8., dtype=float32...), unit='m3')
@@ -4160,7 +4160,7 @@ def pow_p_v_bareq(x: ArrayLike, y: Quantity, /) -> ABCQ:
 
     >>> x = jnp.array([2.0])
     >>> p = u.Q(3, "")
-    >>> jnp.power(x, p)
+    >>> jnp.pow(x, p)
     Quantity(Array([8.], dtype=float32), unit='')
 
     """
@@ -5362,11 +5362,11 @@ def transpose_p(operand: ABCQ, /, *, permutation: Any) -> ABCQ:
     >>> x = jnp.arange(6).reshape(2, 3)
 
     >>> q = u.quantity.Quantity(x, "m")
-    >>> jnp.transpose(q)
+    >>> jnp.matrix_transpose(q)
     Quantity(Array([[0, 3], [1, 4], [2, 5]], dtype=int32), unit='m')
 
     >>> q = u.Q(x, "m")
-    >>> jnp.transpose(q)
+    >>> jnp.matrix_transpose(q)
     Quantity(Array([[0, 3], [1, 4], [2, 5]], dtype=int32), unit='m')
 
     """


### PR DESCRIPTION
## Summary

Audited the repo for legacy numpy/`jax.numpy` function names that have Array API standard equivalents (`concatenate`→`concat`, `power`→`pow`, `transpose`→`permute_dims`/`matrix_transpose`, `arccos`/`arcsin`/`arctan*`→`acos`/`asin`/`atan*`, `left_shift`/`right_shift`/`invert`→`bitwise_*`, etc.).

Only `power`/`transpose` had hits in the codebase:

- `np.power` → `np.pow` in the `StaticQuantity` branch of `integer_pow_p` (`src/unxt/_src/quantity/register_primitives.py`).
- `jnp.power` → `jnp.pow` in docstring examples for `pow_p_qf`/`pow_p_q_bareq`/`pow_p_v_bareq` in `unxt` and `unxts.parametric`.
- `jnp.transpose(q)` → `jnp.matrix_transpose(q)` in the `transpose_p` docstring — the examples are 2-D, an exact match for `matrix_transpose`'s swap-last-two-axes semantics.
- Fixed a stale docstring line in `unxts.linalg`'s `QuantityMatrix.T` that already called `qnp.matrix_transpose` but described itself as `jax.numpy.transpose`.

Left the 1-D `jnp.transpose` case in `unxts.linalg`'s test suite alone — `matrix_transpose` requires `ndim >= 2`, so it isn't a valid substitute for that edge-case test.

## Test plan

- [x] `pytest --doctest-modules` on all three touched files
- [x] Full `unxt` + `unxts.parametric` + `unxts.linalg` test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)