### PR TITLE
⚰️ dead: drop `__getnewargs_ex__`, superseded by `__reduce__`

### DIFF
--- a/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
+++ b/packages/unxts.parametric/src/unxts/parametric/_src/base_parametric.py
@@ -13,7 +13,7 @@ from astropy.units import PhysicalType
 from jaxtyping import Array, Shaped
 from plum import dispatch, parametric, type_unparametrized
 
-from dataclassish import field_items, fields
+from dataclassish import fields
 
 from .config import config as parametric_config
 from unxt._src.dimensions import name_of
@@ -130,27 +130,6 @@ class AbstractParametricQuantity(AbstractQuantity):
     # ---------------------------------------------------------------
     # misc
 
-    def __getnewargs_ex__(self) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        """Return args, kwargs for ``__new__``.
-
-        In protocols 2+, this is used to determine the values (args,
-        and kwargs) passed to ``__new__``. We implement ``__getnewargs_ex__``
-        instead of ``__getnewargs__`` because the latter does not support
-        keyword-only arguments.
-
-        Examples
-        --------
-        >>> import copy as pycopy
-        >>> import unxt as u
-        >>> import unxts.parametric as up
-
-        >>> x = up.PQ([1, 2, 3], "m")
-        >>> pycopy.copy(x)
-        ParametricQuantity(Array([1, 2, 3], dtype=int32), unit='m')
-
-        """
-        return (), field_items(self)
-
     # TODO: see if pickling can be accomplished without reduce.
     # https://docs.python.org/3.12/library/pickle.html
     def __reduce__(
@@ -187,6 +166,7 @@ class AbstractParametricQuantity(AbstractQuantity):
 
         Examples
         --------
+        >>> import copy as pycopy
         >>> import pickle
         >>> import unxt as u
         >>> import unxts.parametric as up
@@ -194,6 +174,12 @@ class AbstractParametricQuantity(AbstractQuantity):
         >>> x = up.PQ([1, 2, 3], "m")
         >>> pickle.dumps(x)
         b'...'
+
+        This is also what `copy.copy` and `copy.deepcopy` go through -- the copy
+        protocol consults ``__reduce_ex__`` (and hence ``__reduce__``) too:
+
+        >>> pycopy.copy(x)
+        ParametricQuantity(Array([1, 2, 3], dtype=int32), unit='m')
 
         """
         args, kwargs = [], {}

--- a/packages/unxts.parametric/tests/test_parametric_quantity.py
+++ b/packages/unxts.parametric/tests/test_parametric_quantity.py
@@ -76,40 +76,37 @@ def test_type_parameter_from_a_unit_without_a_named_dimension():
     assert "m5" in str(u.dimension_of(cls))
 
 
-class TestGetNewArgsEx:
-    """`__getnewargs_ex__` returns the reconstruction args for `__new__`."""
+class TestReconstructionProtocol:
+    """`__reduce__` is the single reconstruction path for parametric quantities.
 
-    def test_returns_no_positional_args_and_all_fields_as_kwargs(self):
-        """The contract: no positional args, every field as a keyword."""
+    `__getnewargs_ex__` used to be defined alongside it (both landed in #209,
+    "fix: pickling parametric types") but was never reachable: the copy and
+    pickle protocols consult ``__reduce_ex__`` -> ``__reduce__`` first. It was
+    removed; these tests pin the behaviour it was supposed to provide.
+    """
+
+    @pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+    def test_pickle_roundtrip_every_protocol(self, protocol):
+        """Every pickle protocol reconstructs value, unit and type parameter."""
         q = up.PQ([1, 2, 3], "m")
-        args, kwargs = q.__getnewargs_ex__()
-        assert args == ()
-        assert dict(kwargs).keys() == {"value", "unit"}
-        assert dict(kwargs)["unit"] == u.unit("m")
+        got = pickle.loads(pickle.dumps(q, protocol=protocol))  # noqa: S301
+        assert type(got) is type(q)
+        assert got.unit == q.unit
+        assert jnp.array_equal(got.value, q.value)
 
-    def test_reduce_takes_precedence_on_every_copy_path(self):
-        """Note: nothing *reaches* `__getnewargs_ex__` in practice.
+    @pytest.mark.parametrize("copier", [pycopy.copy, pycopy.deepcopy])
+    def test_copy_roundtrip(self, copier):
+        """`copy` and `deepcopy` reconstruct through the same path."""
+        q = up.PQ([1, 2, 3], "m")
+        got = copier(q)
+        assert type(got) is type(q)
+        assert got.unit == q.unit
+        assert jnp.array_equal(got.value, q.value)
 
-        `AbstractParametricQuantity` also defines `__reduce__`, which the copy
-        and pickle protocols consult first, so `copy`, `deepcopy` and `pickle`
-        all bypass this method. It is kept as the documented `__new__` contract
-        and exercised directly above; this test pins the precedence so a future
-        change to `__reduce__` does not silently alter reconstruction.
+    def test_getnewargs_ex_is_not_defined(self):
+        """The superseded hook is gone, so there is no second, dead path.
+
+        `object` does not define it either, so a plain ``hasattr`` is a
+        sufficient check.
         """
-        q = up.PQ([1, 2, 3], "m")
-        calls = []
-        original = type(q).__getnewargs_ex__
-
-        def spy(self):
-            calls.append(1)
-            return original(self)
-
-        type(q).__getnewargs_ex__ = spy
-        try:
-            pycopy.copy(q)
-            pycopy.deepcopy(q)
-            pickle.loads(pickle.dumps(q))  # noqa: S301
-        finally:
-            type(q).__getnewargs_ex__ = original
-
-        assert calls == []
+        assert not hasattr(up.PQ, "__getnewargs_ex__")


### PR DESCRIPTION
Follow-up to #857, which covered this method and found its doctest passes for the wrong reason.

> [!IMPORTANT]
> **Stacked on #857.** GitHub won't let a cross-fork PR use a fork branch as its base, so this shows both commits — review **[6ed62dd](https://github.com/GalacticDynamics/unxt/pull/858/commits/6ed62dd)** only; the first is #857. Merge #857 first, then this. They must not merge in the other order: #857 adds a test that calls the method this PR deletes.

## The finding

`AbstractParametricQuantity` defines **both** `__getnewargs_ex__` and `__reduce__`. They landed together in #209 ("fix: pickling parametric types"), and `__reduce__`'s own docstring explains why it was needed — the `__getnewargs_ex__` route can't carry keyword-only arguments, so reconstruction goes through a `functools.partial`-wrapped class instead.

But `__reduce__` doesn't merely supersede `__getnewargs_ex__` in spirit — it **shadows it entirely**. The copy and pickle protocols consult `__reduce_ex__`, which dispatches to `__reduce__` whenever it's defined, so `__getnewargs_ex__` is never reached.

Measured with a spy installed on `AbstractParametricQuantity`:

```
pickle protocol 0    getnewargs_ex called=0    roundtrip_ok=True
pickle protocol 1    called=0                  ok=True
pickle protocol 2    called=0                  ok=True
pickle protocol 3    called=0                  ok=True
pickle protocol 4    called=0                  ok=True
pickle protocol 5    called=0                  ok=True
copy.copy            called=0                  ok=True
copy.deepcopy        called=0                  ok=True
StaticValue-backed   called=0                  ok=True
```

**Zero calls on every path, while every path reconstructs correctly.** It was dead code carrying a doctest (`pycopy.copy(x)`) that looked like it exercised the method but actually exercised `__reduce__` — which is why it read as fine before #857 un-excluded the function from coverage.

## The change

- Remove `__getnewargs_ex__` (and the now-unused `field_items` import).
- Move its `copy` example onto `__reduce__`, beside the existing pickle example, so the documented behaviour stays documented on the method that implements it.
- Replace #857's precedence test with tests of the behaviour itself: a pickle round-trip across **every** protocol, `copy` and `deepcopy`, and an assertion that the superseded hook is gone so a second dead path can't creep back.

## Verification

Beyond the suites, reconstruction still holds for the cases most likely to break:

```
PQ          pickle_ok=True  deepcopy_ok=True  param=length
PQ static   pickle_ok=True  deepcopy_ok=True  param=length     <- StaticValue-backed
subclass    pickle_ok=True  deepcopy_ok=True  param=time       <- user @parametric subclass
jit:        ParametricQuantity['length'](6., unit='m')
arithmetic: ParametricQuantity['length'](3., unit='m')
```

Type, unit **and** dimension type parameter survive on each.

- `pytest packages/unxts.parametric/src` — 98 passed; `tests` — 88 passed; `docs` — 52 passed
- Coverage stays at **100%** (217 statements, 0 missed — two fewer statements now the dead ones are gone)
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

## Scope

Only `AbstractParametricQuantity` had this pair. Core `unxt` defines neither dunder; `unxt/_src/unitsystems/core.py` injects a `__reduce__` for dynamically-built unit systems with no `__getnewargs_ex__` alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)