### PR TITLE
ci: parallelize test jobs with pytest-xdist, trim macOS/Windows matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,8 @@ jobs:
         run: uv sync --no-default-groups --extra all --group test-all --upgrade
 
       - name: Test package
-        run: uv run --no-sync pytest -n logical --dist=loadfile
+        run:
+          uv run --no-sync pytest --benchmark-disable -n logical --dist=loadfile
 
   test-interoperability:
     name: Check Interoperability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,23 @@ jobs:
       matrix:
         python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS runners bill at 10x the Linux rate and Windows at 2x
+        # (https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions).
+        # All 3 Python versions are already fully exercised on Linux; running
+        # them again on macOS/Windows is cross-OS coverage, not cross-version
+        # coverage, so one version per non-Linux OS is enough to catch a
+        # platform-specific break. Pin it to the newest version so it also
+        # doubles as a "does the latest supported Python work on this OS"
+        # check.
+        exclude:
+          - runs-on: macos-latest
+            python-version: "3.12"
+          - runs-on: macos-latest
+            python-version: "3.13"
+          - runs-on: windows-latest
+            python-version: "3.12"
+          - runs-on: windows-latest
+            python-version: "3.13"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ concurrency:
 
 env:
   PYTHON_VERSIONS: '["3.12", "3.13", "3.14"]'
+  # NB: the tests-unxt job's exclude list (lines 144-152) hardcodes these
+  # versions; update it if this changes, or macOS/Windows will silently run the
+  # full matrix (GitHub Actions does not warn when exclude entries go stale).
   # Many color libraries just need this to be set to any value, but at least
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
@@ -163,6 +166,16 @@ jobs:
         run: |
           uv sync --no-default-groups --group nox --group test --locked --package unxt
 
+      # Parallelization via pytest-xdist: -n logical and --dist=loadfile. The
+      # --dist=loadfile strategy is required (not tuning): Sybil's doctest
+      # regions within one document share a namespace and must run in order in a
+      # single worker; the default --dist=load would shard them across workers
+      # and break those tests. --benchmark-disable appears on only 4 jobs
+      # (tests-unxt, test-oldest, test-newest, test-interoperability):
+      # pytest-benchmark is not installed in per-package job environments, and on
+      # these 4 the flag is required because pyproject.toml's filterwarnings =
+      # ["error",...] turns benchmark's xdist-auto-disable warning into an
+      # INTERNALERROR. Do not add this flag to other jobs without verifying.
       - name: Test package
         run: |
           uv run --frozen --package unxt nox -s "pytest(package='unxt')" -- --cov --cov-report=xml --cov-report=term --durations=20 --benchmark-disable -n logical --dist=loadfile
@@ -326,6 +339,7 @@ jobs:
           # `hypothesis`, so sybil mis-imports it. Run these via pytest's
           # namespace-aware --doctest-modules (doctest plugin re-enabled by
           # overriding addopts, which otherwise sets `-p no:doctest`).
+          # These src invocations run serially (no xdist), by design -- not oversight.
           uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
           uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/tests --cov=packages/unxts.hypothesis/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,7 +619,7 @@ jobs:
         run: uv sync --no-default-groups --extra all --group test-all --upgrade
 
       - name: Test package
-        run:
+        run: |
           uv run --no-sync pytest --benchmark-disable -n logical --dist=loadfile
 
   test-interoperability:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxt nox -s "pytest(package='unxt')" -- --cov --cov-report=xml --cov-report=term --durations=20
+          uv run --frozen --package unxt nox -s "pytest(package='unxt')" -- --cov --cov-report=xml --cov-report=term --durations=20 --benchmark-disable -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -186,7 +186,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxt-api pytest packages/unxt-api/tests --cov=packages/unxt-api/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxt-api pytest packages/unxt-api/tests --cov=packages/unxt-api/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -226,7 +226,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxt-hypothesis pytest packages/unxt-hypothesis/tests --cov=packages/unxt-hypothesis/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxt-hypothesis pytest packages/unxt-hypothesis/tests --cov=packages/unxt-hypothesis/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -265,7 +265,7 @@ jobs:
       - name: Test package
         run: |
           uv run --frozen --package unxts-api pytest packages/unxts.api/src
-          uv run --frozen --package unxts-api pytest packages/unxts.api/tests --cov=packages/unxts.api/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-api pytest packages/unxts.api/tests --cov=packages/unxts.api/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -310,7 +310,7 @@ jobs:
           # namespace-aware --doctest-modules (doctest plugin re-enabled by
           # overriding addopts, which otherwise sets `-p no:doctest`).
           uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
-          uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/tests --cov=packages/unxts.hypothesis/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-hypothesis pytest packages/unxts.hypothesis/tests --cov=packages/unxts.hypothesis/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -353,7 +353,7 @@ jobs:
           # src doctests: leaf dir `unxts/interop/gala` shadows the installed
           # `gala`, so sybil mis-imports it; use namespace-aware --doctest-modules.
           uv run --frozen --package unxts-interop-gala pytest packages/unxts.interop.gala/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"
-          uv run --frozen --package unxts-interop-gala pytest packages/unxts.interop.gala/tests --cov=packages/unxts.interop.gala/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-interop-gala pytest packages/unxts.interop.gala/tests --cov=packages/unxts.interop.gala/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -393,7 +393,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxts-interop-matplotlib pytest packages/unxts.interop.matplotlib/tests --cov=packages/unxts.interop.matplotlib/src --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-interop-matplotlib pytest packages/unxts.interop.matplotlib/tests --cov=packages/unxts.interop.matplotlib/src --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -438,7 +438,7 @@ jobs:
           # Both invocations measure coverage (the second appends), so the
           # doctest-only lines are not reported as uncovered.
           uv run --frozen --package unxts-interop-xarray pytest packages/unxts.interop.xarray/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE" --cov=packages/unxts.interop.xarray/src --cov-report=
-          uv run --frozen --package unxts-interop-xarray pytest packages/unxts.interop.xarray/tests --cov=packages/unxts.interop.xarray/src --cov-append --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-interop-xarray pytest packages/unxts.interop.xarray/tests --cov=packages/unxts.interop.xarray/src --cov-append --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -491,7 +491,7 @@ jobs:
           # namespace package's leaf dir is imported under one name for src and
           # another for tests, so co-collecting them double-imports the module.
           uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/src --cov=packages/unxts.parametric/src --cov-report=
-          uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/tests --cov=packages/unxts.parametric/src --cov-append --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-parametric pytest packages/unxts.parametric/tests --cov=packages/unxts.parametric/src --cov-append --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -534,7 +534,7 @@ jobs:
           # namespace package's leaf dir is imported under one name for src and
           # another for tests, so co-collecting them double-imports the module.
           uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/src --cov=packages/unxts.linalg/src --cov-report=
-          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/tests --cov=packages/unxts.linalg/src --cov-append --cov-report=xml --cov-report=term
+          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/tests --cov=packages/unxts.linalg/src --cov-append --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -565,7 +565,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxt --extra all --group test-all --resolution lowest-direct pytest --cov --cov-report=xml --cov-report=term --durations=20 --mpl
+          uv run --frozen --package unxt --extra all --group test-all --resolution lowest-direct pytest --cov --cov-report=xml --cov-report=term --durations=20 --mpl --benchmark-disable -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -588,7 +588,7 @@ jobs:
         run: uv sync --no-default-groups --extra all --group test-all --upgrade
 
       - name: Test package
-        run: uv run --no-sync pytest
+        run: uv run --no-sync pytest -n logical --dist=loadfile
 
   test-interoperability:
     name: Check Interoperability
@@ -610,7 +610,7 @@ jobs:
 
       - name: Test package
         run: |
-          uv run --frozen --package unxt --extra all --group test-all pytest --cov --cov-report=xml --cov-report=term --durations=20 --mpl
+          uv run --frozen --package unxt --extra all --group test-all pytest --cov --cov-report=xml --cov-report=term --durations=20 --mpl --benchmark-disable -n logical --dist=loadfile
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/packages/unxt-api/pyproject.toml
+++ b/packages/unxt-api/pyproject.toml
@@ -42,6 +42,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxt-hypothesis/pyproject.toml
+++ b/packages/unxt-hypothesis/pyproject.toml
@@ -42,6 +42,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
   "unxt",
 ]

--- a/packages/unxts.hypothesis/pyproject.toml
+++ b/packages/unxts.hypothesis/pyproject.toml
@@ -42,6 +42,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.interop.gala/pyproject.toml
+++ b/packages/unxts.interop.gala/pyproject.toml
@@ -48,6 +48,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.interop.matplotlib/pyproject.toml
+++ b/packages/unxts.interop.matplotlib/pyproject.toml
@@ -41,6 +41,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.interop.xarray/pyproject.toml
+++ b/packages/unxts.interop.xarray/pyproject.toml
@@ -41,6 +41,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -48,6 +48,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ test = [
   "pytest-cov>=6.2.1",
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
+  "pytest-xdist>=3.6.1",
   "sybil[pytest]>=9.2.0",
 ]
 test-all = [{ include-group = "test" }, { include-group = "test-mpl" }]

--- a/uv.lock
+++ b/uv.lock
@@ -4055,6 +4055,7 @@ dev = [
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-mpl" },
+    { name = "pytest-xdist" },
     { name = "pytz" },
     { name = "quax" },
     { name = "sphinx" },
@@ -4122,6 +4123,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 test-all = [
@@ -4135,6 +4137,7 @@ test-all = [
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-mpl" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 test-mpl = [
@@ -4232,6 +4235,7 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "pytz", specifier = ">=2024.2" },
     { name = "quax", specifier = ">=0.4.2" },
     { name = "sphinx", specifier = ">=7.0" },
@@ -4297,6 +4301,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 test-all = [
@@ -4310,6 +4315,7 @@ test-all = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 test-mpl = [
@@ -4348,6 +4354,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4362,6 +4369,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4380,6 +4388,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4394,6 +4403,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4412,6 +4422,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
     { name = "unxt" },
 ]
@@ -4427,6 +4438,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
     { name = "unxt", editable = "." },
 ]
@@ -4448,6 +4460,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4466,6 +4479,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4485,6 +4499,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4502,6 +4517,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4521,6 +4537,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4538,6 +4555,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4556,6 +4574,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4572,6 +4591,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4594,6 +4614,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4614,6 +4635,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 
@@ -4635,6 +4657,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-xdist" },
     { name = "sybil", extra = ["pytest"] },
 ]
 
@@ -4654,6 +4677,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
 ]
 


### PR DESCRIPTION
## Summary

Two independent CI-performance changes (Tasks 1-2 of the linked plan; Task 3 — folding `test-interoperability` into `tests-unxt` — is deliberately deferred to a follow-up PR since it changes test scope/gating and deserves its own before/after measurement):

- **Parallelize test execution.** Adds `pytest-xdist` and appends `-n logical --dist=loadfile` to every non-benchmark `pytest` invocation in CI (`--dist=loadfile` keeps each file's tests, including Sybil's stateful doctest regions, on a single worker while still parallelizing across files). `--benchmark-disable` is added wherever `pytest-benchmark` is installed, since this repo's `filterwarnings = ["error", ...]` turns pytest-benchmark's xdist-auto-disable warning into a hard failure otherwise. Locally, the main `unxt` suite dropped from ~139s to ~52s (2.7x) on an 8-core machine.
- **Right-size the `tests-unxt` OS × Python matrix.** macOS bills at 10x the Linux rate and Windows at 2x ([GitHub's published multipliers](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions)); running the full 3-version Python sweep on all three OSes was costing far more in billed compute than it bought in coverage, since all 3 versions are already fully exercised on Linux. macOS/Windows are now pinned to the newest supported version only (still a full cross-OS check), while Linux keeps the full matrix.

Full investigation, evidence, and plan: `docs/superpowers/plans/2026-08-14-ci-test-suite-performance.md` (this file is git-ignored locally via `.git/info/exclude` and is not part of this PR's diff — included here for context only).

Both changes were implemented and reviewed via subagent-driven development (task-scoped review + fix loop per task, then a whole-branch review). The whole-branch review caught one real gap worth calling out: an early attempt at the xdist change forgot to add `pytest-xdist` to 9 of the per-package jobs' own dependency groups, which would have broken those jobs outright — caught and fixed before this ever reached CI.

## Test plan

- [x] `uv lock --check` passes (dependency/lock consistency across all touched `pyproject.toml` files)
- [x] Local run of the main `unxt` suite with the new flags: 3992 passed, 49 skipped, 20 xfailed, 0 failures (52s, down from ~139s baseline)
- [x] YAML validated (`yaml.safe_load`) after every edit
- [x] Matrix expansion verified by hand: `tests-unxt` now produces exactly 5 jobs (ubuntu × {3.12, 3.13, 3.14}, macos × 3.14, windows × 3.14)
- [ ] **Not yet done — needs a real run on this PR:** this config has not executed on actual GitHub Actions yet. Please watch this PR's first CI run for anything local verification couldn't catch (real matrix/exclude expansion, xdist behavior on GHA's runners, `--mpl`/hypothesis tests under worker parallelism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)