### PR TITLE
💚 ci: bump `build-and-inspect-python-package` to v3.0.1

### DIFF
--- a/.github/workflows/cd-pr-unxt-api.yml
+++ b/.github/workflows/cd-pr-unxt-api.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-api
           upload-name-suffix: -unxt-api

--- a/.github/workflows/cd-pr-unxt-hypothesis.yml
+++ b/.github/workflows/cd-pr-unxt-hypothesis.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-hypothesis
           upload-name-suffix: -unxt-hypothesis

--- a/.github/workflows/cd-pr-unxt.yml
+++ b/.github/workflows/cd-pr-unxt.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: .
           upload-name-suffix: -unxt

--- a/.github/workflows/cd-pr-unxts-api.yml
+++ b/.github/workflows/cd-pr-unxts-api.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.api
           upload-name-suffix: -unxts-api

--- a/.github/workflows/cd-pr-unxts-hypothesis.yml
+++ b/.github/workflows/cd-pr-unxts-hypothesis.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.hypothesis
           upload-name-suffix: -unxts-hypothesis

--- a/.github/workflows/cd-pr-unxts-interop-gala.yml
+++ b/.github/workflows/cd-pr-unxts-interop-gala.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.gala
           upload-name-suffix: -unxts-interop-gala

--- a/.github/workflows/cd-pr-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-pr-unxts-interop-matplotlib.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.matplotlib
           upload-name-suffix: -unxts-interop-matplotlib

--- a/.github/workflows/cd-pr-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-pr-unxts-interop-xarray.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.xarray
           upload-name-suffix: -unxts-interop-xarray

--- a/.github/workflows/cd-pr-unxts-linalg.yml
+++ b/.github/workflows/cd-pr-unxts-linalg.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.linalg
           upload-name-suffix: -unxts-linalg

--- a/.github/workflows/cd-pr-unxts-parametric.yml
+++ b/.github/workflows/cd-pr-unxts-parametric.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.parametric
           upload-name-suffix: -unxts-parametric

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-api
           upload-name-suffix: -unxt-api

--- a/.github/workflows/cd-unxt-hypothesis.yml
+++ b/.github/workflows/cd-unxt-hypothesis.yml
@@ -68,7 +68,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-hypothesis
           upload-name-suffix: -unxt-hypothesis

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: .
           upload-name-suffix: -unxt

--- a/.github/workflows/cd-unxts-api.yml
+++ b/.github/workflows/cd-unxts-api.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.api
           upload-name-suffix: -unxts-api

--- a/.github/workflows/cd-unxts-hypothesis.yml
+++ b/.github/workflows/cd-unxts-hypothesis.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.hypothesis
           upload-name-suffix: -unxts-hypothesis

--- a/.github/workflows/cd-unxts-interop-gala.yml
+++ b/.github/workflows/cd-unxts-interop-gala.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.gala
           upload-name-suffix: -unxts-interop-gala

--- a/.github/workflows/cd-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-unxts-interop-matplotlib.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.matplotlib
           upload-name-suffix: -unxts-interop-matplotlib

--- a/.github/workflows/cd-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-unxts-interop-xarray.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.xarray
           upload-name-suffix: -unxts-interop-xarray

--- a/.github/workflows/cd-unxts-linalg.yml
+++ b/.github/workflows/cd-unxts-linalg.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.linalg
           upload-name-suffix: -unxts-linalg

--- a/.github/workflows/cd-unxts-parametric.yml
+++ b/.github/workflows/cd-unxts-parametric.yml
@@ -70,7 +70,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.parametric
           upload-name-suffix: -unxts-parametric


### PR DESCRIPTION
The `Build & inspect package` step fails on every CD workflow:

```
Checking /tmp/baipp/dist/unxts_linalg-2.0.2.dev58-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling now emits `Metadata-Version: 2.5`, but v2.18.0 of the action pins
`twine==6.2.0`, which rejects it. v3.0.1 ships twine 7, which supports metadata 2.5.

All 20 CD workflows were on the same pinned SHA, so all 20 are bumped. Every input
in use (`path`, `upload-name-suffix`, `attest-build-provenance-github`) is unchanged
in v3.0.1's `action.yml`.

Same fix as GalacticDynamics/coordinax#697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)