### PR TITLE
⬆️ dep-bump(gala): require astropy>=7.1, matching the rest of the workspace

### DIFF
--- a/packages/unxts.interop.gala/pyproject.toml
+++ b/packages/unxts.interop.gala/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 # only be required off-Windows. unxt guards the gala interop import on gala
 # actually being importable, so this package is simply inert on Windows.
 dependencies = [
-  "astropy>=7.0.0",
+  "astropy>=7.1",
   "gala>=1.8; sys_platform != 'win32'",
   "unxt>=2.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4490,7 +4490,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astropy", specifier = ">=7.0.0" },
+    { name = "astropy", specifier = ">=7.1" },
     { name = "gala", marker = "sys_platform != 'win32'", specifier = ">=1.8" },
     { name = "unxt", editable = "." },
 ]


### PR DESCRIPTION
From a ponytail-audit of the shim packages. One of 3 independent PRs; split out from #863 so the source change and the dependency change land separately (as with #836 / #838).

`unxts.interop.gala` was the **last** package still declaring `astropy>=7.0.0` — unxt moved to `>=7.1` in #830 and `unxts.parametric` followed in #838.

> [!NOTE]
> Unlike #838, this is **consistency, not a correctness fix**, and I'd rather not overstate it. That PR had a concrete reason: parametric calls `name_of`, which reaches the ≥7.1-only `PhysicalType._physical_type` after #830 removed the version shim. The gala interop touches no such API — it uses `astropy.units.UnitBase` for conversion, unchanged across 7.0 and 7.1. I grepped for `name_of` / `_physical_type` in the package to confirm before writing this.
>
> So the value here is that the declared floor matches what the workspace actually resolves and tests against, and that no package is left behind the others.

## Verification

- `pytest packages/unxts.interop.gala/tests` — 4 passed
- `uv lock` regenerated; the only change is the `astropy` specifier
- Full pre-commit suite passes (including the `uv-lock` consistency hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)