### PR TITLE
📝 docs: exclude the dead pre-Diátaxis paths from the Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,12 @@ exclude_patterns = [
     ".venv",
     # Excluded: converted to optimize-performance.ipynb during the build
     "how-to/optimize-performance.md",
+    # The pre-Diataxis tree is gone and every path under it is now a rediraffe
+    # redirect. A machine that built the docs before the move still has the
+    # notebook jupytext generated there (`guides/perf.ipynb`), and `.ipynb` is a
+    # `source_suffix` -- so Sphinx would build `guides/perf.html` and rediraffe
+    # would then refuse to write its redirect over it, failing the build.
+    "guides/**",
     "**/_data/**",  # Sample-data dirs (e.g. the xarray guide's), not doc pages
 ]
 


### PR DESCRIPTION
## Symptom

`nox -s docs` fails on any machine that built the docs before #909, with an error naming a file the build never created:

```
WARNING: (broken) guides/perf.html redirects to how-to/optimize-performance.html
but .../html/guides/perf.html already exists!
```

## Cause

#909 moved `guides/perf.md` → `how-to/optimize-performance.md` and correctly updated both the noxfile's jupytext target and `.gitignore` to the new path. What it could not do is remove the notebook already generated at the *old* path on developer machines.

`.ipynb` is in `source_suffix`, so Sphinx still picks that leftover `docs/guides/perf.ipynb` up as a source document and builds `guides/perf.html` from it. rediraffe then wants to write its `guides/perf` → `how-to/optimize-performance` redirect at that same path, finds a file there, and reports it as broken — failing the build.

The stale file is untracked and two releases old, so nothing in the repo points at it and nothing suggests it as the culprit.

## Fix

Exclude the tree. Nothing should live under `docs/guides/` any more: the directory is untracked, every path beneath it is a rediraffe redirect *target*, and rediraffe owns those URLs. Excluding it makes a stale artifact unable to shadow a redirect.

## Why fix this in the repo at all

CI never sees it — a clean checkout has no leftover — so this costs CI nothing and protects only local builds. That asymmetry is the argument for fixing it here rather than leaving each developer to work out on their own that an untracked file from two releases ago is what broke their build. I hit it myself while verifying #920, and it took a bisect-by-moving-the-directory to identify.

## Verification

With `docs/guides/perf.ipynb` deliberately left in place:

- build goes from **exit 1 → exit 0**
- zero `(broken)` warnings
- `guides/perf.html` is the redirect stub again rather than a rendered notebook
- `how-to/optimize-performance.html` still builds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
