### PR TITLE
📌 pin(deps): exclude plum-dispatch 2.10.0

### DIFF
--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -17,7 +17,12 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["plum-dispatch>=2.5.7,!=2.10.0"] # !=2.10.0: see root pyproject
+# !=2.10.0: see the root `pyproject.toml`. The 3.14 floor is spelled out because,
+# unlike the sibling packages, this one does not depend on `unxt` to supply it.
+dependencies = [
+  "plum-dispatch>=2.5.7,!=2.10.0",
+  "plum-dispatch>=2.9.0; python_version>='3.14'",
+]
 description = "Abstract dispatch API definitions for unxt (canonical: unxts.api)"
 dynamic = ["version"]
 license = "BSD-3-Clause"

--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["plum-dispatch>=2.5.7"]
+dependencies = ["plum-dispatch>=2.5.7,!=2.10.0"] # !=2.10.0: see root pyproject
 description = "Abstract dispatch API definitions for unxt (canonical: unxts.api)"
 dynamic = ["version"]
 license = "BSD-3-Clause"

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "unxt>=2.0.0",
   "equinox>=0.11.8",
   "jaxtyping>=0.2.34",
-  "plum-dispatch>=2.5.7",
+  # See the root `pyproject.toml`: 2.10.0's compiled `Function` breaks `jax.jit`.
+  "plum-dispatch>=2.5.7,!=2.10.0",
   "quax>=0.2.0",
 ]
 description = "Heterogeneous-unit matrices and vectors for unxt (canonical: unxts.linalg)"

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 ]
 dependencies = [
   "astropy>=7.1",
-  "plum-dispatch>=2.5.7",
+  # See the root `pyproject.toml`: 2.10.0's compiled `Function` breaks `jax.jit`.
+  "plum-dispatch>=2.5.7,!=2.10.0",
   "unxt>=2.0.0",
   "unxts.api>=2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,12 @@ dependencies = [
   "jaxtyping>=0.3.9",
   "optional-dependencies>=0.4.1",
   # 2.10.0 ships mypyc-compiled wheels whose `Function` is a native class, so it
-  # is not weak-referenceable and `jax.jit(<dispatched function>)` raises. Only
-  # cp310-cp313 on manylinux/win/macos-x86_64 are affected; other platforms get
-  # the pure-Python wheel. Drop the exclusion once a fixed plum is released.
+  # is not weak-referenceable and `jax.jit(<dispatched function>)` raises. plum
+  # builds those wheels for cp310-cp313 on manylinux/win/macos-x86_64, which of
+  # the versions we support means 3.12 and 3.13; 3.14 and macOS arm64 get the
+  # pure-Python wheel and are unaffected. The exclusion is unconditional anyway,
+  # since the resolver cannot know which wheel an install will get. Fixed by
+  # beartype/plum#319 -- drop this once a release carries it.
   "plum-dispatch>=2.7.0,!=2.10.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,11 @@ dependencies = [
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
   "optional-dependencies>=0.4.1",
-  "plum-dispatch>=2.7.0",
+  # 2.10.0 ships mypyc-compiled wheels whose `Function` is a native class, so it
+  # is not weak-referenceable and `jax.jit(<dispatched function>)` raises. Only
+  # cp310-cp313 on manylinux/win/macos-x86_64 are affected; other platforms get
+  # the pure-Python wheel. Drop the exclusion once a fixed plum is released.
+  "plum-dispatch>=2.7.0,!=2.10.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",
   "quax-blocks>=0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4178,7 +4178,7 @@ requires-dist = [
     { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jaxtyping", specifier = ">=0.3.9" },
     { name = "optional-dependencies", specifier = ">=0.4.1" },
-    { name = "plum-dispatch", specifier = ">=2.7.0" },
+    { name = "plum-dispatch", specifier = ">=2.7.0,!=2.10.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.2" },
     { name = "quax-blocks", specifier = ">=0.5.0" },
@@ -4428,7 +4428,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "plum-dispatch", specifier = ">=2.5.7" }]
+requires-dist = [{ name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" }]
 
 [package.metadata.requires-dev]
 test = [
@@ -4622,7 +4622,7 @@ test = [
 requires-dist = [
     { name = "equinox", specifier = ">=0.11.8" },
     { name = "jaxtyping", specifier = ">=0.2.34" },
-    { name = "plum-dispatch", specifier = ">=2.5.7" },
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
     { name = "quax", specifier = ">=0.2.0" },
     { name = "unxt", editable = "." },
 ]
@@ -4664,7 +4664,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=7.1" },
-    { name = "plum-dispatch", specifier = ">=2.5.7" },
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
     { name = "unxt", editable = "." },
     { name = "unxts-api", editable = "packages/unxts.api" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4428,7 +4428,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" }]
+requires-dist = [
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
+    { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
+]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
## What

Exclude `plum-dispatch==2.10.0` in the root and in `unxts.api`, `unxts.linalg`, `unxts.parametric`. The `uv.lock` change is metadata only — it already resolved to 2.9.0.

## Why

plum 2.10.0 is the first release to ship **mypyc-compiled wheels**, and `_function.py` is in the compile set. A mypyc *native* class gets neither `__dict__` nor `__weakref__`, so `plum.Function` instances are no longer weak-referenceable. `jax.jit` weakly references the callable it wraps (`jax/_src/pjit.py:_cpp_pjit`), so **every `jax.jit(<dispatched function>)` raises on first call**:

```
TypeError: cannot create weak reference to 'Function' object
```

`unxt.uconvert` and `unxt.uconvert_value` are `plum.Function`s, so this is user-facing, not merely a CI break — `pip install unxt` on Linux is enough to hit it.

Surfaced by the weekly pre-release job: https://github.com/GalacticDynamics/unxt/actions/runs/34119991803. The segfault and `KeyError: <WorkerController gwN>` in that log are downstream noise — the xdist worker crashes inside jax's C++ pjit path after the `TypeError`, which is why only two failures are visible.

## Verification

Built plum v2.10.0 with mypyc locally (arm64 publishes no compiled wheel, so this does not reproduce on a stock Mac) and ran the suite against it:

```
8 failed, 4075 passed, 49 skipped, 20 xfailed, 2 errors
```

Seven failures plus both errors are `jax.jit` over a dispatched function, in `tests/integration/test_uconvert_value_performance.py` and `tests/benchmark/test_uconvert_value.py`. (The eighth is the known local-only Sybil artifact under `docs/superpowers/plans/`.) Swapping in a patched plum build turns all 14 of those tests green, which confirms the diagnosis rather than just correlating with it.

## Scope of the break

Only cp310–cp313 on manylinux, Windows and macOS x86_64. plum publishes no cp314 wheel and no macOS arm64 wheel, so those fall back to `py3-none-any` and are unaffected — that is exactly why the weekly job failed on 3.12 and 3.13 but passed on 3.14.

The exclusion is nonetheless unconditional: the resolver cannot know which wheel a given install will receive, so a marker-gated exclusion would be unsound.

## Follow-up

Upstream fix in progress; `!=2.10.0` comes back out once a fixed plum is released. Related upstream symptom of the same root cause: https://github.com/beartype/plum/issues/317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
