### PR TITLE
👷 ci: give Copilot a runner via copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,41 @@
+# Environment for Copilot cloud agent and Copilot code review.
+#
+# Copilot code review runs on a runner from this repository, taking its
+# environment from `copilot-code-review.yml` and falling back to this file.
+# With neither present it can fail to get a runner before its timeout, in which
+# case only the non-agentic review runs and `.github/skills/code-review/SKILL.md`
+# is never consulted.
+#
+# The job MUST be named `copilot-setup-steps`; only `steps`, `permissions`,
+# `runs-on`, `services`, `snapshot` and `timeout-minutes` are honoured.
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-packages --group dev --locked
+
+      - name: Install pre-commit hooks
+        run: uv run prek install


### PR DESCRIPTION
This repository has `.github/skills/code-review/SKILL.md`, which Copilot code
review reads — it looks for agent skills in `.github/skills` and prefers
directories named `code-review`. But it only consults them during its *agentic*
pass, and that pass only runs if it can get a runner.

Copilot code review takes its environment from `copilot-code-review.yml`,
falling back to `copilot-setup-steps.yml`. This repository had neither.

## Why now

diffraxtra was in the same state, and its review on
GalacticDynamics/diffraxtra#37 opened with:

> Copilot couldn't run its full agentic review because it didn't start before
> the timeout. Make sure your repository has a runner available, or add a
> `copilot-code-review.yml` file specifying one with the `runs-on` attribute.

So the skill file added there was doing nothing for Copilot. This repository has
the same gap.

To be straight about the evidence: no Copilot review has timed out *here* — the
last several PRs have no Copilot review at all, so there is nothing to observe
either way. This fixes the same structural gap that produced a timeout in a
sibling repo; it is not a failure observed in this one.

## Choice of file

`copilot-setup-steps.yml` rather than `copilot-code-review.yml`, because it also
configures Copilot cloud agent and there is no reason for the two environments
to differ here. quax and quax-blocks already carry this exact file.

Constraints: the job **must** be named `copilot-setup-steps` or it is ignored,
and only `steps`, `permissions`, `runs-on`, `services`, `snapshot` and
`timeout-minutes` are honoured.

Steps mirror this repo's own CI — same SHA-pinned action versions, the repo's
own `uv sync ... --group dev --locked`, and `prek install`. The `on:` triggers
are scoped to the file's own path, so it runs once here and then stays quiet.

Validated with `check-jsonschema --builtin-schema vendor.github-workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
