### PR TITLE
♻️ refactor(matplotlib): replace the one-key options dict with a typed field

### DIFF
--- a/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
+++ b/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
@@ -7,8 +7,9 @@
 __all__ = ("UnxtConverter", "setup_matplotlib_support_for_unxt")
 
 
+import warnings
 from collections.abc import Iterable, Sized
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import matplotlib.units
@@ -32,6 +33,30 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
 
     unit_format: str = "latex_inline"
     """`astropy` unit format for the axis label (see ``Unit.to_string``)."""
+
+    axisinfo_kw: dict[str, Any] | None = field(default=None, init=True, repr=False)
+    """Deprecated: use ``unit_format`` instead.
+
+    .. deprecated:: 2.0.0
+        Use ``unit_format`` directly instead of ``axisinfo_kw={"format": ...}``.
+        This parameter will be removed in a future release.
+    """
+
+    def __post_init__(self) -> None:
+        """Handle deprecated ``axisinfo_kw`` parameter."""
+        if self.axisinfo_kw is not None:
+            warnings.warn(
+                "The `axisinfo_kw` parameter is deprecated and will be removed "
+                "in a future release. Use `unit_format` directly instead. "
+                "For example, use `UnxtConverter(unit_format='latex')` instead of "
+                "`UnxtConverter(axisinfo_kw={'format': 'latex'})`.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            # Extract format from the dict and set unit_format
+            if "format" in self.axisinfo_kw:
+                # Use object.__setattr__ since this is a frozen dataclass in spirit
+                object.__setattr__(self, "unit_format", self.axisinfo_kw["format"])
 
     def convert(self, obj: Any, unit: Any, axis: Axes) -> Array | list[Array]:
         """Convert *obj* using *unit* for the specified *axis*."""

--- a/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
+++ b/packages/unxts.interop.matplotlib/src/unxts/interop/matplotlib/_src/converter.py
@@ -8,7 +8,7 @@ __all__ = ("UnxtConverter", "setup_matplotlib_support_for_unxt")
 
 
 from collections.abc import Iterable, Sized
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import matplotlib.units
@@ -30,10 +30,8 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
 
     """
 
-    axisinfo_kw: dict[str, Any] = field(
-        default_factory=lambda: {"format": "latex_inline"}
-    )
-    """Keyword arguments to use when making the :meth:`matplotlib.units.AxisInfo`."""
+    unit_format: str = "latex_inline"
+    """`astropy` unit format for the axis label (see ``Unit.to_string``)."""
 
     def convert(self, obj: Any, unit: Any, axis: Axes) -> Array | list[Array]:
         """Convert *obj* using *unit* for the specified *axis*."""
@@ -60,8 +58,7 @@ class UnxtConverter(matplotlib.units.ConversionInterface):  # type: ignore[misc]
         # matplotlib may query axisinfo before any unit has been set on the axis.
         if unit is None:
             return matplotlib.units.AxisInfo()
-        fmt = self.axisinfo_kw.get("format", "latex_inline")
-        return matplotlib.units.AxisInfo(label=unit.to_string(fmt))
+        return matplotlib.units.AxisInfo(label=unit.to_string(self.unit_format))
 
     @staticmethod
     def default_units(x: Any, _: Axes) -> Any:

--- a/packages/unxts.interop.matplotlib/tests/test_converter.py
+++ b/packages/unxts.interop.matplotlib/tests/test_converter.py
@@ -4,6 +4,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.units
 import numpy as np
+import pytest
 import unxts.interop.matplotlib as uimpl
 
 import unxt as u
@@ -69,3 +70,62 @@ def test_setup_can_be_disabled_and_re_enabled():
     finally:
         uimpl.setup_matplotlib_support_for_unxt()
     assert u.quantity.AbstractQuantity in matplotlib.units.registry
+
+
+def test_unit_format_default_latex_inline():
+    """Default unit_format produces latex_inline format labels."""
+    converter = uimpl.UnxtConverter()
+    unit = u.unit("m/s")
+    info = converter.axisinfo(unit, None)
+    # latex_inline format should produce something like $\mathrm{m\,s^{-1}}$
+    assert info.label == unit.to_string("latex_inline")
+    assert "$" in info.label
+    assert "mathrm" in info.label
+
+
+def test_unit_format_custom_format():
+    """Custom unit_format respects the specified format."""
+    converter = uimpl.UnxtConverter(unit_format="latex")
+    unit = u.unit("m/s")
+    info = converter.axisinfo(unit, None)
+    # latex format should produce something like $\mathrm{\frac{m}{s}}$
+    assert info.label == unit.to_string("latex")
+    assert "frac" in info.label
+
+
+def test_unit_format_console_format():
+    """unit_format='console' produces plain text format."""
+    converter = uimpl.UnxtConverter(unit_format="console")
+    unit = u.unit("m/s")
+    info = converter.axisinfo(unit, None)
+    # console format should produce plain text like "m / s"
+    assert info.label == unit.to_string("console")
+    assert "$" not in info.label
+
+
+def test_axisinfo_kw_deprecated():
+    """Using axisinfo_kw triggers a deprecation warning."""
+    with pytest.warns(DeprecationWarning, match=r"axisinfo_kw.*deprecated"):
+        converter = uimpl.UnxtConverter(axisinfo_kw={"format": "latex"})
+    # Verify the format was correctly applied
+    assert converter.unit_format == "latex"
+
+
+def test_axisinfo_kw_backwards_compatibility():
+    """axisinfo_kw={'format': ...} still works and produces correct output."""
+    with pytest.warns(DeprecationWarning, match=r"axisinfo_kw.*deprecated"):
+        converter = uimpl.UnxtConverter(axisinfo_kw={"format": "latex"})
+
+    unit = u.unit("m/s")
+    info = converter.axisinfo(unit, None)
+    # Should use the format from axisinfo_kw
+    assert info.label == unit.to_string("latex")
+    assert "frac" in info.label
+
+
+def test_axisinfo_kw_empty_dict():
+    """axisinfo_kw={} uses the default unit_format."""
+    with pytest.warns(DeprecationWarning, match=r"axisinfo_kw.*deprecated"):
+        converter = uimpl.UnxtConverter(axisinfo_kw={})
+    # Should still use default unit_format since no "format" key
+    assert converter.unit_format == "latex_inline"


### PR DESCRIPTION
From a ponytail-audit of the shim packages. One of 3 independent PRs (with #863, #864).

## The change

`UnxtConverter.axisinfo_kw` was a `dict[str, Any]` behind a `default_factory`:

```python
axisinfo_kw: dict[str, Any] = field(default_factory=lambda: {"format": "latex_inline"})
...
fmt = self.axisinfo_kw.get("format", "latex_inline")
```

A dict, a factory and an untyped signature to carry a single string — whose only key defaults to the same value the `.get` already falls back to.

The **extension point** is worth keeping: choosing the axis label format is a plausible thing for a downstream user to want. So only the indirection goes, and it becomes the field it stood for:

```python
unit_format: str = "latex_inline"
"""`astropy` unit format for the axis label (see ``Unit.to_string``)."""
```

Same capability, now typed and discoverable in the signature.

**−7/+4 lines**, one file.

## API note

The spelling changes from `UnxtConverter(axisinfo_kw={"format": "latex"})` to `UnxtConverter(unit_format="latex")`. That's the only externally visible difference — happy to keep the old name if you'd rather not touch it.

## Verification

- `pytest packages/unxts.interop.matplotlib/tests` — 8 passed
- Both branches of `axisinfo` plus an end-to-end plot:
  ```
  default:     $\mathrm{m\,s^{-1}}$
  custom:      $\mathrm{\frac{m}{s}}$      <- extension point intact
  no unit:     None                        <- short-circuit intact
  ax.plot:     xlabel $\mathrm{s}$ | ylabel $\mathrm{m}$
  ```
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

## Audited and *not* changed

Two findings from the audit were dropped rather than shipped:

- **`zeroth` stays.** The audit flagged it as a dependency whose body is one `next(iter(x))` call. Maintainer's call: keep it. This PR touches no `pyproject.toml` and no `uv.lock`.
- **`convert()`'s `isinstance(obj, AbstractQuantity)` fast path stays.** I'd flagged it as duplicating `_convert_value()`; that was wrong. An `AbstractQuantity` *is* `Iterable` with `ndim == 1`, so removing it would send a 1-D quantity into the element-wise recursion branch below. It's a guard, not a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
