### PR TITLE
📝 docs(quantity): trim two docstrings that re-narrated their commit message

### DIFF
--- a/src/unxt/_src/quantity/base.py
+++ b/src/unxt/_src/quantity/base.py
@@ -1546,17 +1546,7 @@ def _chain_custom(
     ours: Callable[[Any], wl.AbstractDoc | None],
     /,
 ) -> Callable[[Any], wl.AbstractDoc | None]:
-    """Try the caller's ``custom=`` pdoc hook first, then ours.
-
-    ``__pdoc__`` needs its own hook to implement ``short_arrays``, but it used
-    to install it by *assigning* ``kwargs["custom"]``. ``wadler_lindig.pdoc``
-    always puts ``custom`` in the kwargs it forwards, so that assignment
-    silently discarded whatever the caller passed -- on the default path, since
-    ``short_arrays`` is ``True``/``"compact"`` for both ``repr`` and ``str``.
-
-    The caller goes first: passing ``custom=`` is an explicit request to
-    override rendering, so it must be able to beat the default array handling.
-    """
+    """Try the caller's ``custom=`` pdoc hook first, then ours."""
     if caller is None:
         return ours
 

--- a/tests/unit/test_quantity_printing.py
+++ b/tests/unit/test_quantity_printing.py
@@ -68,11 +68,7 @@ def test_repr_hides_non_singleton_defaults() -> None:
 
 
 def test_pdoc_chains_caller_custom_hook() -> None:
-    """A caller's `custom=` hook must run before `__pdoc__`'s own array hook.
-
-    Regression: `__pdoc__` used to *assign* `kwargs["custom"]`, discarding
-    whatever the caller passed on the default `short_arrays` path.
-    """
+    """Regression: __pdoc__ used to drop the caller's custom= hook."""
     q = u.Q([1.0, 2, 3], "m")
 
     def custom(obj: object) -> wl.AbstractDoc | None:


### PR DESCRIPTION
Ponytail-review pass on #869: two docstrings restated the bug's history (already covered by the commit message it landed with) instead of just stating purpose. Shrink both to one line.

- \`_chain_custom\` in \`src/unxt/_src/quantity/base.py\`
- \`test_pdoc_chains_caller_custom_hook\` in \`tests/unit/test_quantity_printing.py\`

No behavior change; tests and ruff pass.