### PR TITLE
Backport PR #870 on branch versions/v2.0.x (🐛 fix(quantity): stop `_repr_latex_` corrupting units without `_repr_latex_`)

### DIFF
--- a/.github/workflows/cd-pr-unxt-api.yml
+++ b/.github/workflows/cd-pr-unxt-api.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-api
           upload-name-suffix: -unxt-api

--- a/.github/workflows/cd-pr-unxt-hypothesis.yml
+++ b/.github/workflows/cd-pr-unxt-hypothesis.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-hypothesis
           upload-name-suffix: -unxt-hypothesis

--- a/.github/workflows/cd-pr-unxt.yml
+++ b/.github/workflows/cd-pr-unxt.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: .
           upload-name-suffix: -unxt

--- a/.github/workflows/cd-pr-unxts-api.yml
+++ b/.github/workflows/cd-pr-unxts-api.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.api
           upload-name-suffix: -unxts-api

--- a/.github/workflows/cd-pr-unxts-hypothesis.yml
+++ b/.github/workflows/cd-pr-unxts-hypothesis.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.hypothesis
           upload-name-suffix: -unxts-hypothesis

--- a/.github/workflows/cd-pr-unxts-interop-gala.yml
+++ b/.github/workflows/cd-pr-unxts-interop-gala.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.gala
           upload-name-suffix: -unxts-interop-gala

--- a/.github/workflows/cd-pr-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-pr-unxts-interop-matplotlib.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.matplotlib
           upload-name-suffix: -unxts-interop-matplotlib

--- a/.github/workflows/cd-pr-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-pr-unxts-interop-xarray.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.xarray
           upload-name-suffix: -unxts-interop-xarray

--- a/.github/workflows/cd-pr-unxts-linalg.yml
+++ b/.github/workflows/cd-pr-unxts-linalg.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.linalg
           upload-name-suffix: -unxts-linalg

--- a/.github/workflows/cd-pr-unxts-parametric.yml
+++ b/.github/workflows/cd-pr-unxts-parametric.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.parametric
           upload-name-suffix: -unxts-parametric

--- a/.github/workflows/cd-unxt-api.yml
+++ b/.github/workflows/cd-unxt-api.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-api
           upload-name-suffix: -unxt-api

--- a/.github/workflows/cd-unxt-hypothesis.yml
+++ b/.github/workflows/cd-unxt-hypothesis.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxt-hypothesis
           upload-name-suffix: -unxt-hypothesis

--- a/.github/workflows/cd-unxt.yml
+++ b/.github/workflows/cd-unxt.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: .
           upload-name-suffix: -unxt

--- a/.github/workflows/cd-unxts-api.yml
+++ b/.github/workflows/cd-unxts-api.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.api
           upload-name-suffix: -unxts-api

--- a/.github/workflows/cd-unxts-hypothesis.yml
+++ b/.github/workflows/cd-unxts-hypothesis.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.hypothesis
           upload-name-suffix: -unxts-hypothesis

--- a/.github/workflows/cd-unxts-interop-gala.yml
+++ b/.github/workflows/cd-unxts-interop-gala.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.gala
           upload-name-suffix: -unxts-interop-gala

--- a/.github/workflows/cd-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-unxts-interop-matplotlib.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.matplotlib
           upload-name-suffix: -unxts-interop-matplotlib

--- a/.github/workflows/cd-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-unxts-interop-xarray.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.interop.xarray
           upload-name-suffix: -unxts-interop-xarray

--- a/.github/workflows/cd-unxts-linalg.yml
+++ b/.github/workflows/cd-unxts-linalg.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.linalg
           upload-name-suffix: -unxts-linalg

--- a/.github/workflows/cd-unxts-parametric.yml
+++ b/.github/workflows/cd-unxts-parametric.yml
@@ -78,7 +78,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/unxts.parametric
           upload-name-suffix: -unxts-parametric

--- a/packages/unxts.linalg/tests/test_printing.py
+++ b/packages/unxts.linalg/tests/test_printing.py
@@ -27,3 +27,14 @@ class TestQuantityMatrixShortName:
         result = wl.pformat(qv, use_short_name=True)
         assert result.startswith("QM(")
         assert "unit='(m, s, kg)'" in result
+
+
+def test_repr_latex_does_not_eat_characters():
+    r"""Regression: `_repr_latex_` used to slice `[1:-1]` off the unit repr.
+
+    That assumed astropy's `$...$` wrapping. `UnitsMatrix` has no
+    `_repr_latex_`, so the fallback `__repr__` was sliced and lost its first
+    and last characters, corrupting the output instead of raising.
+    """
+    qm = QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+    assert qm._repr_latex_() == r'$[1.,~2.,~3.] \; UnitsMatrix("(m, s, kg)")$'

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -179,15 +179,20 @@ class IPythonReprMixin:
 
         """
         unit_repr_latex = getattr(self.unit, "_repr_latex_", None)
-        # `_repr_latex_()` wraps its output in `$...$`; strip that so it can be
-        # re-wrapped below. A unit without `_repr_latex_` (e.g. a unit system
-        # or a `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`,
-        # which carries no such wrapping and must not be sliced.
-        unit_repr = (
-            unit_repr_latex()[1:-1]
-            if unit_repr_latex is not None
-            else self.unit.__repr__()
-        )
+        unit_repr = repr(self.unit) if unit_repr_latex is None else unit_repr_latex()
+        # `_repr_latex_` conventionally wraps its output in `$...$`, and it has
+        # to come off before being re-wrapped below. Strip it only when it is
+        # actually there: keying off the *existence* of `_repr_latex_` would
+        # still corrupt a unit whose implementation returns an unwrapped
+        # string, which is this same defect one step removed. A unit without
+        # `_repr_latex_` at all (a unit system, a `unxts.linalg.UnitsMatrix`)
+        # falls back to `repr` and is likewise left alone.
+        if (
+            len(unit_repr) >= 2
+            and unit_repr.startswith("$")
+            and unit_repr.endswith("$")
+        ):
+            unit_repr = unit_repr[1:-1]
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
         return f"${value_repr} \\; {unit_repr}$"
 

--- a/src/unxt/_src/quantity/mixins.py
+++ b/src/unxt/_src/quantity/mixins.py
@@ -178,9 +178,18 @@ class IPythonReprMixin:
         '$[1.,~2.,~3.,~4.] \\; \\mathrm{m}$'
 
         """
-        unit_repr = getattr(self.unit, "_repr_latex_", self.unit.__repr__)()
+        unit_repr_latex = getattr(self.unit, "_repr_latex_", None)
+        # `_repr_latex_()` wraps its output in `$...$`; strip that so it can be
+        # re-wrapped below. A unit without `_repr_latex_` (e.g. a unit system
+        # or a `unxts.linalg.UnitsMatrix`) falls back to plain `__repr__()`,
+        # which carries no such wrapping and must not be sliced.
+        unit_repr = (
+            unit_repr_latex()[1:-1]
+            if unit_repr_latex is not None
+            else self.unit.__repr__()
+        )
         value_repr = np.array2string(self.value, separator=",~")  # type: ignore[call-overload]
-        return f"${value_repr} \\; {unit_repr[1:-1]}$"
+        return f"${value_repr} \\; {unit_repr}$"
 
     # TODO: implement:
     # - _repr_markdown_

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -8,6 +8,7 @@ import pytest
 import wadler_lindig as wl
 
 import unxt as u
+from unxt._src.quantity.mixins import IPythonReprMixin
 from unxt.units import unit as parse_unit
 
 
@@ -245,3 +246,44 @@ def test_format_non_scalar_raises() -> None:
     for q in (u.Q([1.5, 2.5], "m"), u.StaticQuantity(np.array([1.5, 2.5]), "m")):
         with pytest.raises(TypeError, match="unsupported format string"):
             format(q, ".2f")
+
+
+class TestReprLatexUnitStripping:
+    r"""`_repr_latex_` strips `$...$` only when the unit actually supplied it."""
+
+    class _Fake:
+        """Stands in for a unit; `IPythonReprMixin` only reads value/unit."""
+
+        def __init__(self, latex: str | None, /) -> None:
+            self._latex = latex
+            if latex is not None:
+                self._repr_latex_ = lambda: latex  # type: ignore[method-assign]
+
+        def __repr__(self) -> str:
+            return "Fake(unit)"
+
+    def _render(self, latex: str | None) -> str:
+        obj = IPythonReprMixin()
+        obj.value = np.array([1.0, 2.0])  # type: ignore[assignment]
+        obj.unit = self._Fake(latex)  # type: ignore[assignment]
+        return obj._repr_latex_()
+
+    def test_wrapped_latex_is_unwrapped_once(self):
+        r"""Astropy's `$\mathrm{m}$` loses exactly its own delimiters."""
+        assert self._render(r"$\mathrm{m}$") == r"$[1.,~2.] \; \mathrm{m}$"
+
+    def test_unwrapped_latex_is_left_intact(self):
+        r"""A `_repr_latex_` that returns no `$` must not be sliced.
+
+        Keying the strip off the *existence* of `_repr_latex_` corrupted this
+        case -- the same defect as the `UnitsMatrix` one, one step removed.
+        """
+        assert self._render(r"\mathrm{m}") == r"$[1.,~2.] \; \mathrm{m}$"
+
+    def test_no_repr_latex_falls_back_to_repr(self):
+        """A unit without `_repr_latex_` is rendered by `repr` and not sliced."""
+        assert self._render(None) == r"$[1.,~2.] \; Fake(unit)$"
+
+    def test_lone_dollar_is_not_stripped(self):
+        """A single `$` satisfies both `startswith` and `endswith`."""
+        assert self._render("$") == r"$[1.,~2.] \; $$"


### PR DESCRIPTION
Manual backport of #870 onto `versions/v2.0.x`. Cherry-picked cleanly, no conflicts.