### PR TITLE
docs(linalg): use `ul.QM` alias in code examples

### DIFF
--- a/packages/unxts.linalg/README.md
+++ b/packages/unxts.linalg/README.md
@@ -16,5 +16,5 @@ pip install unxts.linalg
 import jax.numpy as jnp
 import unxts.linalg as ul
 
-qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+qv = ul.QM(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
 ```

--- a/packages/unxts.linalg/docs/index.md
+++ b/packages/unxts.linalg/docs/index.md
@@ -74,7 +74,7 @@ Throughout these guides we import `unxt` as `u` and `unxts.linalg` as `ul` (so `
 A 1-D `QuantityMatrix` is a vector whose entries each have their own unit:
 
 ```{code-block} python
->>> qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+>>> qv = ul.QM(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
 >>> qv.unit.to_string()
 '(m, s, kg)'
 >>> 2 * qv

--- a/packages/unxts.linalg/docs/linear-algebra.md
+++ b/packages/unxts.linalg/docs/linear-algebra.md
@@ -23,9 +23,9 @@ The whole point of `QuantityMatrix` is that linear-algebra operations carry the 
 `matmul` contracts the shared axis and multiplies the corresponding units — here a dimensionless identity leaves a vector's units untouched:
 
 ```{code-block} python
->>> A = ul.QuantityMatrix(jnp.eye(3),
+>>> A = ul.QM(jnp.eye(3),
 ...                       unit=(("", "", ""), ("", "", ""), ("", "", "")))
->>> v = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+>>> v = ul.QM(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
 >>> ul.matvec(A, v).value
 Array([1., 2., 3.], dtype=float32)
 ```
@@ -33,9 +33,9 @@ Array([1., 2., 3.], dtype=float32)
 Units on the contracted axis are combined and converted to a common reference, so mixed units are handled correctly:
 
 ```{code-block} python
->>> A2 = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+>>> A2 = ul.QM(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
 ...                        unit=(("m", "km"), ("m", "km")))
->>> v2 = ul.QuantityMatrix(jnp.array([1.0, 1.0]), unit=("s", "s"))
+>>> v2 = ul.QM(jnp.array([1.0, 1.0]), unit=("s", "s"))
 >>> ul.matvec(A2, v2).value
 Array([2001., 4003.], dtype=float32)
 ```
@@ -50,11 +50,11 @@ A `QuantityMatrix` carries its logical 1-D/2-D units in the _trailing_ axes and 
 
 ```{code-block} python
 >>> # A batch of 2 matrices applied to a batch of 2 vectors.
->>> Ab = ul.QuantityMatrix(
+>>> Ab = ul.QM(
 ...     jnp.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
 ...     unit=(("m", "m"), ("m", "m")),
 ... )
->>> vb = ul.QuantityMatrix(jnp.ones((2, 2)), unit=("s", "s"))
+>>> vb = ul.QM(jnp.ones((2, 2)), unit=("s", "s"))
 >>> (Ab @ vb).value
 Array([[ 3.,  7.],
        [11., 15.]], dtype=float32)
@@ -67,7 +67,7 @@ There is one subtlety inherited from NumPy: a batched vector's value `(B, K)` is
 `.T` swaps both the values and the unit structure of a 2-D matrix:
 
 ```{code-block} python
->>> a = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+>>> a = ul.QM(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
 ...                       unit=(("m", "s"), ("kg", "rad")))
 >>> a.T.unit.to_string()
 '((m, kg), (s, rad))'
@@ -76,7 +76,7 @@ There is one subtlety inherited from NumPy: a batched vector's value `(B, K)` is
 `.diag()` extracts the diagonal as a 1-D `QuantityMatrix`, operating directly on the static unit structure so it works under `jax.jit`:
 
 ```{code-block} python
->>> M = ul.QuantityMatrix(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
+>>> M = ul.QM(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
 ...                       unit=(("m", "s", "kg"),
 ...                             ("m", "s", "kg"),
 ...                             ("m", "s", "kg")))
@@ -95,7 +95,7 @@ The determinant multiplies the main-diagonal units:
 
 ```{code-block} python
 >>> from unxts.linalg import det, inv
->>> G = ul.QuantityMatrix(jnp.array([[2.0, 0.0], [0.0, 3.0]]),
+>>> G = ul.QM(jnp.array([[2.0, 0.0], [0.0, 3.0]]),
 ...                       unit=(("m2", "m2"), ("m2", "m2")))
 >>> quax.quaxify(det)(G)
 Quantity(Array(6., dtype=float32), unit='m4')
@@ -104,7 +104,7 @@ Quantity(Array(6., dtype=float32), unit='m4')
 The inverse carries the reciprocal units:
 
 ```{code-block} python
->>> B = ul.QuantityMatrix(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
+>>> B = ul.QM(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
 ...                       unit=(("m2", "m2"), ("m2", "m2")))
 >>> r = quax.quaxify(inv)(B)
 >>> r.unit.to_string()

--- a/packages/unxts.linalg/docs/quantity-matrix.md
+++ b/packages/unxts.linalg/docs/quantity-matrix.md
@@ -13,7 +13,7 @@
 A 1-D `QuantityMatrix` takes a flat array and a tuple of units, one per element:
 
 ```{code-block} python
->>> qv = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
+>>> qv = ul.QM(jnp.array([1.0, 2.0, 3.0]), unit=("m", "s", "kg"))
 >>> qv.value
 Array([1., 2., 3.], dtype=float32)
 >>> qv.unit.to_string()
@@ -25,7 +25,7 @@ Array([1., 2., 3.], dtype=float32)
 A 2-D `QuantityMatrix` takes a 2-D array and a nested tuple of units:
 
 ```{code-block} python
->>> qm = ul.QuantityMatrix(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
+>>> qm = ul.QM(jnp.ones((2, 2)), unit=(("m", "s"), ("kg", "rad")))
 >>> qm.unit.to_string()
 '((m, s), (kg, rad))'
 >>> qm.ndim, qm.shape
@@ -47,14 +47,14 @@ True
 
 ```{code-block} python
 >>> v = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "s"), "z": u.Q(3.0, "kg")}
->>> ul.QuantityMatrix.from_cdict(v).unit.to_string()
+>>> ul.QM.from_cdict(v).unit.to_string()
 '(m, s, kg)'
 ```
 
 You may select and reorder a subset of keys:
 
 ```{code-block} python
->>> ul.QuantityMatrix.from_cdict(v, keys=("z", "x")).unit.to_string()
+>>> ul.QM.from_cdict(v, keys=("z", "x")).unit.to_string()
 '(kg, m)'
 ```
 
@@ -86,7 +86,7 @@ Quantity(Array(3., dtype=float32), unit='kg')
 Indexing a row of a 2-D matrix returns a 1-D `QuantityMatrix`, while a full `[i, j]` index returns a scalar `Quantity`:
 
 ```{code-block} python
->>> qm2 = ul.QuantityMatrix(jnp.ones((2, 3)),
+>>> qm2 = ul.QM(jnp.ones((2, 3)),
 ...                         unit=(("m", "s", "kg"), ("rad", "deg", "m")))
 >>> qm2[0]
 QuantityMatrix(Array([1., 1., 1.], dtype=float32), unit='(m, s, kg)')
@@ -100,8 +100,8 @@ Addition and subtraction convert each element of the right operand into the corr
 
 ```{code-block} python
 >>> import quaxed.numpy as qnp
->>> a = ul.QuantityMatrix(jnp.ones(3), unit=("m", "s", "kg"))
->>> b = ul.QuantityMatrix(jnp.ones(3), unit=("km", "ms", "g"))
+>>> a = ul.QM(jnp.ones(3), unit=("m", "s", "kg"))
+>>> b = ul.QM(jnp.ones(3), unit=("km", "ms", "g"))
 >>> result = qnp.add(a, b)
 >>> result.unit.to_string()
 '(m, s, kg)'
@@ -119,7 +119,7 @@ Array([2., 2., 2.], dtype=float32)
 You can convert a whole `QuantityMatrix` to a compatible unit structure with `uconvert`:
 
 ```{code-block} python
->>> q = ul.QuantityMatrix(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+>>> q = ul.QM(jnp.array([[1.0, 2.0], [3.0, 4.0]]),
 ...                       unit=(("m", "rad"), ("m", "rad")))
 >>> target = u.unit((("km", "deg"), ("km", "deg")))
 >>> q.uconvert(target).unit.to_string()
@@ -130,7 +130,7 @@ When every element shares the same unit, a `QuantityMatrix` converts to a plain 
 
 ```{code-block} python
 >>> import plum
->>> uniform = ul.QuantityMatrix(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
+>>> uniform = ul.QM(jnp.array([1.0, 2.0, 3.0]), unit=("m", "m", "m"))
 >>> plum.convert(uniform, u.Q)
 Quantity(Array([1., 2., 3.], dtype=float32), unit='m')
 ```

--- a/packages/unxts.linalg/docs/sharp-bits.md
+++ b/packages/unxts.linalg/docs/sharp-bits.md
@@ -28,7 +28,7 @@ rejected
 
 ```{code-block} python
 >>> import quax
->>> v = ul.QuantityMatrix(jnp.array([1.0, 2.0]), unit=("m", "s"))
+>>> v = ul.QM(jnp.array([1.0, 2.0]), unit=("m", "s"))
 >>> try:
 ...     quax.quaxify(ul.det)(v)
 ... except ValueError as e:
@@ -41,7 +41,7 @@ needs a 2-D matrix
 The `.diag()` **method** operates on the static unit structure and works for heterogeneous units, even under `jit`:
 
 ```{code-block} python
->>> M = ul.QuantityMatrix(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
+>>> M = ul.QM(jnp.diag(jnp.array([1.0, 2.0, 3.0])),
 ...                       unit=(("m", "s", "kg"),
 ...                             ("m", "s", "kg"),
 ...                             ("m", "s", "kg")))

--- a/packages/unxts.linalg/docs/tutorial-metric.md
+++ b/packages/unxts.linalg/docs/tutorial-metric.md
@@ -17,7 +17,7 @@ Consider a 2-D configuration space with a radial coordinate (metres) and an angu
 We build `g` as a 2×2 `QuantityMatrix` with per-element units:
 
 ```{code-block} python
->>> g = ul.QuantityMatrix(
+>>> g = ul.QM(
 ...     jnp.array([[1.0, 0.0], [0.0, 4.0]]),
 ...     unit=(("m2", "m2"), ("m2", "m2 / rad2")),
 ... )
@@ -61,7 +61,7 @@ inv on a QuantityMatrix requires uniform units (all entries equal)
 For a uniform-unit metric the inverse carries the single reciprocal unit:
 
 ```{code-block} python
->>> h = ul.QuantityMatrix(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
+>>> h = ul.QM(jnp.array([[4.0, 0.0], [0.0, 1.0]]),
 ...                       unit=(("m2", "m2"), ("m2", "m2")))
 >>> quax.quaxify(ul.inv)(h).unit.to_string()
 '((1 / m2, 1 / m2), (1 / m2, 1 / m2))'


### PR DESCRIPTION
## Summary
- Constructor calls in `unxts.linalg` docs and README now use the short `QM` alias instead of `QuantityMatrix`, matching how `u.Q` is used for `Quantity` elsewhere.
- Left the alias-identity demo line (`ul.QM is ul.QuantityMatrix`) and `repr()` output lines untouched, since the class's actual repr is always `QuantityMatrix(...)`.

## Test plan
- [x] `uv run pytest --doctest-glob="*.md" packages/unxts.linalg/docs packages/unxts.linalg/README.md` — 112 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)