### PR TITLE
💚 ci(docs): stop linkcheck failing on Zenodo timeouts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,11 @@ linkcheck_ignore = [
     # the Docs until the PR merges, so these 404 by construction pre-merge.
     # Internal navigation is already gated by `myst.xref_missing` in CI.
     r"https://unxt\.readthedocs\.io/.*",
+    # Zenodo. The DOI badge and its record page routinely take 15-35s to
+    # follow their redirect chain and intermittently answer 504, so the build
+    # fails on Zenodo's uptime rather than on anything in this repo. A DOI is a
+    # permanent identifier, so there is nothing here that can rot.
+    r"https://zenodo\.org/.*",
 ]
 
 # Third-party pages whose in-page anchors are generated client-side, so the


### PR DESCRIPTION
## What

Ignore `zenodo.org` in `linkcheck_ignore`.

## Why

The Docs job's **Check external links** step failed on [run 33488531883](https://github.com/GalacticDynamics/unxt/actions/runs/33488531883/job/99794255425) — the only failure in the run — on the two Zenodo URLs in the badge row of `docs/about/index.md`:

```
(about/index: line 16) timeout https://zenodo.org/badge/734877295.svg
  - HTTPSConnectionPool(host='zenodo.org', port=443): Read timed out. (read timeout=20)
(about/index: line 16) timeout https://zenodo.org/doi/10.5281/zenodo.10850455
  - HTTPSConnectionPool(host='zenodo.org', port=443): Read timed out. (read timeout=20)
```

Neither link is broken. Measured just now:

| URL | full redirect chain | result |
| --- | --- | --- |
| `https://zenodo.org/badge/734877295.svg` | → `/badge/DOI/10.5281/zenodo.22029885.svg` | 200 in 15.7s / 17.8s / 20.3s |
| `https://zenodo.org/doi/10.5281/zenodo.10850455` | → `/records/22029885` | **504** in 30.3s / 34.3s |

So `linkcheck_timeout = 20` sits right in the middle of Zenodo's response distribution, and raising it does not help against a gateway timeout. `linkcheck_report_timeouts_as_broken` is not an escape hatch either — sphinx sets `statuscode = 1` on `broken_hyperlinks or timed_out_hyperlinks` ([`linkcheck.py:109`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/linkcheck.py)), so a timeout fails the build whichever bucket it lands in.

A DOI is a permanent identifier, so unlike every other external link in the docs there is nothing here that can rot — the check was only ever asserting on Zenodo's uptime.

## Verification

`uv run --frozen sphinx-build -b linkcheck docs docs/_build/linkcheck` locally: **exit 0**, `build succeeded`. Both URLs now report `"status": "ignored"` in `output.json`; every other external link is still checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)