### PR TITLE
🧹 chore(gala): inline the one-call unit converter

### DIFF
--- a/packages/unxts.interop.gala/src/unxts/interop/gala/_src/unitsystems.py
+++ b/packages/unxts.interop.gala/src/unxts/interop/gala/_src/unitsystems.py
@@ -5,7 +5,6 @@ __all__ = (
     "convert_unxt_unitsystem_to_gala_unitsystem",
 )
 
-from typing import Any
 
 import gala.units
 from astropy.units import UnitBase as AstropyUnit
@@ -84,11 +83,6 @@ def convert_gala_unitsystem_to_unxt_unitsystem(
     return unitsystem(usys)
 
 
-def _convert_unit_to_apyu(u: Any) -> AstropyUnit:
-    """Convert a `unxt.AbstractUnit` to an astropy.unit."""
-    return convert(u, AstropyUnit)
-
-
 @conversion_method(type_from=AbstractUnitSystem, type_to=gala.units.UnitSystem)  # type: ignore[arg-type]
 def convert_unxt_unitsystem_to_gala_unitsystem(
     usys: AbstractUnitSystem, /
@@ -115,4 +109,4 @@ def convert_unxt_unitsystem_to_gala_unitsystem(
     <UnitSystem (km, s, solMass, rad)>
 
     """
-    return gala.units.UnitSystem(*map(_convert_unit_to_apyu, usys.base_units))
+    return gala.units.UnitSystem(*(convert(u, AstropyUnit) for u in usys.base_units))


### PR DESCRIPTION
From a ponytail-audit of the shim packages. One of 3 independent PRs; the small one.

`_convert_unit_to_apyu` was a named function wrapping a single `convert(u, AstropyUnit)`, called once, inside a `map`:

```diff
-def _convert_unit_to_apyu(u: Any) -> AstropyUnit:
-    """Convert a `unxt.AbstractUnit` to an astropy.unit."""
-    return convert(u, AstropyUnit)
-
-    return gala.units.UnitSystem(*map(_convert_unit_to_apyu, usys.base_units))
+    return gala.units.UnitSystem(*(convert(u, AstropyUnit) for u in usys.base_units))
```

A generator expression says it in place. The `typing.Any` import goes with it.

**−7/+1 lines.**

## Verification

- `pytest packages/unxts.interop.gala/tests` — 4 passed; `src --doctest-modules` (CI's namespace-aware invocation) — 2 passed
- Round-trip checked in both directions, since this sits on the conversion path:
  ```
  unxt -> gala:   UnitSystem (km, s, solMass, rad)
  gala -> unxt:   LTMAUnitSystem(length, time, mass, angle)
  dimensionless:  DimensionlessUnitSystem()
  ```
- Full pre-commit suite passes (pyright / ty / mypy typing guards included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)