### PR TITLE
💚 ci: pin remaining actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -45,11 +45,11 @@ jobs:
       #     dotnet-version: '3.1.x'
       # Run open source static analysis tools
       - name: Run OSSAR
-        uses: github/ossar-action@v1
+        uses: github/ossar-action@786a16a90ba92b4ae6228fe7382fb16ef5c51000 # v1
         id: ossar
 
         # Upload results to the Security tab
       - name: Upload OSSAR results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: EndBug/label-sync@v2
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yml
           delete-other-labels: true


### PR DESCRIPTION
## Problem

The OSSAR workflow fails before it even starts ([run 33488109575](https://github.com/GalacticDynamics/unxt/actions/runs/33488109575/job/99792877147?pr=912)):

> Error: The actions `github/ossar-action@v1` and `github/codeql-action/upload-sarif@v4` are not allowed in `GalacticDynamics/unxt` because all actions must be pinned to a full-length commit SHA.

## Fix

Pinned every remaining tag/branch ref in `.github/` — there were three, not two; `sync-labels.yml` would have failed the same way on its next run.

| Action | Was | Now |
| --- | --- | --- |
| `github/ossar-action` | `@v1` | `@786a16a90ba92b4ae6228fe7382fb16ef5c51000` (`# v1`) |
| `github/codeql-action/upload-sarif` | `@v4` | `@cdf488f595d80d6e07e03d4674febd5ab45fa938` (`# v4.37.9`) |
| `EndBug/label-sync` | `@v2` | `@52074158190acb45f3077f9099fea818aa43f97a` (`# v2.3.3`) |

Notes on the SHAs:

- `github/ossar-action` has **no** `v1` tag — only `v1.0.0`, `v1.1.0`, `v2.0.0`. `@v1` was resolving to the `v1` *branch*, whose head is `786a16a` (2022-03-11), newer than the `v1.1.0` tag. Pinned to that so behaviour is unchanged; bumping to `v2.0.0` is a separate call.
- `github/codeql-action`'s `v4` tag currently points at `v4.37.9`.
- `EndBug/label-sync`'s `v2` tag currently points at `v2.3.3`.

After this, `grep -rE 'uses: *[^ ]+@[^ ]+' .github/ | grep -vE '@[0-9a-f]{40}'` returns only a commented-out `actions/setup-dotnet@v4` line inside a YAML comment block in `ossar.yml`, which is not parsed.

Dependabot already tracks `github-actions` quarterly, so these stay updated with SHAs intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)