### PR TITLE
🐛 fix(quantity): stop `__pdoc__` discarding a caller's `custom=` hook

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -13,7 +13,7 @@ __all__ = ("AbstractQuantity", "is_any_quantity")
 
 import contextlib
 import functools as ft
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -1031,9 +1031,13 @@ class AbstractQuantity(
             short_arrays = True
         match short_arrays:
             case "compact":
-                kwargs["custom"] = custom_pdoc_noarray
+                kwargs["custom"] = _chain_custom(
+                    kwargs.get("custom"), custom_pdoc_noarray
+                )
             case True:
-                kwargs["custom"] = custom_pdoc_no_kind
+                kwargs["custom"] = _chain_custom(
+                    kwargs.get("custom"), custom_pdoc_no_kind
+                )
                 kwargs["short_arrays"] = True
             case _:  # False
                 kwargs["short_arrays"] = False
@@ -1535,6 +1539,32 @@ def is_any_quantity(obj: Any, /) -> TypeGuard[AbstractQuantity]:
 
     """
     return isinstance(obj, AbstractQuantity)
+
+
+def _chain_custom(
+    caller: Callable[[Any], wl.AbstractDoc | None] | None,
+    ours: Callable[[Any], wl.AbstractDoc | None],
+    /,
+) -> Callable[[Any], wl.AbstractDoc | None]:
+    """Try the caller's ``custom=`` pdoc hook first, then ours.
+
+    ``__pdoc__`` needs its own hook to implement ``short_arrays``, but it used
+    to install it by *assigning* ``kwargs["custom"]``. ``wadler_lindig.pdoc``
+    always puts ``custom`` in the kwargs it forwards, so that assignment
+    silently discarded whatever the caller passed -- on the default path, since
+    ``short_arrays`` is ``True``/``"compact"`` for both ``repr`` and ``str``.
+
+    The caller goes first: passing ``custom=`` is an explicit request to
+    override rendering, so it must be able to beat the default array handling.
+    """
+    if caller is None:
+        return ours
+
+    def chained(obj: Any) -> wl.AbstractDoc | None:
+        doc = caller(obj)
+        return ours(obj) if doc is None else doc
+
+    return chained
 
 
 # TODO: replace with `equinox.internal.TreeWLCustom` when available.

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -66,6 +66,20 @@ def test_repr_hides_non_singleton_defaults() -> None:
     assert "scale=" not in custom_label_repr  # scale is still default
 
 
+def test_pdoc_chains_caller_custom_hook() -> None:
+    """A caller's `custom=` hook must run before `__pdoc__`'s own array hook.
+
+    Regression: `__pdoc__` used to *assign* `kwargs["custom"]`, discarding
+    whatever the caller passed on the default `short_arrays` path.
+    """
+    q = u.Q([1.0, 2, 3], "m")
+
+    def custom(obj: object) -> wl.AbstractDoc | None:
+        return wl.TextDoc("ARRAY_HOOK_FIRED") if isinstance(obj, jax.Array) else None
+
+    assert wl.pformat(q, custom=custom) == "Quantity(ARRAY_HOOK_FIRED, unit='m')"
+
+
 class TestShortName:
     """Test the short_name feature for wadler-lindig printing."""
 


### PR DESCRIPTION
Split out of #855's "bugs fixed in passing" so it can land and backport independently, ahead of that PR rebasing on top.

`AbstractQuantity.__pdoc__` installed its own wadler-lindig `custom=` hook by *assigning* `kwargs["custom"]`. `wadler_lindig.pdoc` always places `custom` in the kwargs it forwards, so that assignment silently discarded whatever the caller passed — and it did so on the default path, since `short_arrays` is `True` for `repr` and `"compact"` for `str`.

Chain the two instead. The caller's hook goes first: passing `custom=` is an explicit request to override rendering, so it has to be able to beat the default array handling.

No output change without a `custom=` argument; `repr`/`str` are unaffected.

Repro before this fix:

```python
import unxt as u, wadler_lindig as wl, jax.numpy as jnp

q = u.Q([1.0, 2, 3], "m")
custom = lambda o: wl.TextDoc("HIT") if isinstance(o, jnp.ndarray) else None
wl.pformat(q, custom=custom)
# 'Quantity(f32[3], unit=\'m\')'  -- should be 'Quantity(HIT, unit=\'m\')'
```