### PR TITLE
✨ feat(linalg): register `ustrip` for `QuantityMatrix`

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -558,11 +558,9 @@ def unit_of(x: QuantityMatrix, /) -> UnitsMatrix:
     Without this, resolution reaches the generic `AbstractQuantity` rule, which
     coerces its result to an astropy `Unit` -- and a matrix of units is not one.
 
-    Deliberately without a doctest: under a combined ``pytest`` session (any
-    test module plus this one) plum's return conversion for this method raises
-    ``Cannot convert UnitsMatrix to UnitsMatrix``, though the call itself works
-    in every other context, including a plain interpreter and a doctest-only
-    run. Tracked in #881; covered by `tests/test_quantity_matrix.py` instead.
+    No doctest here: under a combined ``pytest`` session plum's return
+    conversion raises ``Cannot convert UnitsMatrix to UnitsMatrix`` (#881),
+    though the call works everywhere else. Covered by a test instead.
     """
     return x.unit
 
@@ -609,46 +607,35 @@ def ustrip(units: str, x: QuantityMatrix, /) -> Array:
     >>> bool(jnp.allclose(u.ustrip("", q), jnp.eye(2)))
     True
 
-    Mixed entries are fine when they share a dimension:
+    Mixed entries are fine when each is convertible to the target:
 
-    >>> mixed = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+    >>> mixed = QuantityMatrix(
+    ...     jnp.array([[1000.0, 1.0], [1000.0, 1.0]]), (("m", "km"), ("m", "km"))
+    ... )
     >>> bool(jnp.allclose(u.ustrip("km", mixed), jnp.ones((2, 2))))
     True
 
     """
-    return uconvert(UnitsMatrix.full(x.unit.shape, units), x).value
+    return ustrip(UnitsMatrix.full(x.unit.shape, units), x)
 
 
 @plum.dispatch
-def ustrip(flag: type[AllowValue], units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
-    """`AllowValue` form, for code that also handles bare arrays.
+def ustrip(
+    flag: type[AllowValue], units: UnitsMatrix | str, x: QuantityMatrix, /
+) -> Array:
+    """`AllowValue` form of both spellings, for code that also handles arrays.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
     >>> from unxt.quantity import AllowValue
     >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
 
-    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
-    >>> u.ustrip(AllowValue, UnitsMatrix.full((2, 2), ""), q).shape
-    (2, 2)
-
-    """
-    del flag
-    return ustrip(units, x)
-
-
-@plum.dispatch
-def ustrip(flag: type[AllowValue], units: str, x: QuantityMatrix, /) -> Array:
-    """`AllowValue` form with a single unit.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> from unxt.quantity import AllowValue
-    >>> from unxts.linalg import QuantityMatrix
-
-    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
-    >>> u.ustrip(AllowValue, "", q).shape
-    (2, 2)
+    >>> q = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+    >>> bool(jnp.allclose(u.ustrip(AllowValue, "km", q), jnp.ones((2, 2))))
+    True
+    >>> target = UnitsMatrix.full((2, 2), "km")
+    >>> bool(jnp.allclose(u.ustrip(AllowValue, target, q), jnp.ones((2, 2))))
+    True
 
     """
     del flag

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -552,6 +552,22 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
 
 
 @plum.dispatch
+def unit_of(x: QuantityMatrix, /) -> UnitsMatrix:
+    """Return the `UnitsMatrix` of a ``QuantityMatrix``.
+
+    Without this, resolution reaches the generic `AbstractQuantity` rule, which
+    coerces its result to an astropy `Unit` -- and a matrix of units is not one.
+
+    Deliberately without a doctest: under a combined ``pytest`` session (any
+    test module plus this one) plum's return conversion for this method raises
+    ``Cannot convert UnitsMatrix to UnitsMatrix``, though the call itself works
+    in every other context, including a plain interpreter and a doctest-only
+    run. Tracked in #881; covered by `tests/test_quantity_matrix.py` instead.
+    """
+    return x.unit
+
+
+@plum.dispatch
 def ustrip(units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
     """Convert a ``QuantityMatrix`` to ``units`` and drop them.
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -594,10 +594,12 @@ def ustrip(units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
 
 @plum.dispatch
 def ustrip(units: str, x: QuantityMatrix, /) -> Array:
-    """Strip a *homogeneous* ``QuantityMatrix`` to a single unit.
+    """Strip a ``QuantityMatrix`` to one unit shared by every element.
 
-    The common case -- most often ``""`` for a dimensionless matrix -- without
-    making the caller build a `UnitsMatrix` of identical entries by hand.
+    Saves building a `UnitsMatrix` of identical entries by hand; most often
+    ``""`` for a dimensionless matrix. The matrix need not be *homogeneous* --
+    conversion is elementwise, so any entry convertible to ``units`` is fine,
+    and one that is not raises `UnitConversionError`.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -605,6 +607,12 @@ def ustrip(units: str, x: QuantityMatrix, /) -> Array:
 
     >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
     >>> bool(jnp.allclose(u.ustrip("", q), jnp.eye(2)))
+    True
+
+    Mixed entries are fine when they share a dimension:
+
+    >>> mixed = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+    >>> bool(jnp.allclose(u.ustrip("km", mixed), jnp.ones((2, 2))))
     True
 
     """
@@ -626,7 +634,7 @@ def ustrip(flag: type[AllowValue], units: UnitsMatrix, x: QuantityMatrix, /) -> 
 
     """
     del flag
-    return uconvert(units, x).value
+    return ustrip(units, x)
 
 
 @plum.dispatch
@@ -644,4 +652,4 @@ def ustrip(flag: type[AllowValue], units: str, x: QuantityMatrix, /) -> Array:
 
     """
     del flag
-    return uconvert(UnitsMatrix.full(x.unit.shape, units), x).value
+    return ustrip(units, x)

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -549,3 +549,83 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
         return x
     value = _convert_value(x.value, x.unit, to_units)
     return QuantityMatrix._mk(value=value, unit=to_units)
+
+
+@plum.dispatch
+def ustrip(units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
+    """Convert a ``QuantityMatrix`` to ``units`` and drop them.
+
+    The companion to `uconvert` above, and the reason it is needed: with no
+    dispatch here, resolution falls through to the generic `AbstractQuantity`
+    rule, which does ``x.unit.to(...)``. A `UnitsMatrix` has no ``.to`` -- it is
+    a matrix of units, not one unit -- so the call fails with an `AttributeError`
+    pointing into the astropy interop rather than at the real cause.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+
+    >>> q = QuantityMatrix(
+    ...     jnp.array([[1.0, 2.0], [3.0, 4.0]]), (("m", "m"), ("m", "m"))
+    ... )
+    >>> got = u.ustrip(UnitsMatrix.full((2, 2), "km"), q)
+    >>> bool(jnp.allclose(got, jnp.array([[0.001, 0.002], [0.003, 0.004]])))
+    True
+
+    """
+    return uconvert(units, x).value
+
+
+@plum.dispatch
+def ustrip(units: str, x: QuantityMatrix, /) -> Array:
+    """Strip a *homogeneous* ``QuantityMatrix`` to a single unit.
+
+    The common case -- most often ``""`` for a dimensionless matrix -- without
+    making the caller build a `UnitsMatrix` of identical entries by hand.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
+    >>> bool(jnp.allclose(u.ustrip("", q), jnp.eye(2)))
+    True
+
+    """
+    return uconvert(UnitsMatrix.full(x.unit.shape, units), x).value
+
+
+@plum.dispatch
+def ustrip(flag: type[AllowValue], units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
+    """`AllowValue` form, for code that also handles bare arrays.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+    >>> from unxts.linalg import QuantityMatrix, UnitsMatrix
+
+    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
+    >>> u.ustrip(AllowValue, UnitsMatrix.full((2, 2), ""), q).shape
+    (2, 2)
+
+    """
+    del flag
+    return uconvert(units, x).value
+
+
+@plum.dispatch
+def ustrip(flag: type[AllowValue], units: str, x: QuantityMatrix, /) -> Array:
+    """`AllowValue` form with a single unit.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxt.quantity import AllowValue
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
+    >>> u.ustrip(AllowValue, "", q).shape
+    (2, 2)
+
+    """
+    del flag
+    return uconvert(UnitsMatrix.full(x.unit.shape, units), x).value

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -2574,3 +2574,15 @@ class TestInvQuantityMatrix:
         Ainv = quax.quaxify(qm_inv)(A)
         product = A.value @ Ainv.value
         assert jnp.allclose(product, jnp.eye(2), atol=1e-6)
+
+
+@pytest.mark.xfail(
+    reason="#881: plum resolves `-> UnitsMatrix` to a second class object under "
+    "a combined pytest session, so the return conversion fails. `unit_of` "
+    "itself works -- in a plain interpreter, and in a doctest-only run.",
+    strict=False,
+)
+def test_unit_of_returns_the_units_matrix():
+    """`unit_of` on a `QuantityMatrix` yields its `UnitsMatrix`."""
+    qm = QMat(jnp.eye(2), (("m", "rad"), ("m", "rad")))
+    assert u.unit_of(qm).to_string() == "((m, rad), (m, rad))"


### PR DESCRIPTION
Closes #879.

## The gap

`unxts.linalg` registers `uconvert` for `(UnitsMatrix, QuantityMatrix)` but not `ustrip`, so resolution falls through to the generic `AbstractQuantity` rule:

```
unxt/_interop/unxt_interop_astropy/quantity.py:303
    value = x.unit.to(u, uapi.ustrip(x))
```

That assumes a scalar astropy unit. A `UnitsMatrix` is a *matrix* of units and has no `.to`, so callers get an `AttributeError` pointing into the astropy interop rather than at the real cause. `quaxed.numpy.allclose` fails the same way.

The module already knew — `_quantity_matrix.py:178` notes *"UnitsMatrix unit, for which `unit_of`/`ustrip` have no scalar-unit"*.

## The change

Four dispatches, all delegating to the existing `uconvert`, which already does the elementwise work via `_convert_value`:

| | |
| --- | --- |
| `ustrip(UnitsMatrix, QuantityMatrix)` | the direct form |
| `ustrip(str, QuantityMatrix)` | homogeneous case — most often `""` — so callers need not hand-build a `UnitsMatrix` of identical entries |
| `ustrip(AllowValue, UnitsMatrix, QuantityMatrix)` | for code that also handles bare arrays |
| `ustrip(AllowValue, str, QuantityMatrix)` | ditto |

Verified: `m → km` scales correctly, heterogeneous `m/rad → km/deg` converts per element (2 rad → 114.59°), and an incompatible target still raises `UnitConversionError`.

## `unit_of` is included

An earlier revision left it out, on the belief that `unxt`'s abstract declaration (`-> UnitBase | FunctionUnitBase`) would reject a `UnitsMatrix` return. **That was wrong** — plum enforces each method's own return annotation, not a sibling's, and `u.unit_of(qm)` returns a `UnitsMatrix` correctly in a plain interpreter and in a doctest-only run of this package. No API widening is required.

What does fail is narrower and unrelated to the contract: under a *combined* pytest session (any test module alongside the source) plum resolves `-> UnitsMatrix` to a second class object, and the return conversion raises

```
Cannot convert `UnitsMatrix("((m, rad), (m, rad))")` to `unxts.linalg._src._units_matrix.UnitsMatrix`
```

i.e. it cannot convert the class to itself. Filed separately as #881. `unit_of` ships here; its test is `xfail`ed pointing at that issue, and the docstring records why it carries no example. `ustrip` returns `Array` and is unaffected.

## Verification

- `packages/unxts.linalg`: **zero new failures** against the pre-change baseline (which has 10 unrelated pre-existing failures on `main`)
- Doctests added for each dispatch, written dtype-agnostically since this suite runs without x64

## Downstream

GalacticDynamics/coordinax#716 currently hand-rolls what `ustrip` should do — comparing against `UnitsMatrix.full(shape, "")` then reading `.value` — in three places: the `O(n)` diagonal fast path in `quadratic_form._contract`, `norm`'s bare-array overload, and several tests. Those collapse to a single `ustrip` call once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
