### PR TITLE
📝 docs(dimensions): blank-line the lists in `dimension`'s docstring

### DIFF
--- a/src/unxt/_src/dimensions.py
+++ b/src/unxt/_src/dimensions.py
@@ -231,6 +231,7 @@ def dimension(obj: str, /) -> AbstractDimension:
     """Construct dimension from a string.
 
     The string can be:
+
     1. A simple dimension name (e.g., "length", "time", "mass")
     2. A multi-word dimension name (e.g., "amount of substance", "absement")
     3. A mathematical expression using *, /, and ** operators
@@ -238,21 +239,25 @@ def dimension(obj: str, /) -> AbstractDimension:
     Mathematical Expressions:
 
     Expressions are evaluated using operator precedence (PEMDAS):
+
     - ** (exponentiation, highest precedence)
     - * and / (multiplication and division, equal precedence, left-to-right)
 
     Parentheses are supported for grouping and for dimension names with spaces.
 
     Operators Supported:
+
     - `*` : Multiplication (e.g., "length * time")
     - `/` : Division (e.g., "length / time")
     - `**` : Exponentiation (e.g., "length**2")
 
     Unsupported Operators:
+
     - `+` and `-` are NOT supported as operators since dimensions are invariant
       under addition and subtraction. They are treated as part of dimension names.
 
     Rules for Dimension Names in Expressions:
+
     - Single-word names don't need parentheses: "length * time"
     - Multi-word names MUST be parenthesized: "(amount of substance) * time"
     - Parenthesized single-word names are allowed: "(length) / (time)"


### PR DESCRIPTION
## What

Five blank lines in `dimension`'s docstring, so its lists parse as lists.

## Why

Sphinx reports `ERROR: Unexpected indentation` against `unxts.api._src.dimensions.dimension`, twice — once per entry point (`unxt/dims.py` and `unxt/__init__.py`). The docstring it names is plum's *composed* one, so the reported line lands in the `str` method registered in `src/unxt/_src/dimensions.py`, not in the abstract stub.

reStructuredText needs a blank line between a paragraph and a list that follows it. Five lists in this docstring had none.

**The error is the smaller half of the problem.** Only the "Unsupported Operators" list actually raises, because it is the only one with a wrapped continuation line for docutils to trip over. But without the blank line docutils folds the list into the preceding paragraph, so *none* of the six lists were being parsed at all:

```python
>>> t = publish_doctree(unxt.dims.dimension.__doc__)
# before: bullet_list: 0 | enumerated_list: 0
# after:  bullet_list: 5 | enumerated_list: 1
```

They were rendering as run-together prose. After the fix the built HTML carries real `<ul>`/`<ol>` markup:

```html
<ul class="simple">
<li>+ and - are NOT supported as operators since dimensions are invariant
under addition and subtraction. They are treated as part of dimension names.</li>
</ul>
```

## Verification

A local `nox -s docs` builds clean, with no remaining `Unexpected indentation` anywhere in the build.

## Not a broken build

To be clear about what this does and does not fix: this error did not fail CI. The one red `Docs` run on #917 was the external-link checker taking 504s from github.com on three unrelated URLs, and it passed on re-run. This is a latent rendering bug.

## Follow-up

A repo-wide scan finds **18 further docstrings** with the same paragraph-then-list shape — `register_primitives.py` (4), `unxts.linalg/_register_primitives.py` (3), `config.py` (2), the hypothesis package (3), and others. None of them error, but their lists likely mis-render the same way. Left out of this PR deliberately; happy to sweep them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
