### PR TITLE
⚡️ perf(quantity): answer the angular-unit check once per unit

### DIFF
--- a/src/unxt/_src/quantity/base_angle.py
+++ b/src/unxt/_src/quantity/base_angle.py
@@ -16,6 +16,12 @@ from unxt.units import AbstractUnit
 angle_dimension = dimension("angle")
 
 
+#: Units already shown to be angular. `__check_init__` runs per angle
+#: constructed, and its check is a dispatched call whose result depends only on
+#: the unit -- an immutable value object -- so it is answered once per unit.
+_ANGULAR_UNITS: set[AbstractUnit] = set()
+
+
 class AbstractAngle(AbstractQuantity):
     """Angular quantity.
 
@@ -51,9 +57,19 @@ class AbstractAngle(AbstractQuantity):
 
     def __check_init__(self) -> None:
         """Check the initialization."""
-        if dimension_of(self) != angle_dimension:
+        # `dimension_of(self)` forwards to `dimension_of(self.unit)`, so going
+        # straight to the unit skips a dispatch. The answer is then memoised:
+        # units are immutable value objects, so one that is angular stays
+        # angular, and the set is bounded by the units a program constructs.
+        # This runs on every angle built, and the dispatch dominates it --
+        # ~138us against ~0.9us for the `physical_type` lookup underneath.
+        unit = self.unit
+        if unit in _ANGULAR_UNITS:
+            return
+        if dimension_of(unit) != angle_dimension:
             msg = f"{type(self).__name__} must have units with angular dimensions."
             raise ValueError(msg)
+        _ANGULAR_UNITS.add(unit)
 
     def wrap_to(
         self, /, min: AbstractQuantity, max: AbstractQuantity

--- a/src/unxt/_src/quantity/base_angle.py
+++ b/src/unxt/_src/quantity/base_angle.py
@@ -2,6 +2,8 @@
 
 __all__ = ("AbstractAngle",)
 
+import weakref
+
 import equinox as eqx
 from jaxtyping import Array, Shaped
 from plum import add_promotion_rule
@@ -18,8 +20,11 @@ angle_dimension = dimension("angle")
 
 #: Units already shown to be angular. `__check_init__` runs per angle
 #: constructed, and its check is a dispatched call whose result depends only on
-#: the unit -- an immutable value object -- so it is answered once per unit.
-_ANGULAR_UNITS: set[AbstractUnit] = set()
+#: the unit -- an immutable value object -- so it is answered once per unit. A
+#: `WeakSet` lets dynamically-built units (e.g. scaled/compound ones) be
+#: collected once nothing else references them, instead of pinning every unit
+#: ever seen for the life of the process.
+_ANGULAR_UNITS: "weakref.WeakSet[AbstractUnit]" = weakref.WeakSet()
 
 
 class AbstractAngle(AbstractQuantity):
@@ -69,7 +74,9 @@ class AbstractAngle(AbstractQuantity):
         if dimension_of(unit) != angle_dimension:
             msg = f"{type(self).__name__} must have units with angular dimensions."
             raise ValueError(msg)
-        _ANGULAR_UNITS.add(unit)
+        # pylint sees the module's other `dimension_of` overload, typed
+        # `-> NoReturn`, and (wrongly) infers this line as unreachable.
+        _ANGULAR_UNITS.add(unit)  # pylint: disable=unreachable
 
     def wrap_to(
         self, /, min: AbstractQuantity, max: AbstractQuantity

--- a/tests/unit/test_base_angle.py
+++ b/tests/unit/test_base_angle.py
@@ -1,0 +1,33 @@
+# pylint: disable=import-error
+
+"""Test the `_ANGULAR_UNITS` memoisation cache in `AbstractAngle.__check_init__`."""
+
+import contextlib
+import gc
+
+import astropy.units as apyu
+
+import unxt as u
+from unxt._src.quantity.base_angle import _ANGULAR_UNITS
+
+
+def test_non_angular_unit_is_never_cached():
+    for _ in range(2):
+        with contextlib.suppress(ValueError):
+            u.Angle(1.0, "m")
+    assert apyu.m not in _ANGULAR_UNITS
+
+
+def _scaled_radian() -> apyu.UnitBase:
+    return apyu.CompositeUnit(2, [apyu.rad], [1])  # not interned by astropy
+
+
+def test_angular_unit_cache_is_weak():
+    unit = _scaled_radian()
+    u.Angle(1.0, unit)
+    assert unit in _ANGULAR_UNITS
+
+    del unit
+    gc.collect()
+
+    assert _scaled_radian() not in _ANGULAR_UNITS


### PR DESCRIPTION
`AbstractAngle.__check_init__` runs on every angle constructed, and cost ~138 µs of the ~221 µs that construction took. Almost none of it was the check:

```
dimension_of(angle instance)   138.1 us
dimension_of(unit)              70.9 us
unit.physical_type               0.9 us   <- the actual work
```

Two things are going on. `dimension_of(self)` forwards to `dimension_of(self.unit)`, so asking about the *instance* pays for two dispatches to reach a lookup that takes under a microsecond. And the answer depends only on the unit — an immutable value object, so one that is angular stays angular — which makes it answerable once per unit rather than once per angle.

## Result

```
u.Angle(1.0, "rad")   221.2 us -> 46.4 us     4.8x
u.Q(1.0, "rad")        45.9 us -> 45.5 us
```

Angle construction now costs what a plain `Quantity` does. The angle-specific overhead is **gone**, not merely reduced.

## Correctness

A non-angular unit is still rejected, and is **never cached** — so it is re-checked on every attempt rather than remembered as bad:

```pycon
>>> u.Angle(1.0, "m")
ValueError: Angle must have units with angular dimensions.
```

The cache is bounded by the distinct units a program constructs angles with, which is a handful.

## Why I was looking

Found while profiling GalacticDynamics/coordinax#752, which canonicalises angular components on every chart transition. That PR had to reach for `AbstractQuantity._mk` — the unchecked constructor — specifically to avoid this cost. With this change the checked constructor is cheap enough that reaching past it is far less tempting.

## Verification

`pytest`: **4060 passed**, 49 skipped, 20 xfailed. `prek run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
