### PR TITLE
✨ feat(unitsystems): name the Planck and atomic base units

### DIFF
--- a/docs/guides/units_and_systems.md
+++ b/docs/guides/units_and_systems.md
@@ -138,10 +138,10 @@ LengthMassTimeUnitSystem(length=Unit("...e-16 m"), mass=Unit("...e-27 kg"), time
 LengthMassTimeUnitSystem(length=Unit("m"), mass=Unit("...e+27 kg"), time=Unit("...e-09 s"))
 
 >>> planck  # hbar = c = G = k_B = 1
-LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08 kg"), time=Unit("...e-44 s"), temperature=Unit("...e+32 K"))
+LengthMassTimeTemperatureUnitSystem(length=Unit("l_P"), mass=Unit("m_P"), time=Unit("t_P"), temperature=Unit("T_P"))
 
 >>> atomic  # Hartree: m_e = hbar = e = 4*pi*eps0 = 1
-LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
+LengthMassTimeElectricalChargeUnitSystem(length=Unit("a_0"), mass=Unit("m_e"), time=Unit("t_au"), electrical_charge=Unit("e"))
 ```
 
 By construction the defining constants evaluate to 1 in each system, and the two systems with a remaining free scale (`HEPUSysFlag`, `GeometrizedUSysFlag`) accept it as a keyword. For worked examples on each system — setting those scales, recovering familiar values, and the semantics of natural-unit quantities — see the {doc}`natural-units` guide.

--- a/docs/reference/unitsystems.md
+++ b/docs/reference/unitsystems.md
@@ -58,10 +58,10 @@ LengthMassTimeUnitSystem(length=Unit("...e-16 m"), mass=Unit("...e-27 kg"), time
 LengthMassTimeUnitSystem(length=Unit("m"), mass=Unit("...e+27 kg"), time=Unit("...e-09 s"))
 
 >>> planck  # hbar = c = G = k_B = 1
-LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08 kg"), time=Unit("...e-44 s"), temperature=Unit("...e+32 K"))
+LengthMassTimeTemperatureUnitSystem(length=Unit("l_P"), mass=Unit("m_P"), time=Unit("t_P"), temperature=Unit("T_P"))
 
 >>> atomic  # Hartree: m_e = hbar = e = 4*pi*eps0 = 1
-LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
+LengthMassTimeElectricalChargeUnitSystem(length=Unit("a_0"), mass=Unit("m_e"), time=Unit("t_au"), electrical_charge=Unit("e"))
 ```
 
 Natural unit systems are _numeric_ only: they do not add equivalencies between dimensions, so a `Quantity` in `MeV` remains an energy, not a mass. For worked examples on each system see {doc}`../how-to/work-in-natural-units`.

--- a/src/unxt/_src/unitsystems/core.py
+++ b/src/unxt/_src/unitsystems/core.py
@@ -12,14 +12,8 @@ import jax.tree_util as jtu
 import numpy as np
 from astropy.constants import (  # pylint: disable=E0611
     G as const_G,  # noqa: N811
-    Ryd as const_Ryd,
-    a0 as const_a0,
     c as const_c,
-    e as const_e,
-    h as const_h,
     hbar as const_hbar,
-    k_B as const_kB,
-    m_e as const_me,
 )
 from astropy.units import UnitBase as AstropyUnitBase
 from plum import dispatch
@@ -36,6 +30,7 @@ from .flags import (
     PlanckUSysFlag,
     StandardUSysFlag,
 )
+from .named_units import ATOMIC_UNITS, PLANCK_UNITS
 from .utils import parse_dimlike_name
 from unxt.dims import dimension_of
 from unxt.units import unit
@@ -216,7 +211,7 @@ def unitsystem(name: str, /) -> AbstractUnitSystem:
     DimensionlessUnitSystem()
 
     >>> unitsystem("planck")
-    LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08 kg"), time=Unit("...e-44 s"), temperature=Unit("...e+32 K"))
+    LengthMassTimeTemperatureUnitSystem(length=Unit("l_P"), mass=Unit("m_P"), time=Unit("t_P"), temperature=Unit("T_P"))
 
     A single string is looked up as a *system* name, not a unit. A string that
     is not a registered system -- e.g. a unit like ``"m"`` -- raises a clear
@@ -450,20 +445,14 @@ def unitsystem(flag: type[PlanckUSysFlag], /, *args: Any) -> AbstractUnitSystem:
     >>> from unxt.unitsystems import unitsystem, PlanckUSysFlag
 
     >>> unitsystem(PlanckUSysFlag)
-    LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08 kg"), time=Unit("...e-44 s"), temperature=Unit("...e+32 K"))
+    LengthMassTimeTemperatureUnitSystem(length=Unit("l_P"), mass=Unit("m_P"), time=Unit("t_P"), temperature=Unit("T_P"))
 
     """  # noqa: E501
     _reject_extra_args(flag, args)
-    length = np.sqrt(const_hbar * const_G / const_c**3).decompose()
-    mass = np.sqrt(const_hbar * const_c / const_G).decompose()
-    time = np.sqrt(const_hbar * const_G / const_c**5).decompose()
-    temperature = (np.sqrt(const_hbar * const_c**5 / const_G) / const_kB).decompose()
-    return unitsystem(
-        length,
-        mass,
-        time,
-        temperature,
-    )
+    # Named units, so the system spells itself as ``l_P`` rather than as a
+    # six-significant-figure scale times a metre. They are defined from these
+    # same constants in ``named_units``.
+    return unitsystem(*PLANCK_UNITS)
 
 
 @dispatch
@@ -479,22 +468,13 @@ def unitsystem(flag: type[AtomicUSysFlag], /, *args: Any) -> AbstractUnitSystem:
     >>> from unxt.unitsystems import unitsystem, AtomicUSysFlag
 
     >>> unitsystem(AtomicUSysFlag)
-    LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
+    LengthMassTimeElectricalChargeUnitSystem(length=Unit("a_0"), mass=Unit("m_e"), time=Unit("t_au"), electrical_charge=Unit("e"))
 
     """  # noqa: E501
     _reject_extra_args(flag, args)
-    # Hartree energy E_h = 2 * Rydberg energy (NOT one Rydberg).
-    e_hartree = 2 * const_Ryd * const_h * const_c
-    length = const_a0.decompose()
-    mass = const_me.decompose()
-    time = (const_hbar / e_hartree).decompose()
-    charge = const_e.si.decompose()
-    return unitsystem(
-        length,
-        mass,
-        time,
-        charge,
-    )
+    # Named units; see ``named_units``, where the Hartree energy used for the
+    # time unit is defined as *twice* the Rydberg energy.
+    return unitsystem(*ATOMIC_UNITS)
 
 
 # ----

--- a/src/unxt/_src/unitsystems/flags.py
+++ b/src/unxt/_src/unitsystems/flags.py
@@ -173,7 +173,7 @@ class PlanckUSysFlag(NaturalUSysFlag):
 
     >>> usys = unitsystem(PlanckUSysFlag)
     >>> usys
-    LengthMassTimeTemperatureUnitSystem(length=Unit("...e-35 m"), mass=Unit("...e-08 kg"), time=Unit("...e-44 s"), temperature=Unit("...e+32 K"))
+    LengthMassTimeTemperatureUnitSystem(length=Unit("l_P"), mass=Unit("m_P"), time=Unit("t_P"), temperature=Unit("T_P"))
 
     >>> [str(d) for d in usys.base_dimensions]
     ['length', 'mass', 'time', 'temperature']
@@ -194,7 +194,7 @@ class AtomicUSysFlag(NaturalUSysFlag):
 
     >>> usys = unitsystem(AtomicUSysFlag)
     >>> usys
-    LengthMassTimeElectricalChargeUnitSystem(length=Unit("...e-11 m"), mass=Unit("...e-31 kg"), time=Unit("...e-17 s"), electrical_charge=Unit("...e-19 A s"))
+    LengthMassTimeElectricalChargeUnitSystem(length=Unit("a_0"), mass=Unit("m_e"), time=Unit("t_au"), electrical_charge=Unit("e"))
 
     >>> [str(d) for d in usys.base_dimensions]
     ['length', 'mass', 'time', 'electrical charge']

--- a/src/unxt/_src/unitsystems/named_units.py
+++ b/src/unxt/_src/unitsystems/named_units.py
@@ -1,0 +1,137 @@
+"""Named units for the fully-determined natural unit systems.
+
+`astropy.units` has no names for the Planck or Hartree atomic base units, so
+they can only be spelled as a scale times an SI unit -- and
+`astropy.units.UnitBase.to_string` truncates past six significant figures, so
+that spelling neither reads well nor reparses:
+
+    >>> import unxt as u
+    >>> u.unitsystems.planck["length"].to_string()  # doctest: +SKIP
+    '1.61626e-35 m'
+
+Naming them fixes both at once: ``l_P`` is short, and it reparses exactly.
+
+Each unit is *defined from the same constant expression* that builds its unit
+system rather than from a hard-coded number, so the values track whatever
+CODATA revision `astropy.constants` ships.
+
+The units are registered with `astropy.units.add_enabled_units` at import, so
+``unxt.unit("l_P")`` resolves. That mutates astropy's registry process-wide --
+a deliberate trade for making the spelling round-trip. All eight names were
+checked to be unclaimed; note that ``a0`` and ``Eh`` are *not* free (astropy
+already parses them as dimensionless and as a time, respectively), which is
+why the Bohr radius is ``a_0`` and there is no Hartree-energy unit here.
+
+Upstreaming these into astropy would let unxt drop this module; see the
+tracking issue.
+"""
+
+# ruff: noqa: N816
+#    ``l_P``/``m_P``/``t_P``/``T_P`` are the standard physics symbols for the
+#    Planck units; spelling them ``l_p`` would be wrong, not merely unidiomatic.
+
+__all__ = ("ATOMIC_UNITS", "PLANCK_UNITS")
+
+import astropy.units as apyu
+import numpy as np
+from astropy.constants import (  # pylint: disable=E0611
+    G as const_G,  # noqa: N811
+    Ryd as const_Ryd,
+    a0 as const_a0,
+    c as const_c,
+    e as const_e,
+    h as const_h,
+    hbar as const_hbar,
+    k_B as const_kB,
+    m_e as const_me,
+)
+
+# ============================================================================
+# Planck units: hbar = c = G = k_B = 1
+
+#: Planck length.
+l_P = apyu.def_unit(
+    "l_P",
+    np.sqrt(const_hbar * const_G / const_c**3).decompose(),
+    format={"latex": r"\ell_\mathrm{P}"},
+    doc="Planck length, sqrt(hbar G / c^3).",
+)
+
+#: Planck mass.
+m_P = apyu.def_unit(
+    "m_P",
+    np.sqrt(const_hbar * const_c / const_G).decompose(),
+    format={"latex": r"m_\mathrm{P}"},
+    doc="Planck mass, sqrt(hbar c / G).",
+)
+
+#: Planck time.
+t_P = apyu.def_unit(
+    "t_P",
+    np.sqrt(const_hbar * const_G / const_c**5).decompose(),
+    format={"latex": r"t_\mathrm{P}"},
+    doc="Planck time, sqrt(hbar G / c^5).",
+)
+
+#: Planck temperature.
+T_P = apyu.def_unit(
+    "T_P",
+    (np.sqrt(const_hbar * const_c**5 / const_G) / const_kB).decompose(),
+    format={"latex": r"T_\mathrm{P}"},
+    doc="Planck temperature, sqrt(hbar c^5 / G) / k_B.",
+)
+
+#: The Planck base units, in the order `unxt.unitsystems.planck` declares them.
+PLANCK_UNITS: tuple[apyu.UnitBase, ...] = (l_P, m_P, t_P, T_P)
+
+
+# ============================================================================
+# Atomic (Hartree) units: m_e = hbar = e = 4*pi*eps0 = 1
+
+#: Bohr radius. Spelled ``a_0`` because astropy already parses ``a0`` as
+#: dimensionless.
+a_0 = apyu.def_unit(
+    "a_0",
+    const_a0.decompose(),
+    # ``a_{0}`` not ``a_0``: astropy ignores a format string identical to the
+    # unit's own name, and then escapes the underscore into ``a\_0``.
+    format={"latex": r"a_{0}"},
+    doc="Bohr radius, the atomic unit of length.",
+)
+
+#: Electron rest mass.
+m_e = apyu.def_unit(
+    "m_e",
+    const_me.decompose(),
+    format={"latex": r"m_\mathrm{e}"},
+    doc="Electron rest mass, the atomic unit of mass.",
+)
+
+#: Atomic unit of time, ``hbar / E_h`` with ``E_h`` the Hartree energy.
+#:
+#: The Hartree energy is *twice* the Rydberg energy, not one Rydberg.
+t_au = apyu.def_unit(
+    "t_au",
+    (const_hbar / (2 * const_Ryd * const_h * const_c)).decompose(),
+    format={"latex": r"t_\mathrm{au}"},
+    doc="Atomic unit of time, hbar / E_h.",
+)
+
+#: Elementary charge. A unit named ``e`` does not disturb scientific notation:
+#: ``1e5 m`` still parses as a scale times a metre.
+e = apyu.def_unit(
+    "e",
+    const_e.si.decompose(),
+    format={"latex": r"e"},
+    doc="Elementary charge, the atomic unit of charge.",
+)
+
+#: The atomic base units, in the order `unxt.unitsystems.atomic` declares them.
+ATOMIC_UNITS: tuple[apyu.UnitBase, ...] = (a_0, m_e, t_au, e)
+
+
+# ============================================================================
+
+# Make the names parseable, so ``unxt.unit("l_P")`` resolves and a unit system's
+# ``repr`` reconstructs. This is process-wide; see the module docstring.
+apyu.add_enabled_units([*PLANCK_UNITS, *ATOMIC_UNITS])

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -2,6 +2,7 @@
 
 import itertools
 import pickle
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
@@ -13,6 +14,7 @@ from astropy import constants as const
 from astropy.constants import G as const_G  # noqa: N811
 
 import unxt as u
+import unxt.unitsystems as usx
 from unxt import dimension, unit, unitsystems
 from unxt._src.unitsystems import base as us_base
 from unxt._src.unitsystems.utils import parse_dimlike_name
@@ -691,3 +693,61 @@ class TestParseFieldNamesAndDimensions:
 
         with pytest.raises(ValueError, match="Some dimensions are repeated"):
             us_base.parse_field_names_and_dimensions(TwoLengths)
+
+
+class TestNamedNaturalUnits:
+    """The fully-determined natural systems spell their bases by name."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("planck", ["l_P", "m_P", "t_P", "T_P"]),
+            ("atomic", ["a_0", "m_e", "t_au", "e"]),
+        ],
+    )
+    def test_bases_are_named(self, name, expected):
+        """Each base prints as its physics symbol."""
+        usys = getattr(usx, name)
+        assert [str(b) for b in usys.base_units] == expected
+
+    @pytest.mark.parametrize("name", ["planck", "atomic"])
+    def test_names_reparse_exactly(self, name):
+        """The point of naming them: the spelling reconstructs.
+
+        ``to_string()`` truncates a scaled unit past six significant figures,
+        so ``1.61626e-35 m`` did not compare equal on reconstruction.
+        """
+        for base in getattr(usx, name).base_units:
+            assert u.unit(str(base)) == base
+
+    @pytest.mark.parametrize("name", ["planck", "atomic"])
+    def test_no_numeric_scale_in_repr(self, name):
+        """No scale factor survives into the repr."""
+        assert not re.search(r"\de[+-]\d", repr(getattr(usx, name)))
+
+    def test_values_track_astropy_constants(self):
+        """Defined from the constant expressions, not hard-coded numbers.
+
+        A CODATA revision in astropy must move these with it.
+        """
+        expected = np.sqrt(const.hbar * const_G / const.c**3).decompose()
+        assert (1 * usx.planck["length"]).to(apyu.m).value == pytest.approx(
+            expected.value
+        )
+
+    @pytest.mark.parametrize(
+        ("unit_str", "latex"),
+        [("l_P", r"\ell_\mathrm{P}"), ("a_0", r"a_{0}"), ("m_e", r"m_\mathrm{e}")],
+    )
+    def test_latex_is_typeset_not_escaped(self, unit_str, latex):
+        r"""Without a ``format`` override astropy emits ``\mathrm{a\_0}``."""
+        assert latex in u.unit(unit_str).to_string("latex")
+
+    def test_defining_e_does_not_disturb_scientific_notation(self):
+        """A unit named ``e`` is the elementary charge, not an exponent."""
+        assert u.unit("1e5 m") == u.unit("100000 m")
+        assert u.unit("1.5e3 kg") == u.unit("1500 kg")
+
+    def test_astropy_a0_is_untouched(self):
+        """``a0`` was already taken by astropy (dimensionless); we use ``a_0``."""
+        assert apyu.Unit("a0").physical_type == "dimensionless"

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -2,6 +2,7 @@
 
 import itertools
 import pickle
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
@@ -13,6 +14,7 @@ from astropy import constants as const
 from astropy.constants import G as const_G  # noqa: N811
 
 import unxt as u
+import unxt.unitsystems as usx
 from unxt import dimension, unit, unitsystems
 from unxt._src.unitsystems import base as us_base
 from unxt._src.unitsystems.utils import parse_dimlike_name
@@ -727,3 +729,61 @@ class TestParseFieldNamesAndDimensions:
 
         with pytest.raises(ValueError, match="Some dimensions are repeated"):
             us_base.parse_field_names_and_dimensions(TwoLengths)
+
+
+class TestNamedNaturalUnits:
+    """The fully-determined natural systems spell their bases by name."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("planck", ["l_P", "m_P", "t_P", "T_P"]),
+            ("atomic", ["a_0", "m_e", "t_au", "e"]),
+        ],
+    )
+    def test_bases_are_named(self, name, expected):
+        """Each base prints as its physics symbol."""
+        usys = getattr(usx, name)
+        assert [str(b) for b in usys.base_units] == expected
+
+    @pytest.mark.parametrize("name", ["planck", "atomic"])
+    def test_names_reparse_exactly(self, name):
+        """The point of naming them: the spelling reconstructs.
+
+        ``to_string()`` truncates a scaled unit past six significant figures,
+        so ``1.61626e-35 m`` did not compare equal on reconstruction.
+        """
+        for base in getattr(usx, name).base_units:
+            assert u.unit(str(base)) == base
+
+    @pytest.mark.parametrize("name", ["planck", "atomic"])
+    def test_no_numeric_scale_in_repr(self, name):
+        """No scale factor survives into the repr."""
+        assert not re.search(r"\de[+-]\d", repr(getattr(usx, name)))
+
+    def test_values_track_astropy_constants(self):
+        """Defined from the constant expressions, not hard-coded numbers.
+
+        A CODATA revision in astropy must move these with it.
+        """
+        expected = np.sqrt(const.hbar * const_G / const.c**3).decompose()
+        assert (1 * usx.planck["length"]).to(apyu.m).value == pytest.approx(
+            expected.value
+        )
+
+    @pytest.mark.parametrize(
+        ("unit_str", "latex"),
+        [("l_P", r"\ell_\mathrm{P}"), ("a_0", r"a_{0}"), ("m_e", r"m_\mathrm{e}")],
+    )
+    def test_latex_is_typeset_not_escaped(self, unit_str, latex):
+        r"""Without a ``format`` override astropy emits ``\mathrm{a\_0}``."""
+        assert latex in u.unit(unit_str).to_string("latex")
+
+    def test_defining_e_does_not_disturb_scientific_notation(self):
+        """A unit named ``e`` is the elementary charge, not an exponent."""
+        assert u.unit("1e5 m") == u.unit("100000 m")
+        assert u.unit("1.5e3 kg") == u.unit("1500 kg")
+
+    def test_astropy_a0_is_untouched(self):
+        """``a0`` was already taken by astropy (dimensionless); we use ``a_0``."""
+        assert apyu.Unit("a0").physical_type == "dimensionless"


### PR DESCRIPTION
Closes #868.

`astropy.units` has no names for the Planck or Hartree atomic base units, so
they could only be spelled as a scale times an SI unit — and `to_string()`
truncates past six significant figures, so that spelling neither read well nor
reparsed:

```pycon
>>> planck["length"]
Unit("1.61626e-35 m")          # before — and does *not* reparse
>>> planck["length"]
Unit("l_P")                    # after
```

Eight units: `l_P`, `m_P`, `t_P`, `T_P` for Planck; `a_0`, `m_e`, `t_au`, `e`
for Hartree atomic.

## Scope

Only these two systems get names. `hep` and `geometrized` take a free scale
(an energy and a length respectively), so their bases change with the
parameter — verified — and no fixed name would be correct:

```pycon
>>> unitsystem(HEPUSysFlag)["length"]              # 1.97327e-16 m
>>> unitsystem(HEPUSysFlag, energy="TeV")["length"] # 1.97327e-19 m
```

## Three traps, each checked rather than assumed

- **`a0` and `Eh` are not free.** astropy already parses them as
  *dimensionless* and as a *time* (`E`×`h`, hour). Either would have silently
  meant the wrong thing. Hence `a_0`, and no Hartree-energy unit here.
- **A unit named `e` does not disturb scientific notation** — `1e5 m` and
  `1.5e3 kg` still parse as a scale times a unit. Tested, since this was the
  main worry with the conventional name for elementary charge.
- **astropy ignores a `format` string identical to the unit's own name** and
  then escapes the underscore, so `a_0` renders `$\mathrm{a\_0}$` unless the
  override differs — `a_{0}` fixes it.

## Values track astropy

Each unit is defined from the *same constant expression* that already built
its unit system, not from a hard-coded number, so a CODATA revision in
`astropy.constants` moves these with it. A test pins that.

That also means doctests which hid these behind `...` no longer need to: a
name is stable across CODATA revisions where six significant figures were not.

## The registry trade-off

Registered with `add_enabled_units` at import, so `unxt.unit("l_P")` resolves
and the spelling round-trips. This mutates astropy's registry process-wide —
it is exactly why the change was kept out of #855, and the trade is
deliberate. All eight names were checked unclaimed.

Display alone would not have needed this (a `def_unit` knows its own name);
parsing does.

**Follow-up:** #876 tracks upstreaming these into astropy, which would let unxt
drop the module entirely.

## Interaction with #855

#855 should rebase on top of this. Its unit-system `repr` routes a system whose
units have no short exact spelling to the realization's registered *name*
(`unitsystem('planck')`). With these units named, `planck`'s bases *do* spell
exactly, so it will instead render `unitsystem(['l_P', 'm_P', 't_P', 'T_P'])` —
informative *and* round-trippable, and quite possibly making that name-lookup
path redundant.

## Verification

`nox -s "pytest(package='unxt')"` — 4068 passed. Every other package session
green (`interop_gala`, `parametric`, `api`, `hypothesis`, `interop_xarray`),
plus `unxts.linalg` 287. pylint 10.00/10, ruff clean.