### PR TITLE
fix(quantity): forward extra lax reduce-primitive kwargs (out_sharding)

### DIFF
--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -3,7 +3,6 @@
 
 __all__: tuple[str, ...] = ()
 
-from collections.abc import Sequence
 from math import prod
 from typing import Any, Literal, TypeAlias, overload
 
@@ -4183,56 +4182,54 @@ def real_p(x: ABCQ, /) -> ABCQ:
 
 
 @quax.register(lax.reduce_and_p)
-def reduce_and_p(operand: ABCQ, /, *, axes: Sequence[int]) -> ABCQ:
+def reduce_and_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
     # `all` returns a dimensionless quantity sharing the operand's namespace
     # (per the Array API), matching `reduce_or_p` (`any`).
-    return _as_dimensionless_like(
-        operand, lax.reduce_and_p.bind(ustrip(operand), axes=tuple(axes))
-    )
+    return _as_dimensionless_like(operand, lax.reduce_and_p.bind(ustrip(operand), **kw))
 
 
 # ==============================================================================
 
 
 @quax.register(lax.reduce_max_p)
-def reduce_max_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    return revalue(operand, lax.reduce_max_p.bind(ustrip(operand), axes=axes))
+def reduce_max_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
+    return revalue(operand, lax.reduce_max_p.bind(ustrip(operand), **kw))
 
 
 # ==============================================================================
 
 
 @quax.register(lax.reduce_min_p)
-def reduce_min_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    return revalue(operand, lax.reduce_min_p.bind(ustrip(operand), axes=axes))
+def reduce_min_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
+    return revalue(operand, lax.reduce_min_p.bind(ustrip(operand), **kw))
 
 
 # ==============================================================================
 
 
 @quax.register(lax.reduce_or_p)
-def reduce_or_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    return type_np(operand)(lax.reduce_or_p.bind(ustrip(operand), axes=axes), unit=one)
+def reduce_or_p(operand: ABCQ, /, **kw: Any) -> ABCQ:
+    return type_np(operand)(lax.reduce_or_p.bind(ustrip(operand), **kw), unit=one)
 
 
 # ==============================================================================
 
 
 @quax.register(lax.reduce_prod_p)
-def reduce_prod_p(operand: ABCQ, /, *, axes: Axes) -> ABCQ:
-    value = lax.reduce_prod_p.bind(ustrip(operand), axes=axes)
+def reduce_prod_p(operand: ABCQ, /, *, axes: Axes, **kw: Any) -> ABCQ:
+    value = lax.reduce_prod_p.bind(ustrip(operand), axes=axes, **kw)
     u = operand.unit ** prod(operand.shape[ax] for ax in axes)
     return type_np(operand)(value, unit=u)
 
 
 @quax.register(lax.reduce_prod_p)
-def reduce_prod_p_a(operand: AbstractAngle, /, *, axes: Axes) -> ABCQ:
+def reduce_prod_p_a(operand: AbstractAngle, /, *, axes: Axes, **kw: Any) -> ABCQ:
     """Product-reduction of an Angle array.
 
     The product of N angles is not angular (``rad**N``), so it degrades to a
     plain `Quantity`, mirroring ``Angle * Angle``.
     """
-    return reduce_prod_p(convert(operand, Quantity), axes=axes)
+    return reduce_prod_p(convert(operand, Quantity), axes=axes, **kw)
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Fixes a CI failure on the "Newest supported deps" job (spotted on [#897](https://github.com/GalacticDynamics/unxt/pull/897), unrelated to that PR's docs-only changes): [run](https://github.com/GalacticDynamics/unxt/actions/runs/32185245947/job/95884008359?pr=897).

- Newer JAX passes an `out_sharding` keyword argument to the `lax.reduce_max_p`/`reduce_min_p`/`reduce_or_p`/`reduce_and_p`/`reduce_prod_p` primitives. unxt's `quax`-registered handlers for these five only accepted `axes`, so any quax-dispatched call on a `Quantity` (`jnp.max`, `jnp.min`, `jnp.linalg.matrix_rank`, `.all()`, `.any()`, `.prod()`, ...) raised `TypeError: got an unexpected keyword argument 'out_sharding'` under that newer JAX.
- `lax.reduce_sum_p`'s handler already forwarded arbitrary kwargs via `**kw`. Four of the five (`reduce_and_p`/`reduce_max_p`/`reduce_min_p`/`reduce_or_p`) only ever pass `axes` straight through to `.bind()`, so they now fold fully into that same `**kw`-only pattern — no need to name `axes` explicitly. `reduce_prod_p` (and its `Angle` variant) is the one exception: it also reads `axes` directly to compute the result unit's exponent, so it keeps `axes` as a named parameter alongside `**kw` for everything else.
- No behavior change against the currently-pinned JAX (0.10.1): none of these primitives pass `out_sharding` in that version, so `**kw` is empty and the bind call is identical to before.

## Test plan

- [x] `uv run pytest` on the affected areas (`reduce`/`aggregation`/`max`/`min`/`sum`/`prod`/`all`/`any`/`matrix_rank`) — 80 passed
- [x] Full root-package suite (`tests/`, `src/`, `README.md`) — 3135 passed, no regressions
- [x] `uv run nox -s pyright ty mypy` — all pass
- [x] `uv run prek run ruff-check ruff-format` on the changed file — pass
- [x] CI on this PR, including the newest-deps job that originally caught this

🤖 Generated with [Claude Code](https://claude.com/claude-code)