### PR TITLE
fix(linalg): stop sybil double-importing UnitsMatrix under a combined pytest run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,10 +561,14 @@ jobs:
 
       - name: Test package
         run: |
-          # src doctests and tests are collected in separate invocations: the
-          # namespace package's leaf dir is imported under one name for src and
-          # another for tests, so co-collecting them double-imports the module.
-          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/src --cov=packages/unxts.linalg/src --cov-report=
+          # src doctests: sybil's leaf-based import at the namespace boundary
+          # would double-import the module under a second name (see conftest.py
+          # `_DOCTEST_MODULE_SRC`); run these via pytest's namespace-aware
+          # --doctest-modules (doctest plugin re-enabled by overriding addopts,
+          # which otherwise sets `-p no:doctest`). Both invocations measure
+          # coverage (the second appends), so the doctest-only lines are not
+          # reported as uncovered.
+          uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE" --cov=packages/unxts.linalg/src --cov-report=
           uv run --frozen --package unxts-linalg pytest packages/unxts.linalg/tests --cov=packages/unxts.linalg/src --cov-append --cov-report=xml --cov-report=term -n logical --dist=loadfile
 
       - name: Upload coverage report

--- a/conftest.py
+++ b/conftest.py
@@ -92,14 +92,10 @@ _sybil_collect_file = (docs + python).pytest()
 # of the real ``unxts.<pkg>`` one. For the packages whose leaf shadows an
 # installed library (gala/xarray/hypothesis) that name collides with the real
 # library and the import fails loudly. ``unxts.linalg`` has no such collision,
-# so the mis-import "succeeds" instead -- but it builds a second, wrongly
-# named module tree alongside the real ``unxts.linalg`` one, so any class
-# defined there (e.g. ``UnitsMatrix``) gets duplicated: the copy the doctest
-# sees and the copy the rest of the session imports are `!=`-different classes,
-# breaking `isinstance` checks and plum dispatch/conversion (see #881). Their
-# ``src`` doctests are instead run with pytest's
-# ``--doctest-modules --import-mode=importlib`` (namespace-aware) in each
-# package's CI job, so skip them here to avoid the mis-import.
+# so the mis-import silently succeeds instead, duplicating classes (e.g.
+# ``UnitsMatrix``) between the two module trees. Their ``src`` doctests are
+# instead run with pytest's ``--doctest-modules --import-mode=importlib``
+# (namespace-aware) in each package's CI job, so skip them here.
 # (unxts.interop.matplotlib also collides but has no ``src`` doctests, so sybil
 # never imports it; it stays on the normal path.)
 _DOCTEST_MODULE_SRC = (

--- a/conftest.py
+++ b/conftest.py
@@ -88,18 +88,25 @@ python = Sybil(
 _sybil_collect_file = (docs + python).pytest()
 
 # Sybil imports a doctest module by walking up through ``__init__.py`` dirs, so
-# at a PEP 420 namespace boundary it computes a leaf-based module name. For the
-# ``unxts.*`` packages whose leaf shadows an installed library
-# (gala/xarray/hypothesis) that name collides with the real library and the
-# import fails. Their ``src`` doctests are instead run with pytest's
+# at a PEP 420 namespace boundary it computes a leaf-based module name instead
+# of the real ``unxts.<pkg>`` one. For the packages whose leaf shadows an
+# installed library (gala/xarray/hypothesis) that name collides with the real
+# library and the import fails loudly. ``unxts.linalg`` has no such collision,
+# so the mis-import "succeeds" instead -- but it builds a second, wrongly
+# named module tree alongside the real ``unxts.linalg`` one, so any class
+# defined there (e.g. ``UnitsMatrix``) gets duplicated: the copy the doctest
+# sees and the copy the rest of the session imports are `!=`-different classes,
+# breaking `isinstance` checks and plum dispatch/conversion (see #881). Their
+# ``src`` doctests are instead run with pytest's
 # ``--doctest-modules --import-mode=importlib`` (namespace-aware) in each
-# package's CI job, so skip them here to avoid the failing sybil import.
+# package's CI job, so skip them here to avoid the mis-import.
 # (unxts.interop.matplotlib also collides but has no ``src`` doctests, so sybil
 # never imports it; it stays on the normal path.)
 _DOCTEST_MODULE_SRC = (
     "packages/unxts.interop.gala/src/",
     "packages/unxts.interop.xarray/src/",
     "packages/unxts.hypothesis/src/",
+    "packages/unxts.linalg/src/",
 )
 
 

--- a/packages/unxts.linalg/tests/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/test_quantity_matrix.py
@@ -2576,12 +2576,6 @@ class TestInvQuantityMatrix:
         assert jnp.allclose(product, jnp.eye(2), atol=1e-6)
 
 
-@pytest.mark.xfail(
-    reason="#881: plum resolves `-> UnitsMatrix` to a second class object under "
-    "a combined pytest session, so the return conversion fails. `unit_of` "
-    "itself works -- in a plain interpreter, and in a doctest-only run.",
-    strict=False,
-)
 def test_unit_of_returns_the_units_matrix():
     """`unit_of` on a `QuantityMatrix` yields its `UnitsMatrix`."""
     qm = QMat(jnp.eye(2), (("m", "rad"), ("m", "rad")))


### PR DESCRIPTION
## Summary

Fixes #881.

Sybil computes a doctest module's import name by walking up through `__init__.py` directories, so at the `unxts` PEP 420 namespace boundary it imports `packages/unxts.linalg/src` doctests as `linalg.*` instead of `unxts.linalg.*`. Unlike `unxts.interop.gala` / `unxts.interop.xarray` / `unxts.hypothesis` — which hit this same mechanism but fail loudly because their leaf name collides with an installed library — `linalg` has no installed package to collide with, so the mis-import silently "succeeds": it builds a *second*, wrongly-named module tree alongside the real `unxts.linalg` one, duplicating any class defined there (e.g. `UnitsMatrix`). Whichever copy a doctest sees is a `!=`-different class from the copy the rest of the pytest session imports, so `isinstance` checks and plum's return-type conversion both fail wherever a `-> UnitsMatrix` dispatch (like `unit_of`) is exercised in the same session as the package's own doctests — i.e. `pytest packages/unxts.linalg` (src + tests together).

Confirmed the mechanism directly: a debug test dumping `sys.modules` mid-run shows two live `UnitsMatrix` classes with different `id()`s, one under `linalg._src._units_matrix` (sybil's leaf-based name) and one under `unxts.linalg._src._units_matrix` (the real one).

The repo already has the fix for this exact class of bug — `conftest.py`'s `_DOCTEST_MODULE_SRC` skip-list plus a namespace-aware `--doctest-modules --import-mode=importlib` CI step, applied for gala/xarray/hypothesis. This PR applies the same fix to `unxts.linalg`.

## Changes

- `conftest.py`: add `packages/unxts.linalg/src/` to `_DOCTEST_MODULE_SRC` so sybil skips collecting its doctests under the wrong module name (in any combined session, not just CI); broadened the explanatory comment to cover the silent-duplicate-class failure mode, not just the loud import-collision one.
- `.github/workflows/ci.yml`: switch the `unxts-linalg` job's src-doctest step to the same `--doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"` invocation already used for gala/xarray/hypothesis, so src doctests keep running under the correct module name. (The job's previous split-invocation comment was a workaround for CI specifically; it didn't help local combined runs, which is what #881 reports.)

## Test plan

- [x] `pytest packages/unxts.linalg` (src + tests together, the exact repro from #881) — was 8 failed, now 374 passed
- [x] `pytest packages/unxts.linalg/src --doctest-modules -o addopts="--import-mode=importlib" -o consider_namespace_packages=true -o doctest_optionflags="ELLIPSIS NORMALIZE_WHITESPACE"` (new CI step) — 42 passed, same doctest-bearing functions/classes as before, just one item per docstring instead of per sybil example-region
- [x] `pytest packages/unxts.linalg/tests` — 262 passed, unaffected
- [x] `pytest packages/unxts.linalg src/unxt` (sanity check against the rest of the tree) — 2397 passed
- [x] pre-commit hooks (ruff, pyright/ty/mypy typing guards, yaml validation, etc.) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)