### PR TITLE
✅ test: stop the coverage exclude pattern from hiding whole functions

### DIFF
--- a/packages/unxts.linalg/tests/test_edge_cases.py
+++ b/packages/unxts.linalg/tests/test_edge_cases.py
@@ -10,6 +10,9 @@ from jax.interpreters import ad
 from unxts.linalg import QuantityMatrix as QMat, UnitsMatrix, det, inv
 from unxts.linalg._src._det import _det_jvp
 from unxts.linalg._src._inv import _inv_jvp
+from unxts.linalg._src._register_primitives import transpose_qm
+
+import quaxed.numpy as qnp
 
 import unxt as u
 
@@ -150,3 +153,39 @@ def test_zero_tangent_rule_short_circuits():
 
     _, inv_tangent = _inv_jvp((x,), (zero,))
     assert np.allclose(np.asarray(inv_tangent), 0.0)
+
+
+class TestTransposeRankGuard:
+    """`transpose_qm` only implements the matrix transpose."""
+
+    def test_non_identity_permutation_below_rank_2(self):
+        """A non-identity permutation of a rank-1 value has no matrix transpose.
+
+        The identity permutation is handled just above as a no-op, so this is
+        the only way to reach the rank guard.
+        """
+        v = QMat(jnp.array([1.0, 2.0]), unit=("m", "s"))
+        with pytest.raises(NotImplementedError, match=r"requires ndim >= 2"):
+            transpose_qm(v, permutation=(1,))
+
+
+class TestTracedScalarGather:
+    """A scalar gather with a *traced* index falls back to the uniform unit."""
+
+    def test_scalar_gather_under_jit(self):
+        """Under `jax.jit` the index is a tracer, so the unit cannot be read off it.
+
+        With uniform units the answer does not depend on which element is
+        picked, so the fallback returns that shared unit.
+        """
+        v = QMat(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+        got = jax.jit(lambda q, i: qnp.take(q, i))(v, jnp.asarray(1))
+        assert isinstance(got, u.Quantity)
+        assert got.unit == u.unit("m")
+        assert got.value == pytest.approx(2.0)
+
+    def test_scalar_gather_under_jit_rejects_mixed_units(self):
+        """Heterogeneous units make the traced pick ambiguous, so it raises."""
+        v = QMat(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+        with pytest.raises(ValueError, match="requires all units to be equal"):
+            jax.jit(lambda q, i: qnp.take(q, i))(v, jnp.asarray(1))

--- a/packages/unxts.parametric/tests/test_parametric_quantity.py
+++ b/packages/unxts.parametric/tests/test_parametric_quantity.py
@@ -1,5 +1,6 @@
 """Unit tests specific to ``ParametricQuantity``."""
 
+import copy as pycopy
 import pickle
 import re
 
@@ -73,3 +74,42 @@ def test_type_parameter_from_a_unit_without_a_named_dimension():
     """A unit astropy cannot name falls back to a unit-derived dimension."""
     cls = up.ParametricQuantity[u.unit("m5/s3")]
     assert "m5" in str(u.dimension_of(cls))
+
+
+class TestGetNewArgsEx:
+    """`__getnewargs_ex__` returns the reconstruction args for `__new__`."""
+
+    def test_returns_no_positional_args_and_all_fields_as_kwargs(self):
+        """The contract: no positional args, every field as a keyword."""
+        q = up.PQ([1, 2, 3], "m")
+        args, kwargs = q.__getnewargs_ex__()
+        assert args == ()
+        assert dict(kwargs).keys() == {"value", "unit"}
+        assert dict(kwargs)["unit"] == u.unit("m")
+
+    def test_reduce_takes_precedence_on_every_copy_path(self):
+        """Note: nothing *reaches* `__getnewargs_ex__` in practice.
+
+        `AbstractParametricQuantity` also defines `__reduce__`, which the copy
+        and pickle protocols consult first, so `copy`, `deepcopy` and `pickle`
+        all bypass this method. It is kept as the documented `__new__` contract
+        and exercised directly above; this test pins the precedence so a future
+        change to `__reduce__` does not silently alter reconstruction.
+        """
+        q = up.PQ([1, 2, 3], "m")
+        calls = []
+        original = type(q).__getnewargs_ex__
+
+        def spy(self):
+            calls.append(1)
+            return original(self)
+
+        type(q).__getnewargs_ex__ = spy
+        try:
+            pycopy.copy(q)
+            pycopy.deepcopy(q)
+            pickle.loads(pickle.dumps(q))  # noqa: S301
+        finally:
+            type(q).__getnewargs_ex__ = original
+
+        assert calls == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,10 @@ name = "cz_gitmoji"
 
 [tool.coverage]
 report.exclude_also = [
-  '\.\.\.',
+  # An `...` *body* (a stub or an abstract method), anchored so it cannot
+  # also match an `...` inside a signature -- e.g. `tuple[Any, ...]` or
+  # `Int[Array, "..."]`, which excluded the whole function from measurement.
+  '^\s*\.\.\.\s*$',
   'if typing.TYPE_CHECKING:',
   'if TYPE_CHECKING:',
 ]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,7 @@ import unxt as u
 from unxt._src.config import (
     QuantityReprConfig,
     _auto_load_project_toml_config,
+    _config_from_toml_data,
     _find_pyproject,
     _load_toml_config_from_pyproject,
     _walk_toml_config,
@@ -1228,3 +1229,36 @@ def test_update_config_forwards_to_nested_sections() -> None:
         u.config.quantity_str.short_arrays = str_baseline
     assert u.config.quantity_repr.short_arrays == repr_baseline
     assert u.config.quantity_str.short_arrays == str_baseline
+
+
+class TestConfigFromTomlData:
+    """`_config_from_toml_data` bails out on a malformed ``[tool]`` tree."""
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({}, id="no-tool"),
+            pytest.param({"tool": "not-a-table"}, id="tool-not-a-table"),
+            pytest.param({"tool": {"unxts": "not-a-table"}}, id="mid-not-a-table"),
+            pytest.param(
+                {"tool": {"unxts": {"unxt": "not-a-table"}}}, id="leaf-not-a-table"
+            ),
+        ],
+    )
+    def test_malformed_tool_section_gives_empty_config(self, data):
+        """A non-table anywhere along ``tool.unxts.unxt`` yields an empty Config.
+
+        Project configuration must never break an import, so each of these is
+        skipped rather than raised.
+        """
+        assert not _config_from_toml_data(data)
+
+    def test_explicit_path_to_class(self):
+        """An explicit ``path_to_class`` overrides unxt's default mapping."""
+        data = {"tool": {"pkg": {"quantity": {"repr": {"short_arrays": "compact"}}}}}
+        loaded = _config_from_toml_data(
+            data,
+            tool_path=("pkg",),
+            path_to_class={("quantity", "repr"): "OtherReprConfig"},
+        )
+        assert loaded["OtherReprConfig"]["short_arrays"] == "compact"

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -10,8 +10,6 @@ import astropy.units as apyu
 import numpy as np
 import pytest
 
-import quaxed.numpy as qnp
-
 import unxt as u
 from unxt._src.quantity import register_ufuncs
 
@@ -222,21 +220,42 @@ def test_bare_quantity_also_supported():
 
 
 class TestUnhandledUfuncs:
-    """Built-in ufuncs with no `quaxed.numpy` counterpart fall through.
+    """A ufunc with no unit-aware counterpart must fall through.
 
-    `apply_ufunc` must return ``NotImplemented`` -- letting NumPy raise a loud
-    ``TypeError`` -- rather than silently dropping units.
+    `apply_ufunc` returns ``NotImplemented`` so NumPy raises a loud
+    ``TypeError`` rather than silently dropping units.
+
+    Both tests *force* the "no counterpart" premise rather than relying on a
+    gap that happens to exist in `quaxed` today -- otherwise a future release
+    filling that gap would make them fail (or pass vacuously) even though
+    `apply_ufunc` is behaving correctly.
     """
 
-    def test_call_without_quaxed_counterpart(self):
-        """``np.isnat`` is a real ufunc that `quaxed.numpy` does not provide."""
-        assert getattr(qnp, "isnat", None) is None  # guards the premise
-        got = register_ufuncs.apply_ufunc(np.isnat, "__call__", (u.Q(1.0, "m"),), {})
+    def test_call_without_quaxed_counterpart(self, monkeypatch):
+        """No `quaxed.numpy` function for the ufunc -> ``NotImplemented``.
+
+        `quaxed.numpy` resolves names through a module-level ``__getattr__``
+        that synthesises wrappers on demand, and keeps its module dict empty --
+        so deleting an attribute would neither find anything nor stick. Swap
+        the module reference `apply_ufunc` consults instead.
+        """
+
+        class _NoCounterparts:
+            """Stands in for `quaxed.numpy` with nothing defined."""
+
+            def __getattr__(self, name: str) -> object:
+                raise AttributeError(name)
+
+        monkeypatch.setattr(register_ufuncs, "qnp", _NoCounterparts())
+        got = register_ufuncs.apply_ufunc(np.add, "__call__", (u.Q(1.0, "m"),), {})
         assert got is NotImplemented
 
-    def test_reduce_without_mapping(self):
-        """``np.absolute`` has no entry in the reduce map."""
-        got = register_ufuncs.apply_ufunc(
-            np.absolute, "reduce", (u.Q([1.0, 2.0], "m"),), {}
-        )
+    def test_reduce_without_mapping(self, monkeypatch):
+        """A ufunc absent from the reduce map -> ``NotImplemented``.
+
+        The map is emptied of the ufunc under test so the premise is explicit
+        rather than dependent on which ufuncs `_REDUCE_MAP` happens to list.
+        """
+        monkeypatch.delitem(register_ufuncs._REDUCE_MAP, "add", raising=False)
+        got = register_ufuncs.apply_ufunc(np.add, "reduce", (u.Q([1.0, 2.0], "m"),), {})
         assert got is NotImplemented

--- a/tests/unit/test_numpy_ufunc.py
+++ b/tests/unit/test_numpy_ufunc.py
@@ -10,6 +10,8 @@ import astropy.units as apyu
 import numpy as np
 import pytest
 
+import quaxed.numpy as qnp
+
 import unxt as u
 from unxt._src.quantity import register_ufuncs
 
@@ -217,3 +219,24 @@ def test_bare_quantity_also_supported():
 
     assert got.unit == u.unit("m2")
     assert got.value == 25.0
+
+
+class TestUnhandledUfuncs:
+    """Built-in ufuncs with no `quaxed.numpy` counterpart fall through.
+
+    `apply_ufunc` must return ``NotImplemented`` -- letting NumPy raise a loud
+    ``TypeError`` -- rather than silently dropping units.
+    """
+
+    def test_call_without_quaxed_counterpart(self):
+        """``np.isnat`` is a real ufunc that `quaxed.numpy` does not provide."""
+        assert getattr(qnp, "isnat", None) is None  # guards the premise
+        got = register_ufuncs.apply_ufunc(np.isnat, "__call__", (u.Q(1.0, "m"),), {})
+        assert got is NotImplemented
+
+    def test_reduce_without_mapping(self):
+        """``np.absolute`` has no entry in the reduce map."""
+        got = register_ufuncs.apply_ufunc(
+            np.absolute, "reduce", (u.Q([1.0, 2.0], "m"),), {}
+        )
+        assert got is NotImplemented

--- a/tests/unit/test_optional_deps.py
+++ b/tests/unit/test_optional_deps.py
@@ -1,11 +1,13 @@
 """Tests for the internal optional-dependency detection (`unxt._interop`)."""
 
 import pytest
+from astropy.units import Quantity as AstropyQuantity
 
 from optional_dependencies import OptionalDependencyEnum, auto
 from optional_dependencies.utils import is_installed
 
 from unxt._interop.optional_deps import OptDeps
+from unxt._src.quantity.base import _astropy_quantity_types
 
 
 def test_no_members_alias() -> None:
@@ -65,3 +67,32 @@ def test_gala_member_requires_the_gala_backend() -> None:
     """
     expected = is_installed("unxts.interop.gala") and is_installed("gala")
     assert OptDeps.UNXTS_INTEROP_GALA.installed is expected
+
+
+class TestAstropyQuantityTypes:
+    """`_astropy_quantity_types` gates the astropy-coercion path."""
+
+    def test_returns_quantity_when_astropy_installed(self):
+        """With astropy present (the norm), the astropy `Quantity` is coerced."""
+        _astropy_quantity_types.cache_clear()
+        try:
+            assert _astropy_quantity_types() == (AstropyQuantity,)
+        finally:
+            _astropy_quantity_types.cache_clear()
+
+    def test_returns_empty_when_astropy_absent(self, monkeypatch):
+        """Without astropy there is nothing to coerce, so the tuple is empty.
+
+        astropy is a hard dependency today, so this branch is only reachable by
+        forcing the `OptDeps` gate -- but it is the guard that keeps
+        `_coerce_foreign_quantity` working if astropy ever becomes optional
+        again.
+        """
+        monkeypatch.setattr(
+            type(OptDeps.ASTROPY), "installed", property(lambda _self: False)
+        )
+        _astropy_quantity_types.cache_clear()
+        try:
+            assert _astropy_quantity_types() == ()
+        finally:
+            _astropy_quantity_types.cache_clear()

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -662,3 +662,32 @@ def test_equivalent_checks_dimensions_and_unit_convertibility() -> None:
     assert equivalent(galactic, galactic)
     assert not equivalent(galactic, si)
     assert not equivalent(si, cgs)
+
+
+class TestParseFieldNamesAndDimensions:
+    """Field-scanning edge cases in `parse_field_names_and_dimensions`."""
+
+    def test_non_unit_annotated_field_is_skipped(self):
+        """An ``Annotated`` field whose origin is not a unit is not a base dimension.
+
+        Unit systems may carry annotated bookkeeping fields; only the ones
+        annotated as units participate in the dimension signature.
+        """
+
+        class Carrier:
+            length: Annotated[apyu.UnitBase, dimension("length")]
+            label: Annotated[str, "not-a-unit"]
+
+        names, dims = us_base.parse_field_names_and_dimensions(Carrier)
+        assert names == ("length",)
+        assert dims == (dimension("length"),)
+
+    def test_repeated_dimension_is_rejected(self):
+        """Two fields claiming the same dimension is an ambiguous signature."""
+
+        class TwoLengths:
+            length: Annotated[apyu.UnitBase, dimension("length")]
+            breadth: Annotated[apyu.UnitBase, dimension("length")]
+
+        with pytest.raises(ValueError, match="Some dimensions are repeated"):
+            us_base.parse_field_names_and_dimensions(TwoLengths)


### PR DESCRIPTION
Follow-up to #849, where this surfaced.

## The bug

`[tool.coverage] report.exclude_also` carried a bare `'\.\.\.'` — intended to skip an `...` stub body. The regex is **unanchored**, so it also matches an `...` *inside a signature*:

```python
def promote_dtypes[T: HasDType](*arrays: T) -> tuple[T, ...]:   # ← excluded
def lu_p_q(x) -> tuple[ABCQ, Int[Array, "..."], Int[Array, "..."]]:   # ← excluded
```

And excluding a `def` line excludes the **whole function body**. **16 functions** across core, linalg and parametric were silently unmeasured — `promote_dtypes`, `_astropy_quantity_types`, `_combine_quantities`, `_reject_extra_args`, `AbstractUnitSystem.base_dimensions` / `.base_units`, `UnitsMatrix.full` / `.shape` / `_parse_structure_string`, `cdict_units`, `__getnewargs_ex__`, and more.

So #847's "100% across every package" was partly an artifact.

```diff
-  '\.\.\.',
+  '^\s*\.\.\.\s*$',
```

## The 9 statements it exposed

Each was checked individually rather than blanket-`pragma`'d. **All nine turned out reachable**, so all nine got real tests:

| where | what |
|---|---|
| `_config_from_toml_data` | a non-table anywhere along `tool.unxts.unxt` (project config must never break an import); explicit `path_to_class` |
| `apply_ufunc` | a built-in ufunc with no `quaxed.numpy` counterpart (`np.isnat`), and a `.reduce` with no mapping (`np.absolute`) — both must return `NotImplemented` so NumPy raises loudly rather than dropping units |
| `parse_field_names_and_dimensions` | a non-unit `Annotated` field is skipped; two fields claiming one dimension is rejected |
| `_astropy_quantity_types` | the astropy-absent branch, via the `OptDeps` gate |
| `transpose_qm` | the rank guard — reachable only with a *non-identity* permutation below rank 2, since identity is short-circuited above it |
| `gather_qm` | a scalar gather with a **traced** index, which falls back to the uniform unit (and rejects mixed units) |
| `__getnewargs_ex__` | called directly |

> [!NOTE]
> While covering `__getnewargs_ex__` I found its doctest passes for the wrong reason. `AbstractParametricQuantity` also defines `__reduce__`, which the copy and pickle protocols consult first — so `copy`, `deepcopy` **and** `pickle` all bypass `__getnewargs_ex__` entirely (verified with a spy: zero calls on all three paths). Its docstring advertises it as the protocol-2+ `__new__` hook and demonstrates `copy.copy(x)`, which succeeds via `__reduce__`. The new test pins that precedence rather than papering over it. Whether the method should simply be deleted is worth a separate look — I didn't want to remove a dunder inside a coverage PR.

## Coverage, measured the way CI measures it

CI already combines the `src` doctest run and the `tests` run via `--cov-append` for linalg / parametric / xarray, so these are like-for-like:

| suite | before | after |
|---|---|---|
| unxt core | 2481 stmts, 27 miss | **2692 stmts, 27 miss** |
| linalg | 559 stmts, 0 miss | **656 stmts, 0 miss** |
| parametric | 203 stmts, 0 miss | **219 stmts, 0 miss** |
| xarray | 227 stmts, 2 miss | **229 stmts, 2 miss** |

**211 more statements measured in core, ~100 more across the packages, with no increase in misses anywhere.** linalg and parametric stay at a genuine 100%.

The remaining gaps are all pre-existing, untouched by this PR: core's `interop_astropy/quantity.py:255-256`, `base.py:85,1376-1378`, `register_primitives.py` (21), and xarray's `conversion.py:311-314`.

## Verification

- `pytest tests/unit src` — **2449 passed**, 0 failed; `--cov=unxt` → 2692 stmts / 27 miss / 99%
- linalg, parametric, xarray each re-measured CI-style (src `--cov` + tests `--cov-append`)
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)