### PR TITLE
🐛 fix(quantity): stop `_repr_latex_` corrupting units without `_repr_latex_`

### DIFF
--- a/packages/unxts.linalg/tests/test_printing.py
+++ b/packages/unxts.linalg/tests/test_printing.py
@@ -27,3 +27,14 @@ class TestQuantityMatrixShortName:
         result = wl.pformat(qv, use_short_name=True)
         assert result.startswith("QM(")
         assert "unit='(m, s, kg)'" in result
+
+
+def test_repr_latex_does_not_eat_characters():
+    r"""Regression: `_repr_latex_` used to slice `[1:-1]` off the unit repr.
+
+    That assumed astropy's `$...$` wrapping. `UnitsMatrix` has no
+    `_repr_latex_`, so the fallback `__repr__` was sliced and lost its first
+    and last characters, corrupting the output instead of raising.
+    """
+    qm = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+    assert qm._repr_latex_() == r'$[1.,~2.,~3.] \; UnitsMatrix("(m, s, kg)")$'

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -179,13 +179,20 @@ class IPythonReprMixin:
 
         """
         unit_repr_latex = getattr(self.unit, "_repr_latex_", None)
-        # `_repr_latex_()` wraps its output in `$...$`; strip that so it can be
-        # re-wrapped below. A unit without `_repr_latex_` (e.g. a unit system
-        # or a `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`,
-        # which carries no such wrapping and must not be sliced.
-        unit_repr = (
-            unit_repr_latex()[1:-1] if unit_repr_latex is not None else repr(self.unit)
-        )
+        unit_repr = repr(self.unit) if unit_repr_latex is None else unit_repr_latex()
+        # `_repr_latex_` conventionally wraps its output in `$...$`, and it has
+        # to come off before being re-wrapped below. Strip it only when it is
+        # actually there: keying off the *existence* of `_repr_latex_` would
+        # still corrupt a unit whose implementation returns an unwrapped
+        # string, which is this same defect one step removed. A unit without
+        # `_repr_latex_` at all (a unit system, a `unxts.linalg.UnitsMatrix`)
+        # falls back to `repr` and is likewise left alone.
+        if (
+            len(unit_repr) >= 2
+            and unit_repr.startswith("$")
+            and unit_repr.endswith("$")
+        ):
+            unit_repr = unit_repr[1:-1]
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
         return f"${value_repr} \\; {unit_repr}$"
 

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -178,9 +178,18 @@ class IPythonReprMixin:
         '$[1.,~2.,~3.,~4.] \\; \\mathrm{m}$'
 
         """
-        unit_repr = getattr(self.unit, "_repr_latex_", self.unit.__repr__)()
+        unit_repr_latex = getattr(self.unit, "_repr_latex_", None)
+        # `_repr_latex_()` wraps its output in `$...$`; strip that so it can be
+        # re-wrapped below. A unit without `_repr_latex_` (e.g. a unit system
+        # or a `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`,
+        # which carries no such wrapping and must not be sliced.
+        unit_repr = (
+            unit_repr_latex()[1:-1]
+            if unit_repr_latex is not None
+            else self.unit.__repr__()
+        )
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
-        return f"${value_repr} \\; {unit_repr[1:-1]}$"
+        return f"${value_repr} \\; {unit_repr}$"
 
     # TODO: implement:
     # - _repr_markdown_

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -184,9 +184,7 @@ class IPythonReprMixin:
         # or a `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`,
         # which carries no such wrapping and must not be sliced.
         unit_repr = (
-            unit_repr_latex()[1:-1]
-            if unit_repr_latex is not None
-            else self.unit.__repr__()
+            unit_repr_latex()[1:-1] if unit_repr_latex is not None else repr(self.unit)
         )
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
         return f"${value_repr} \\; {unit_repr}$"

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -8,6 +8,7 @@ import pytest
 import wadler_lindig as wl
 
 import unxt as u
+from unxt._src.quantity.mixins import IPythonReprMixin
 from unxt.units import unit as parse_unit
 
 
@@ -245,3 +246,44 @@ def test_format_non_scalar_raises() -> None:
     for q in (u.Q([1.5, 2.5], "m"), u.StaticQuantity(np.array([1.5, 2.5]), "m")):
         with pytest.raises(TypeError, match="unsupported format string"):
             format(q, ".2f")
+
+
+class TestReprLatexUnitStripping:
+    r"""`_repr_latex_` strips `$...$` only when the unit actually supplied it."""
+
+    class _Fake:
+        """Stands in for a unit; `IPythonReprMixin` only reads value/unit."""
+
+        def __init__(self, latex: str | None, /) -> None:
+            self._latex = latex
+            if latex is not None:
+                self._repr_latex_ = lambda: latex  # type: ignore[method-assign]
+
+        def __repr__(self) -> str:
+            return "Fake(unit)"
+
+    def _render(self, latex: str | None) -> str:
+        obj = IPythonReprMixin()
+        obj.value = np.array([1.0, 2.0])  # type: ignore[assignment]
+        obj.unit = self._Fake(latex)  # type: ignore[assignment]
+        return obj._repr_latex_()
+
+    def test_wrapped_latex_is_unwrapped_once(self):
+        r"""Astropy's `$\mathrm{m}$` loses exactly its own delimiters."""
+        assert self._render(r"$\mathrm{m}$") == r"$[1.,~2.] \; \mathrm{m}$"
+
+    def test_unwrapped_latex_is_left_intact(self):
+        r"""A `_repr_latex_` that returns no `$` must not be sliced.
+
+        Keying the strip off the *existence* of `_repr_latex_` corrupted this
+        case -- the same defect as the `UnitsMatrix` one, one step removed.
+        """
+        assert self._render(r"\mathrm{m}") == r"$[1.,~2.] \; \mathrm{m}$"
+
+    def test_no_repr_latex_falls_back_to_repr(self):
+        """A unit without `_repr_latex_` is rendered by `repr` and not sliced."""
+        assert self._render(None) == r"$[1.,~2.] \; Fake(unit)$"
+
+    def test_lone_dollar_is_not_stripped(self):
+        """A single `$` satisfies both `startswith` and `endswith`."""
+        assert self._render("$") == r"$[1.,~2.] \; $$"


### PR DESCRIPTION
Split out of #855's "bugs fixed in passing" so it can land and backport independently, ahead of that PR rebasing on top.

`_repr_latex_` sliced `[1:-1]` off the unit's representation, assuming astropy's `$...$` wrapping. A unit type with no `_repr_latex_` (e.g. `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`, which carries no such wrapping — the slice ate its first and last characters instead of just unwrapping `$...$`:

```
before: '$[1.,~2.,~3.] \; nitsMatrix("(m, s, kg)"$'
after:  '$[1.,~2.,~3.] \; UnitsMatrix("(m, s, kg)")$'
```

Only strip the `$...$` wrapping when it's actually there, i.e. when `_repr_latex_` exists; the plain `__repr__()` fallback is used unsliced. Nothing covered this before; a regression test is included in `unxts.linalg` (the concrete type that hits the fallback path) and `unxt`'s own astropy-backed path is unaffected.