### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/cd-publish-unxt-api.yml
+++ b/.github/workflows/cd-publish-unxt-api.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxt-api
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxt-hypothesis.yml
+++ b/.github/workflows/cd-publish-unxt-hypothesis.yml
@@ -183,7 +183,7 @@ jobs:
           name: Packages-unxt-hypothesis
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -214,4 +214,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxt.yml
+++ b/.github/workflows/cd-publish-unxt.yml
@@ -183,7 +183,7 @@ jobs:
           name: Packages-unxt
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -214,4 +214,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-api.yml
+++ b/.github/workflows/cd-publish-unxts-api.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-api
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-hypothesis.yml
+++ b/.github/workflows/cd-publish-unxts-hypothesis.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-hypothesis
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-interop-gala.yml
+++ b/.github/workflows/cd-publish-unxts-interop-gala.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-interop-gala
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-publish-unxts-interop-matplotlib.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-interop-matplotlib
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-publish-unxts-interop-xarray.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-interop-xarray
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-linalg.yml
+++ b/.github/workflows/cd-publish-unxts-linalg.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-linalg
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/cd-publish-unxts-parametric.yml
+++ b/.github/workflows/cd-publish-unxts-parametric.yml
@@ -182,7 +182,7 @@ jobs:
           name: Packages-unxts-parametric
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -213,4 +213,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

Every `cd-publish-*.yml` in this repo still pins `pypa/gh-action-pypi-publish@cef221092...` (`v1.14.0`), which bundles `packaging==25.0` / `twine==6.1.0`. Since `hatchling` 1.32.0 (2026-08-11) bumped its default core metadata version to 2.5 ([PEP 794](https://peps.python.org/pep-0794/)), any CD Publish run after that point will fail `verify-metadata` with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

#867 already fixed the equivalent problem on the *build* side (`hynek/build-and-inspect-python-package` → v3.0.1), but the *publish*-side pin was untouched, so this repo hasn't actually hit the failure yet only because there's been no push to `main` since hatchling 1.32.0 shipped — the next one will fail exactly like [GalacticDynamics/coordinax#717](https://github.com/GalacticDynamics/coordinax/pull/717) did.

**Fix:** bump the pin to `v1.14.2` (`packaging==26.2` / `twine==7.0.0`, which supports metadata 2.5) across all 10 `cd-publish-*.yml` workflows.

## Test plan

- [x] `prek run` passes on all 10 changed workflow files
- [x] Verified `v1.14.2`'s `requirements/runtime.txt` pins `packaging==26.2`/`twine==7.0.0` vs. `v1.14.0`'s `packaging==25.0`/`twine==6.1.0`
- [x] Verified the pinned commit SHA (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`) resolves to the `v1.14.2` tag in `pypa/gh-action-pypi-publish`
- [ ] CD Publish workflow succeeds end-to-end on merge to `main` (can't run the privileged publish workflow from here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
