### PR TITLE
fix(test): ignore astropy's XDG config-dir race warning under pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,12 @@ filterwarnings = [
   "ignore:'mode' parameter is deprecated and will be removed in Pillow 13 \\(2026-10-15\\):DeprecationWarning",
   # pyparsing <- matplotlib
   "ignore:'parseAll' argument is deprecated, use 'parse_all':DeprecationWarning",
+  # astropy: pytest-xdist workers race to create ~/.astropy/{config,cache} on
+  # first import; whichever worker loses the race gets this warning. Category
+  # is UserWarning (AstropyUserWarning's base), not the astropy class itself:
+  # resolving that name would import astropy, which can re-trigger this same
+  # warning before the ignore rule is installed.
+  "ignore:XDG_(CONFIG|CACHE)_HOME is set to .*, but the default location, .*, already exists, and takes precedence:UserWarning",
 ]
 log_level = "INFO"
 minversion = "8.3"


### PR DESCRIPTION
## Summary
- pytest-xdist workers race to create `~/.astropy/config` on first `astropy` import; whichever worker loses the race gets an `AstropyUserWarning`, which `filterwarnings = "error"` turns into a collection-crashing error (`Different tests were collected between gwN and gwM`). Introduced as latent flakiness by #883's `-n logical --dist=loadfile` parallelization.
- Adds an `ignore` filter for the warning message. Category is the builtin `UserWarning` (which `AstropyUserWarning` subclasses), not `astropy.utils.exceptions.AstropyUserWarning` itself — resolving that dotted name forces `import astropy`, which can re-trigger the very same warning before the ignore rule is installed.
- Same fix already landed on `versions/v2.0.x` via #890.

## Test plan
- [x] Forced the race locally (pre-created `~/.astropy/config` + `XDG_CONFIG_HOME` set) against `tests/benchmark/test_dims.py` under 4 xdist workers — reproduced the crash before the fix, passed after.
- [x] Full `unxt` suite (`pytest --benchmark-disable -n logical --dist=loadfile`) passes.