### PR TITLE
💚 ci(release): publish to PyPI only after TestPyPI succeeds

### DIFF
--- a/.github/workflows/cd-publish-unxt-api.yml
+++ b/.github/workflows/cd-publish-unxt-api.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxt-hypothesis.yml
+++ b/.github/workflows/cd-publish-unxt-hypothesis.yml
@@ -189,7 +189,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxt.yml
+++ b/.github/workflows/cd-publish-unxt.yml
@@ -189,7 +189,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-api.yml
+++ b/.github/workflows/cd-publish-unxts-api.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-hypothesis.yml
+++ b/.github/workflows/cd-publish-unxts-hypothesis.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-interop-gala.yml
+++ b/.github/workflows/cd-publish-unxts-interop-gala.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-interop-matplotlib.yml
+++ b/.github/workflows/cd-publish-unxts-interop-matplotlib.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-interop-xarray.yml
+++ b/.github/workflows/cd-publish-unxts-interop-xarray.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-linalg.yml
+++ b/.github/workflows/cd-publish-unxts-linalg.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/cd-publish-unxts-parametric.yml
+++ b/.github/workflows/cd-publish-unxts-parametric.yml
@@ -188,7 +188,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate]
+    needs: [validate, publish-testpypi]
     if: needs.validate.outputs.publish_pypi == 'true'
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## What

In every `cd-publish-*.yml`, the `publish-testpypi` and `publish-pypi` jobs both had `needs: [validate]`, so they ran **concurrently**. A TestPyPI failure did nothing to stop the real PyPI upload — which is irreversible.

Now `publish-pypi` has `needs: [validate, publish-testpypi]`.

## Why it's safe

A skipped `needs` job would block `publish-pypi`, but that can't happen here: `validate` only sets `publish_pypi=true` in the verified-tag branch, and that branch sets `publish_testpypi=true` as well. TestPyPI is never skipped when PyPI is wanted.

## Trade-off

PyPI publishing now serializes behind TestPyPI (adds ~1 job of latency), and a TestPyPI-side failure — e.g. that version already uploaded there — will block the PyPI upload. No `if: always()` escape hatch was added; say the word if you'd rather have one.

Applied uniformly to all 10 publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)