### PR TITLE
🐛 fix(linalg): a scalar unit target works on a `QuantityMatrix`

### DIFF
--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -555,12 +555,6 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
 def uconvert(to_units: u.AbstractUnit, x: QuantityMatrix, /) -> QuantityMatrix:
     """Convert every element of a ``QuantityMatrix`` to one shared unit.
 
-    The scalar companion to the `UnitsMatrix` dispatch above, and needed for the
-    same reason `ustrip` needs one: without it a scalar target matches the
-    generic `AbstractQuantity` rule, which does ``x.unit.to(...)``. A
-    `UnitsMatrix` has no ``.to``, so the call died with an `AttributeError`
-    pointing into the astropy interop rather than at the real cause.
-
     The matrix need not be homogeneous -- conversion is elementwise, so any
     entry convertible to ``to_units`` is fine, and one that is not raises
     `UnitConversionError`.
@@ -575,14 +569,6 @@ def uconvert(to_units: u.AbstractUnit, x: QuantityMatrix, /) -> QuantityMatrix:
     >>> bool(jnp.allclose(u.uconvert("km", q).value, jnp.ones((2, 2))))
     True
 
-    Mixed entries are fine when each is convertible to the target:
-
-    >>> mixed = QuantityMatrix(
-    ...     jnp.array([[1000.0, 1.0], [1000.0, 1.0]]), (("m", "km"), ("m", "km"))
-    ... )
-    >>> bool(jnp.allclose(u.uconvert("km", mixed).value, jnp.ones((2, 2))))
-    True
-
     """
     return uconvert(UnitsMatrix.full(x.unit.shape, to_units), x)
 
@@ -591,18 +577,8 @@ def uconvert(to_units: u.AbstractUnit, x: QuantityMatrix, /) -> QuantityMatrix:
 def uconvert(to_units: str, x: QuantityMatrix, /) -> QuantityMatrix:
     """Take the string spelling of the unit, as the dispatch above does.
 
-    A separate method rather than a `u.AbstractUnit | str` union: the generic
-    rule is ``uconvert(str, AbstractQuantity)``, so a union would be *wider* in
-    the unit argument while narrower in the quantity, leaving neither signature
-    dominant and every call ambiguous.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> from unxts.linalg import QuantityMatrix
-
-    >>> q = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
-    >>> u.uconvert("km", q).unit.to_string()
-    '((km, km), (km, km))'
+    Separate from the `u.AbstractUnit` dispatch rather than a union with it: a
+    union is ambiguous against the generic ``uconvert(str, AbstractQuantity)``.
 
     """
     return uconvert(UnitsMatrix.full(x.unit.shape, to_units), x)
@@ -656,10 +632,6 @@ def ustrip(units: u.AbstractUnit, x: QuantityMatrix, /) -> Array:
     conversion is elementwise, so any entry convertible to ``units`` is fine,
     and one that is not raises `UnitConversionError`.
 
-    Takes a unit object as readily as its string spelling: annotated `str`
-    alone, ``u.unit("km")`` fell through to the same generic rule the
-    `UnitsMatrix` dispatch exists to avoid.
-
     >>> import jax.numpy as jnp
     >>> import unxt as u
     >>> from unxts.linalg import QuantityMatrix
@@ -685,17 +657,7 @@ def ustrip(units: u.AbstractUnit, x: QuantityMatrix, /) -> Array:
 
 @plum.dispatch
 def ustrip(units: str, x: QuantityMatrix, /) -> Array:
-    """Take the string spelling; see the dispatch above for why they are separate.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> from unxts.linalg import QuantityMatrix
-
-    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
-    >>> bool(jnp.allclose(u.ustrip("", q), jnp.eye(2)))
-    True
-
-    """
+    """Take the string spelling; see the dispatch above for why they are separate."""
     return ustrip(UnitsMatrix.full(x.unit.shape, units), x)
 
 

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_quantity_matrix.py
@@ -552,6 +552,63 @@ def uconvert(to_units: UnitsMatrix, x: QuantityMatrix, /) -> QuantityMatrix:
 
 
 @plum.dispatch
+def uconvert(to_units: u.AbstractUnit, x: QuantityMatrix, /) -> QuantityMatrix:
+    """Convert every element of a ``QuantityMatrix`` to one shared unit.
+
+    The scalar companion to the `UnitsMatrix` dispatch above, and needed for the
+    same reason `ustrip` needs one: without it a scalar target matches the
+    generic `AbstractQuantity` rule, which does ``x.unit.to(...)``. A
+    `UnitsMatrix` has no ``.to``, so the call died with an `AttributeError`
+    pointing into the astropy interop rather than at the real cause.
+
+    The matrix need not be homogeneous -- conversion is elementwise, so any
+    entry convertible to ``to_units`` is fine, and one that is not raises
+    `UnitConversionError`.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> q = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+    >>> u.uconvert("km", q).unit.to_string()
+    '((km, km), (km, km))'
+    >>> bool(jnp.allclose(u.uconvert("km", q).value, jnp.ones((2, 2))))
+    True
+
+    Mixed entries are fine when each is convertible to the target:
+
+    >>> mixed = QuantityMatrix(
+    ...     jnp.array([[1000.0, 1.0], [1000.0, 1.0]]), (("m", "km"), ("m", "km"))
+    ... )
+    >>> bool(jnp.allclose(u.uconvert("km", mixed).value, jnp.ones((2, 2))))
+    True
+
+    """
+    return uconvert(UnitsMatrix.full(x.unit.shape, to_units), x)
+
+
+@plum.dispatch
+def uconvert(to_units: str, x: QuantityMatrix, /) -> QuantityMatrix:
+    """Take the string spelling of the unit, as the dispatch above does.
+
+    A separate method rather than a `u.AbstractUnit | str` union: the generic
+    rule is ``uconvert(str, AbstractQuantity)``, so a union would be *wider* in
+    the unit argument while narrower in the quantity, leaving neither signature
+    dominant and every call ambiguous.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> q = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+    >>> u.uconvert("km", q).unit.to_string()
+    '((km, km), (km, km))'
+
+    """
+    return uconvert(UnitsMatrix.full(x.unit.shape, to_units), x)
+
+
+@plum.dispatch
 def unit_of(x: QuantityMatrix, /) -> UnitsMatrix:
     """Return the `UnitsMatrix` of a ``QuantityMatrix``.
 
@@ -591,13 +648,17 @@ def ustrip(units: UnitsMatrix, x: QuantityMatrix, /) -> Array:
 
 
 @plum.dispatch
-def ustrip(units: str, x: QuantityMatrix, /) -> Array:
+def ustrip(units: u.AbstractUnit, x: QuantityMatrix, /) -> Array:
     """Strip a ``QuantityMatrix`` to one unit shared by every element.
 
     Saves building a `UnitsMatrix` of identical entries by hand; most often
     ``""`` for a dimensionless matrix. The matrix need not be *homogeneous* --
     conversion is elementwise, so any entry convertible to ``units`` is fine,
     and one that is not raises `UnitConversionError`.
+
+    Takes a unit object as readily as its string spelling: annotated `str`
+    alone, ``u.unit("km")`` fell through to the same generic rule the
+    `UnitsMatrix` dispatch exists to avoid.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -615,13 +676,35 @@ def ustrip(units: str, x: QuantityMatrix, /) -> Array:
     >>> bool(jnp.allclose(u.ustrip("km", mixed), jnp.ones((2, 2))))
     True
 
+    >>> bool(jnp.allclose(u.ustrip(u.unit("km"), mixed), jnp.ones((2, 2))))
+    True
+
+    """
+    return ustrip(UnitsMatrix.full(x.unit.shape, units), x)
+
+
+@plum.dispatch
+def ustrip(units: str, x: QuantityMatrix, /) -> Array:
+    """Take the string spelling; see the dispatch above for why they are separate.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from unxts.linalg import QuantityMatrix
+
+    >>> q = QuantityMatrix(jnp.eye(2), (("", ""), ("", "")))
+    >>> bool(jnp.allclose(u.ustrip("", q), jnp.eye(2)))
+    True
+
     """
     return ustrip(UnitsMatrix.full(x.unit.shape, units), x)
 
 
 @plum.dispatch
 def ustrip(
-    flag: type[AllowValue], units: UnitsMatrix | str, x: QuantityMatrix, /
+    flag: type[AllowValue],
+    units: UnitsMatrix | u.AbstractUnit | str,
+    x: QuantityMatrix,
+    /,
 ) -> Array:
     """`AllowValue` form of both spellings, for code that also handles arrays.
 

--- a/packages/unxts.linalg/tests/unit/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/unit/test_quantity_matrix.py
@@ -2584,13 +2584,7 @@ def test_unit_of_returns_the_units_matrix():
 
 
 class TestScalarUnitTarget:
-    """`uconvert`/`ustrip` accept one unit standing for the whole matrix.
-
-    Without these dispatches a scalar target matched the generic
-    `AbstractQuantity` rule, which does ``x.unit.to(...)``; a `UnitsMatrix` has
-    no ``.to``, so the call died with an `AttributeError` from the astropy
-    interop instead of doing the obvious thing.
-    """
+    """`uconvert`/`ustrip` accept one unit standing for the whole matrix."""
 
     @staticmethod
     def _thousand_m():
@@ -2605,12 +2599,6 @@ class TestScalarUnitTarget:
     @pytest.mark.parametrize("target", ["km", u.unit("km")])
     def test_ustrip_broadcasts_the_unit(self, target):
         assert jnp.allclose(u.ustrip(target, self._thousand_m()), jnp.ones((2, 2)))
-
-    def test_it_agrees_with_the_explicit_units_matrix(self):
-        """The scalar spelling is shorthand, not a different conversion."""
-        qm = self._thousand_m()
-        explicit = u.uconvert(UnitsMatrix.full((2, 2), u.unit("km")), qm)
-        assert jnp.allclose(u.uconvert("km", qm).value, explicit.value)
 
     def test_a_heterogeneous_matrix_converts_elementwise(self):
         """Entries need not share a unit, only be convertible to the target."""

--- a/packages/unxts.linalg/tests/unit/test_quantity_matrix.py
+++ b/packages/unxts.linalg/tests/unit/test_quantity_matrix.py
@@ -35,6 +35,7 @@ from unxts.linalg._src._register_primitives import (
 import quaxed.numpy as qnp
 
 import unxt as u
+from unxt.quantity import AllowValue
 
 # ---------------------------------------------------------------------------
 # Unit shorthands (visual noise reduction)
@@ -2580,3 +2581,51 @@ def test_unit_of_returns_the_units_matrix():
     """`unit_of` on a `QuantityMatrix` yields its `UnitsMatrix`."""
     qm = QMat(jnp.eye(2), (("m", "rad"), ("m", "rad")))
     assert u.unit_of(qm).to_string() == "((m, rad), (m, rad))"
+
+
+class TestScalarUnitTarget:
+    """`uconvert`/`ustrip` accept one unit standing for the whole matrix.
+
+    Without these dispatches a scalar target matched the generic
+    `AbstractQuantity` rule, which does ``x.unit.to(...)``; a `UnitsMatrix` has
+    no ``.to``, so the call died with an `AttributeError` from the astropy
+    interop instead of doing the obvious thing.
+    """
+
+    @staticmethod
+    def _thousand_m():
+        return QMat(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
+
+    @pytest.mark.parametrize("target", ["km", u.unit("km")])
+    def test_uconvert_broadcasts_the_unit(self, target):
+        got = u.uconvert(target, self._thousand_m())
+        assert got.unit.to_string() == "((km, km), (km, km))"
+        assert jnp.allclose(got.value, jnp.ones((2, 2)))
+
+    @pytest.mark.parametrize("target", ["km", u.unit("km")])
+    def test_ustrip_broadcasts_the_unit(self, target):
+        assert jnp.allclose(u.ustrip(target, self._thousand_m()), jnp.ones((2, 2)))
+
+    def test_it_agrees_with_the_explicit_units_matrix(self):
+        """The scalar spelling is shorthand, not a different conversion."""
+        qm = self._thousand_m()
+        explicit = u.uconvert(UnitsMatrix.full((2, 2), u.unit("km")), qm)
+        assert jnp.allclose(u.uconvert("km", qm).value, explicit.value)
+
+    def test_a_heterogeneous_matrix_converts_elementwise(self):
+        """Entries need not share a unit, only be convertible to the target."""
+        mixed = QMat(
+            jnp.array([[1000.0, 1.0], [1000.0, 1.0]]), (("m", "km"), ("m", "km"))
+        )
+        assert jnp.allclose(u.uconvert("km", mixed).value, jnp.ones((2, 2)))
+
+    def test_an_inconvertible_entry_raises_a_unit_error(self):
+        """Not an `AttributeError` from inside the interop -- the real problem."""
+        bad = QMat(jnp.eye(2), (("m", "s"), ("m", "s")))
+        with pytest.raises(apu.UnitConversionError, match="not convertible"):
+            u.uconvert("km", bad)
+
+    @pytest.mark.parametrize("target", ["km", u.unit("km")])
+    def test_allow_value_form_takes_both_spellings(self, target):
+        got = u.ustrip(AllowValue, target, self._thousand_m())
+        assert jnp.allclose(got, jnp.ones((2, 2)))


### PR DESCRIPTION
Closes #901.

## The bug

`uconvert` with a scalar unit target failed on a `QuantityMatrix`:

```python
qm = QuantityMatrix(jnp.full((2, 2), 1000.0), (("m", "m"), ("m", "m")))
u.uconvert("km", qm)   # AttributeError: 'UnitsMatrix' object has no attribute 'to'
```

`QuantityMatrix` is an `AbstractQuantity`, so a scalar target matched the generic rule,
which does `x.unit.to(...)`. `QuantityMatrix.unit` is a `UnitsMatrix` — a matrix of
units, not one unit — so the call fell through to an overload whose precondition does not
hold, and failed from inside the astropy interop with no hint that the fix was to wrap
the unit.

While fixing it I found the hole is **wider than #901 reported**. `ustrip`'s scalar
overload was annotated `str`, so a unit *object* fell through to the same generic rule:

| target | `ustrip` before | `uconvert` before | now |
| --- | --- | --- | --- |
| `str` | ✅ | ❌ | ✅ |
| `u.AbstractUnit` | ❌ | ❌ | ✅ |
| `UnitsMatrix` | ✅ | ✅ | ✅ |

So the two verbs disagreed about calls that look identical at the call site, and `ustrip`
accepted one spelling of a unit but not the other.

## The fix

Both verbs now broadcast a scalar across the matrix via
`UnitsMatrix.full(x.unit.shape, unit)` — exactly what an explicit `UnitsMatrix` target
already produced. Verified they agree:

```python
u.uconvert("km", qm).value == u.uconvert(UnitsMatrix.full((2, 2), u.unit("km")), qm).value
```

Conversion stays elementwise, so a heterogeneous matrix is fine when each entry is
convertible, and one that is not now raises the real error instead of an `AttributeError`:

```python
bad = QuantityMatrix(jnp.eye(2), (("m", "s"), ("m", "s")))
u.uconvert("km", bad)
# UnitConversionError: 's' (time) and 'km' (length) are not convertible
```

## One thing worth reviewing

`u.AbstractUnit` and `str` are **separate dispatches, not a `u.AbstractUnit | str`
union**. I wrote the union first and every call became an `AmbiguousLookupError`,
including the `ustrip(str, ...)` that already worked:

```
uconvert(ustr: str, x: AbstractQuantity)                    <- generic
uconvert(to_units: UnitBase | FunctionUnitBase | str,
         x: QuantityMatrix)                                 <- the union
```

The union is *wider* in the unit argument and *narrower* in the quantity, so neither
signature dominates. Split into exact types, each is narrower in one argument and equal
or narrower in the other, and resolution is unambiguous. Noted in the docstrings so the
next person does not re-introduce it.

## Testing

New `TestScalarUnitTarget` covers both verbs across both spellings, agreement with the
explicit `UnitsMatrix` form, a heterogeneous matrix, the inconvertible case, and the
`AllowValue` form. Doctests added on each new dispatch.

Full suite: **4060 passed**, 49 skipped, 20 xfailed. Lint, `ty`, `pyright` and `mypy` all
clean.

## Context

Found while auditing coordinax against unxt 2.0.2 — nothing there depends on the scalar
form today, so this is an API-usability fix rather than an unblocking one. Follows #879,
which added `ustrip`/`unit_of` for `QuantityMatrix`; this closes the same gap on the verb
that issue recorded as already working.
