### PR TITLE
ci: add weekly pre-release dependency check

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,10 +23,9 @@ jobs:
     outputs:
       python-versions: ${{ env.PYTHON_VERSIONS }}
     steps:
-      - id: versions
-        run: |
-          versions='${{ env.PYTHON_VERSIONS }}'
-          echo "versions=$versions" >> $GITHUB_OUTPUT
+      # `strategy.matrix` below can't read `env` directly, only `needs` -- this
+      # step exists solely to re-expose PYTHON_VERSIONS as a job output.
+      - run: "true"
 
   # Newest-supported deps (`uv sync --upgrade`) are already exercised weekly by
   # ci.yml's own `schedule` trigger via the `test-newest` job -- not duplicated
@@ -49,12 +48,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install with pre-release deps (alpha/beta/rc/nightly)
-        run:
+        run: >
           uv sync --no-default-groups --extra all --group test-all --upgrade
           --prerelease=allow
 
       - name: Test
-        run:
+        run: >
           uv run --no-sync pytest --benchmark-disable -n logical --dist=loadfile
 
   weekly-pass:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,69 @@
+name: Weekly CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 6am UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 3
+  PYTHON_VERSIONS: '["3.12", "3.13", "3.14"]'
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ env.PYTHON_VERSIONS }}
+    steps:
+      - id: versions
+        run: |
+          versions='${{ env.PYTHON_VERSIONS }}'
+          echo "versions=$versions" >> $GITHUB_OUTPUT
+
+  # Newest-supported deps (`uv sync --upgrade`) are already exercised weekly by
+  # ci.yml's own `schedule` trigger via the `test-newest` job -- not duplicated
+  # here.
+
+  pre-release:
+    name: Pre-release deps (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: [setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install with pre-release deps (alpha/beta/rc/nightly)
+        run:
+          uv sync --no-default-groups --extra all --group test-all --upgrade
+          --prerelease=allow
+
+      - name: Test
+        run:
+          uv run --no-sync pytest --benchmark-disable -n logical --dist=loadfile
+
+  weekly-pass:
+    name: Weekly CI Pass
+    runs-on: ubuntu-latest
+    needs: [setup, pre-release]
+    if: always()
+    steps:
+      - name: All required jobs passed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/weekly.yml`, mirroring the pattern from [nstarman/quax](https://github.com/nstarman/quax/blob/main/.github/workflows/weekly.yml)
- Weekly (Monday 6am UTC) + manual-dispatch job that installs with `--upgrade --prerelease=allow` and runs the test suite, to catch breakage from alpha/beta/rc/nightly builds of dependencies (e.g. jax) before they land in a stable release
- Newest-*stable*-deps coverage isn't duplicated here since `ci.yml`'s own `schedule` trigger already exercises that weekly via the `test-newest` job

## Test plan
- [x] `Validate GitHub Workflows` pre-commit hook passes (confirmed locally)
- [ ] Workflow runs successfully via `workflow_dispatch` after merge
