### PR TITLE
🐛 fix(ci): open the hook-update PR with the release App token

### DIFF
--- a/.github/workflows/update-hooks.yml
+++ b/.github/workflows/update-hooks.yml
@@ -5,15 +5,26 @@ on:
     - cron: "0 0 1 * *" # Monthly, on the 1st at midnight UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   prek-auto-update:
     name: prek auto-update
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN is read-only in this repo and Actions is not permitted to
+    # open pull requests, so the PR below is created with a GitHub App token.
+    # Requires RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY (see
+    # create-package-tags.yml); the App needs "Contents: Read and write" and
+    # "Pull requests: Read and write".
+    permissions:
+      contents: read
+
     steps:
+      - name: Mint a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -27,6 +38,7 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "👷: update pre-commit hooks"
           title: "👷: update pre-commit hooks"
           body: "Automated hook update via `prek auto-update`."


### PR DESCRIPTION
The monthly `Update hooks` workflow has been failing at the **Open pull request** step: [run 33464573885](https://github.com/GalacticDynamics/unxt/actions/runs/33464573885) → `GitHub Actions is not permitted to create or approve pull requests`.

## Root cause

Two separate token limits, both hit by that step:

1. This repo's `GITHUB_TOKEN` is read-only (`default_workflow_permissions: read`), so the workflow's declared `contents: write` / `pull-requests: write` could never be granted. The branch push would have failed too, even if PR creation were permitted.
2. The org forbids Actions from creating PRs outright.

This is the same pair of constraints already documented in `create-package-tags.yml`.

## Fix

Mint a token from the `unxt-release-bot` GitHub App and pass it to `create-pull-request`, reusing the pattern `create-package-tags.yml` already uses for tag pushes. With the App token doing the work, the job's own `GITHUB_TOKEN` drops to `contents: read`.

## Prerequisite — already done

The App installation has been granted `pull_requests: write` alongside its existing `contents: write`:

```console
$ gh api /orgs/GalacticDynamics/installations \
    --jq '.installations[] | select(.app_slug=="unxt-release-bot") | .permissions'
{"contents":"write","metadata":"read","pull_requests":"write"}
```

## Verification status

YAML validates and the workflow-lint hook passes, but this has **not** been run end to end. `workflow_dispatch` only sees branches in this repo, and fork branches don't get secrets, so a live test needs the branch pushed here (or the merge itself). A successful run will open a real `update-hooks` PR — that is the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)