### PR TITLE
🐛 fix(unitsystems): derived units of scaled systems can be printed

### DIFF
--- a/src/unxt/_src/unitsystems/base.py
+++ b/src/unxt/_src/unitsystems/base.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 from typing import ClassVar, get_args, get_type_hints
 
 import jax.tree_util as jtu
-from astropy.units import PhysicalType, UnitBase as AstropyUnitBase
+from astropy.units import NamedUnit, PhysicalType, UnitBase as AstropyUnitBase
 from astropy.units.physical import _physical_unit_mapping
 
 from is_annotated import isannotated
@@ -269,6 +269,15 @@ class AbstractUnitSystem:
 
         out = out.decompose(self.base_units)
         out._scale = 1.0  # noqa: SLF001
+        # A system built on a scaled unit -- every flag-solved one, e.g.
+        # ``unitsystem(DynamicalSimUSysFlag, "kpc", "solMass")`` -- has
+        # `CompositeUnit` base units, and `decompose` nests those inside
+        # ``out.bases``. astropy's formatters call `_get_format_name` on each
+        # base, which only `NamedUnit` has, so such a unit can be neither
+        # printed nor converted to. Reducing to irreducible bases keeps the same
+        # physical unit and makes it usable.
+        if any(not isinstance(b, NamedUnit) for b in out.bases):
+            out = out.decompose()
         return out
 
     def __len__(self) -> int:

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -543,8 +543,16 @@ def test_simulation_usys_underdetermined():
     ],
     ids=["dynamical", "hep", "geometrized", "planck", "atomic"],
 )
-@pytest.mark.parametrize("dim", ["velocity", "acceleration", "energy", "force"])
-def test_derived_unit_of_scaled_system_is_printable(usys, dim) -> None:
+@pytest.mark.parametrize(
+    ("dim", "unit_str"),
+    [
+        ("velocity", "km / s"),
+        ("acceleration", "km / s2"),
+        ("energy", "J"),
+        ("force", "N"),
+    ],
+)
+def test_derived_unit_of_scaled_system_is_printable(usys, dim, unit_str) -> None:
     """Derived units of a flag-solved system can be printed and converted to.
 
     Regression: these systems have `CompositeUnit` base units, so a derived
@@ -552,12 +560,12 @@ def test_derived_unit_of_scaled_system_is_printable(usys, dim) -> None:
     -- ``repr(usys["velocity"])`` raised ``AttributeError: 'CompositeUnit'
     object has no attribute '_get_format_name'``.
     """
-    assert str(usys[dim])  # used to raise
+    assert repr(usys[dim])  # used to raise; `repr` formats via `str`
 
-    speed = u.Quantity(220.0, "km/s")
-    assert np.isclose(
-        speed.uconvert(usys["velocity"]).value, speed.ustrip(usys), rtol=1e-5
-    )
+    # Converting onto the derived unit raised the same error, and must agree
+    # with stripping to the system as a whole.
+    q = u.Quantity(1.0, unit_str)
+    assert np.isclose(q.uconvert(usys[dim]).value, q.ustrip(usys), rtol=1e-5)
 
 
 # ===================================================================

--- a/tests/unit/test_unitsystems.py
+++ b/tests/unit/test_unitsystems.py
@@ -532,6 +532,34 @@ def test_simulation_usys_underdetermined():
     assert usys == unitsystem(apyu.Unit("kg"))
 
 
+@pytest.mark.parametrize(
+    "usys",
+    [
+        unitsystem(DynamicalSimUSysFlag, "kpc", "Msun"),
+        unitsystems.hep,
+        unitsystems.geometrized,
+        unitsystems.planck,
+        unitsystems.atomic,
+    ],
+    ids=["dynamical", "hep", "geometrized", "planck", "atomic"],
+)
+@pytest.mark.parametrize("dim", ["velocity", "acceleration", "energy", "force"])
+def test_derived_unit_of_scaled_system_is_printable(usys, dim) -> None:
+    """Derived units of a flag-solved system can be printed and converted to.
+
+    Regression: these systems have `CompositeUnit` base units, so a derived
+    unit nested a composite inside its own bases, which astropy cannot format
+    -- ``repr(usys["velocity"])`` raised ``AttributeError: 'CompositeUnit'
+    object has no attribute '_get_format_name'``.
+    """
+    assert str(usys[dim])  # used to raise
+
+    speed = u.Quantity(220.0, "km/s")
+    assert np.isclose(
+        speed.uconvert(usys["velocity"]).value, speed.ustrip(usys), rtol=1e-5
+    )
+
+
 # ===================================================================
 # Natural unit systems (issues #228-#232)
 


### PR DESCRIPTION
## Problem

Derived units of any unit system whose base units are *scaled* (`CompositeUnit`) could not be printed or converted to:

```python
import unxt as u
from unxt.unitsystems import DynamicalSimUSysFlag

usys = u.unitsystem(DynamicalSimUSysFlag, "kpc", "solMass")
usys["velocity"]  # AttributeError: 'CompositeUnit' object has no attribute '_get_format_name'
```

`repr`, `str`, and `u.Q(1.0, "km/s").uconvert(usys["velocity"])` all raised. The values were fine — `usys["velocity"].decompose()` gave `Unit("2.07387 m / s")` and `ustrip(usys)` worked — so this was purely a formatting failure.

## Root cause

`AbstractUnitSystem.__getitem__` builds a derived unit as `out.decompose(self.base_units)`. When one of `self.base_units` is itself a `CompositeUnit`, astropy nests that composite inside `out.bases`. The formatters call `_get_format_name` on each base, and only `NamedUnit` defines it.

Two notes on the diagnosis from the report:

- **Not specific to `DynamicalSimUSysFlag`.** All four natural-unit flags (`hep`, `geometrized`, `planck`, `atomic`) hit it too — and those *already* `.decompose()` when solving, which still yields a scaled `CompositeUnit` like `Unit("1e-16 m")`. Normalising in the `AbstractUSysFlag` path would not have fixed it, and would not cover a user-built `unitsystem(unit("2 m"), "s")`.
- **The nesting happens in `__getitem__`, not the solver**, which is why the guard goes there — one place all callers route through.

## Fix

```python
out = out.decompose(self.base_units)
out._scale = 1.0
if any(not isinstance(b, NamedUnit) for b in out.bases):
    out = out.decompose()
```

Same physical unit, now printable and convertible. Systems whose base units are already named are untouched, so existing reprs are preserved (`unitsystem("kpc", "Myr", "solMass")["velocity"]` is still `Unit("kpc / Myr")`).

For `unitsystem(DynamicalSimUSysFlag, "kpc", "solMass")`:

| dimension | before | after |
| --- | --- | --- |
| `velocity` | `AttributeError` | `Unit("2.07387 m / s")` |
| `acceleration` | `AttributeError` | `Unit("1.39383e-19 m / s2")` |
| `energy` | `AttributeError` | `Unit("8.55199e+30 m2 kg / s2")` |
| `force` | `AttributeError` | `Unit("2.77151e+11 kg m / s2")` |

and `Q(220.0, "km/s").uconvert(usys["velocity"])` == `.ustrip(usys)` == `106082.11`.

## Tests

New regression test parametrised over 4 derived dimensions × 5 flag-built systems (dynamical + the four natural ones), asserting both that the unit renders and that the converted value still matches `ustrip(usys)`. Verified all 20 fail with the guard disabled and pass with it.

Full suite: 2500 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)