### PR TITLE
Backport PR #917 on branch versions/v2.0.x (📌 pin(deps): exclude plum-dispatch 2.10.0)

### DIFF
--- a/packages/unxts.api/pyproject.toml
+++ b/packages/unxts.api/pyproject.toml
@@ -17,7 +17,12 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["plum-dispatch>=2.5.7"]
+# !=2.10.0: see the root `pyproject.toml`. The 3.14 floor is spelled out because,
+# unlike the sibling packages, this one does not depend on `unxt` to supply it.
+dependencies = [
+  "plum-dispatch>=2.5.7,!=2.10.0",
+  "plum-dispatch>=2.9.0; python_version>='3.14'",
+]
 description = "Abstract dispatch API definitions for unxt (canonical: unxts.api)"
 dynamic = ["version"]
 license = "BSD-3-Clause"

--- a/packages/unxts.linalg/pyproject.toml
+++ b/packages/unxts.linalg/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "unxt>=2.0.0",
   "equinox>=0.11.8",
   "jaxtyping>=0.2.34",
-  "plum-dispatch>=2.5.7",
+  # See the root `pyproject.toml`: 2.10.0's compiled `Function` breaks `jax.jit`.
+  "plum-dispatch>=2.5.7,!=2.10.0",
   "quax>=0.2.0",
 ]
 description = "Heterogeneous-unit matrices and vectors for unxt (canonical: unxts.linalg)"

--- a/packages/unxts.parametric/pyproject.toml
+++ b/packages/unxts.parametric/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 ]
 dependencies = [
   "astropy>=7.0.0",
-  "plum-dispatch>=2.5.7",
+  # See the root `pyproject.toml`: 2.10.0's compiled `Function` breaks `jax.jit`.
+  "plum-dispatch>=2.5.7,!=2.10.0",
   "unxt>=2.0.0",
   "unxts.api>=2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,14 @@ dependencies = [
   "jaxtyping>=0.3.9",
   "optional-dependencies>=0.3.2",
   "packaging>=20.0",
-  "plum-dispatch>=2.7.0",
+  # 2.10.0 ships mypyc-compiled wheels whose `Function` is a native class, so it
+  # is not weak-referenceable and `jax.jit(<dispatched function>)` raises. plum
+  # builds those wheels for cp310-cp313 on manylinux/win/macos-x86_64, which of
+  # the versions we support means 3.12 and 3.13; 3.14 and macOS arm64 get the
+  # pure-Python wheel and are unaffected. The exclusion is unconditional anyway,
+  # since the resolver cannot know which wheel an install will get. Fixed by
+  # beartype/plum#319 -- drop this once a release carries it.
+  "plum-dispatch>=2.7.0,!=2.10.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",
   "quax-blocks>=0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4180,7 +4180,7 @@ requires-dist = [
     { name = "jaxtyping", specifier = ">=0.3.9" },
     { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "packaging", specifier = ">=20.0" },
-    { name = "plum-dispatch", specifier = ">=2.7.0" },
+    { name = "plum-dispatch", specifier = ">=2.7.0,!=2.10.0" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "quax", specifier = ">=0.4.2" },
     { name = "quax-blocks", specifier = ">=0.5.0" },
@@ -4430,7 +4430,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "plum-dispatch", specifier = ">=2.5.7" }]
+requires-dist = [
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
+    { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
+]
 
 [package.metadata.requires-dev]
 test = [
@@ -4624,7 +4627,7 @@ test = [
 requires-dist = [
     { name = "equinox", specifier = ">=0.11.8" },
     { name = "jaxtyping", specifier = ">=0.2.34" },
-    { name = "plum-dispatch", specifier = ">=2.5.7" },
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
     { name = "quax", specifier = ">=0.2.0" },
     { name = "unxt", editable = "." },
 ]
@@ -4666,7 +4669,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=7.0.0" },
-    { name = "plum-dispatch", specifier = ">=2.5.7" },
+    { name = "plum-dispatch", specifier = ">=2.5.7,!=2.10.0" },
     { name = "unxt", editable = "." },
     { name = "unxts-api", editable = "packages/unxts.api" },
 ]


### PR DESCRIPTION
Backport of GalacticDynamics/unxt#917 to `versions/v2.0.x`. The automated backport hit conflicts, so this was cherry-picked by hand.

## What

Exclude `plum-dispatch==2.10.0` in the root and in `unxts.api`, `unxts.linalg`, `unxts.parametric`. The `uv.lock` change is metadata only — it already resolved to 2.9.0.

## Why

plum 2.10.0 is the first release to ship **mypyc-compiled wheels**, and `_function.py` is in the compile set. A mypyc *native* class gets neither `__dict__` nor `__weakref__`, so `plum.Function` instances are no longer weak-referenceable. `jax.jit` weakly references the callable it wraps (`jax/_src/pjit.py:_cpp_pjit`), so **every `jax.jit(<dispatched function>)` raises on first call**:

```
TypeError: cannot create weak reference to 'Function' object
```

`unxt.uconvert` and `unxt.uconvert_value` are `plum.Function`s, so this is user-facing, not merely a CI break — `pip install unxt` on Linux is enough to hit it.

Only cp310–cp313 on manylinux, Windows and macOS x86_64 are affected; plum publishes no cp314 wheel and no macOS arm64 wheel, so those fall back to `py3-none-any`. The exclusion is unconditional anyway, since the resolver cannot know which wheel a given install will receive.

## Conflict resolution

The conflicts were entirely in the *surrounding* dependency floors, which are older on this branch than on `main`:

| Line | `main` | `versions/v2.0.x` (kept) |
| --- | --- | --- |
| root | `optional-dependencies>=0.4.1` | `optional-dependencies>=0.3.2`, plus a `packaging>=20.0` line absent on main |
| `unxts.parametric` | `astropy>=7.1` | `astropy>=7.0.0` |

Those floors were left untouched; only the `plum-dispatch` specifiers and their comments were taken from #917. The same two hunks conflicted again in `uv.lock` and were resolved the same way; `uv lock --check` passes and the locked `plum-dispatch` is still 2.9.0.

## Follow-up

Upstream fix in progress; `!=2.10.0` comes back out once a fixed plum is released. Root cause: https://github.com/beartype/plum/issues/317, fix https://github.com/beartype/plum/pull/319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
