### PR TITLE
📝 docs: blank-line the remaining paragraph-then-list docstrings

### DIFF
--- a/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
+++ b/packages/unxts.hypothesis/src/unxts/hypothesis/_src/unitsystems.py
@@ -25,6 +25,7 @@ def unitsystems(
         Hypothesis draw function (automatically provided by @st.composite).
     *units : str | unxt.AbstractUnit | st.SearchStrategy[u.AbstractUnit]
         Variable number of unit specifications. Each can be:
+
         - str: Fixed unit string (e.g., "kpc", "Myr", "Msun")
         - unxt.AbstractUnit: Fixed unit object
         - SearchStrategy: Strategy that generates units

--- a/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/accessors.py
+++ b/packages/unxts.interop.xarray/src/unxts/interop/xarray/_src/accessors.py
@@ -79,6 +79,7 @@ class UnxtDataArrayAccessor:
         ----------
         units : str | AbstractUnit | Mapping | None, optional
             Units to attach. Can be:
+
             - A string or unit object to apply to the data array
             - A dict-like mapping coordinate/variable names to units
             - None to use the "units" attribute

--- a/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
+++ b/packages/unxts.linalg/src/unxts/linalg/_src/_register_primitives.py
@@ -1,6 +1,7 @@
 """Quax primitive registrations for QuantityMatrix arithmetic.
 
 Registers handlers for the following JAX primitives:
+
 - ``lax.add_p`` — element-wise addition
 - ``lax.sub_p`` — element-wise subtraction
 - ``lax.mul_p`` — element-wise multiplication
@@ -437,6 +438,7 @@ def _dot_general_2d_2d(
     then sum with a plain matmul.
 
     The strategy:
+
     1. Pick a reference unit for each ``(i, k)`` output element:
        ``ref[i][k] = A.unit[i][0] * B.unit[0][k]``.
     2. For each contraction index ``j``, compute per-element conversion
@@ -503,6 +505,7 @@ def dot_general_qm_qm(
 
     Delegates to specialized implementations based on the (logical)
     dimensionality of each operand:
+
     - 1D @ 1D → scalar (vector dot product)
     - 2D @ 1D → 1D (matrix-vector product)
     - 1D @ 2D → 1D (vector-matrix product)

--- a/src/unxt/_src/config.py
+++ b/src/unxt/_src/config.py
@@ -280,9 +280,11 @@ class QuantityReprConfig(AbstractQuantityDisplayConfig):
     ----------
     short_arrays : bool | Literal["compact"]
         Controls how arrays are displayed in repr. Options:
+
         - "compact": Show array values without Array wrapper
         - `True`: Show short array summary (shape/dtype)
         - `False`: Show full array representation
+
         Default: `False`
     use_short_name : bool
         If True and a class has a `short_name` attribute, use the short
@@ -319,9 +321,11 @@ class QuantityStrConfig(AbstractQuantityDisplayConfig):
     ----------
     short_arrays : bool | Literal["compact"]
         Controls how arrays are displayed in str. Options:
+
         - "compact": Show array values without Array wrapper
         - `True`: Show short array summary (shape/dtype)
         - `False`: Show full array representation
+
         Default: "compact"
     use_short_name : bool
         If True and a class has a `short_name` attribute, use the short
@@ -807,6 +811,7 @@ def _auto_load_project_toml_config(cfg: UnxtConfig, /, *, stacklevel: int = 2) -
     """Auto-load nearest project TOML config without raising import-time errors.
 
     This function:
+
     1. Searches for nearest pyproject.toml from cwd
     2. Loads [tool.unxts.unxt] configuration
     3. Applies valid settings to config instances

--- a/src/unxt/_src/quantity/register_primitives.py
+++ b/src/unxt/_src/quantity/register_primitives.py
@@ -1622,6 +1622,7 @@ def svd_p_q(
     """SVD decomposition of a quantity matrix.
 
     For a matrix with units (e.g., 'm'), SVD returns:
+
     - When compute_uv=True: [U, S, VT] where S has input units
     - When compute_uv=False: [S] (singular values with input units)
 
@@ -1701,6 +1702,7 @@ def qr_p_q(x: ABCQ, /, **params: Any) -> Any:
     """QR decomposition of a quantity matrix.
 
     For QR decomposition A = Q·R:
+
     - Q is orthonormal (dimensionless)
     - R is upper triangular with the same units as the input
 


### PR DESCRIPTION
Follow-up to #919, which fixed `dimension`. Same defect, everywhere else it occurs.

## The rule

reStructuredText needs a blank line between a paragraph and a list that follows it. Without one, docutils folds the list into the preceding paragraph and it renders as running text.

## Why this is 10 docstrings and not 18

A naive scan for "paragraph line followed by a list marker" flags **24 sites**, and I quoted 18 on #919. Most are false positives: a bullet's own wrapped continuation line followed by the next bullet matches exactly the same shape, and is perfectly well-formed.

So rather than trust the pattern, each candidate was run through `sphinx.ext.napoleon` and `docutils.publish_doctree` before and after, keeping only the ones where the count of parsed `bullet_list` / `enumerated_list` nodes actually rose, or an error disappeared:

| symbol | before → after |
| --- | --- |
| `unitsystems` (hypothesis) | lists 0 → 1 |
| `quantify` (interop.xarray) | lists 0 → 1 |
| `_register_primitives` (linalg, module) | lists 0 → 1 |
| `dot_general_qm_qm` (linalg) | lists 0 → 1 |
| `_dot_general_2d_2d` (linalg) | errors 1 → 0 |
| `_auto_load_project_toml_config` | lists 0 → 1 |
| `svd_p_q` | lists 0 → 1 |
| `qr_p_q` | lists 0 → 1 |

## Two that needed a hand fix

`QuantityReprConfig` and `QuantityStrConfig` came back 0 → 0 and looked like false positives. They are not. Their lists sit inside a numpydoc `Attributes` entry, which napoleon turns into a `.. attribute::` directive that bare docutils cannot parse — so the harness could not see inside it either way. Parsing the directive body on its own shows the real change: **0 lists → 1 list of 3 items**.

Those two also needed a blank line *after* the list, so the trailing `Default:` line reads as its own paragraph instead of an unexpected unindent.

## Deliberately left alone

- `_det.py` and `_inv.py` **indent** their lists under the intro line. That parses as a block quote containing a list — different rendering from a plain list, but not broken, and changing it would be a styling decision rather than a fix.
- `quantity.py`, `revalue`, `apply_ufunc`, `_as_dimensionless_like`, `_combine_quantities`, and the two hypothesis strategies are naive-scan false positives and already parse correctly.

## Verification

Full `nox -s docs`: clean, with no `Unexpected indentation` or `unexpected unindent`. Doctests on all touched modules: 1274 passed.

In the core docs build, `unitsystems` is the one affected symbol that is actually rendered, and it moves from bare text to `<li>` markup. The rest are autodoc'd in the per-package docs, so their improvement is verified at the docutils level rather than in this build's HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
