### PR TITLE
⬆️ dep-bump: plum-dispatch 2.10.1, and correct the exclusion comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,11 @@ dependencies = [
   "jaxlib>=0.7.2",
   "jaxtyping>=0.3.9",
   "optional-dependencies>=0.4.1",
-  # 2.10.0 ships mypyc-compiled wheels whose `Function` is a native class, so it
-  # is not weak-referenceable and `jax.jit(<dispatched function>)` raises. plum
-  # builds those wheels for cp310-cp313 on manylinux/win/macos-x86_64, which of
-  # the versions we support means 3.12 and 3.13; 3.14 and macOS arm64 get the
-  # pure-Python wheel and are unaffected. The exclusion is unconditional anyway,
-  # since the resolver cannot know which wheel an install will get. Fixed by
-  # beartype/plum#319 -- drop this once a release carries it.
+  # 2.10.0 is the one release whose mypyc-compiled `Function` is a native class:
+  # not weak-referenceable, so `jax.jit(<dispatched function>)` raises, and with
+  # no instance `__dict__`, so `__doc__` assignment fails. Fixed in 2.10.1 by
+  # beartype/plum#319. Keep the exclusion: 2.10.0 stays broken forever, and `!=`
+  # on a single bad release is exactly what keeps a resolver off it.
   "plum-dispatch>=2.7.0,!=2.10.0",
   "plum-dispatch>=2.9.0; python_version>='3.14'",
   "quax>=0.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2615,22 +2615,24 @@ wheels = [
 
 [[package]]
 name = "plum-dispatch"
-version = "2.9.0"
+version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/75/807b02f339906867de07baaecd3519fe8704df013a27ae0a57250ed461d3/plum_dispatch-2.10.1.tar.gz", hash = "sha256:93aa1ec5c4683c0777b9d7d1ccc0b31e0e82f38399116345b4ed8d0fb67cc66e", size = 250842, upload-time = "2026-09-07T17:38:44.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/d6/fc6591336731b5e291319ec3c43d81cd6cc7940c9079183b333b85ed4d77/plum_dispatch-2.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:39a325b0b041fad687271d71abc11b5271d5a3b62af2c6b1271f4ececc3b59de", size = 175166, upload-time = "2026-04-28T08:38:24.467Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4d/5418649397b477ae08839564c97596ede5ef36523147899bb913bbe959d1/plum_dispatch-2.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d39b20a1af776a39e4a0833e97c6258d938e5d874c7f3537bb7d772c39718c1e", size = 205988, upload-time = "2026-04-28T08:38:25.838Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a5/28a6c4e45c4465a6e1a30d65206e913c217690752dc3c9261d78a9187aed/plum_dispatch-2.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:beb9b92c6994404a0d2dc83c857263f5da49519575e5cbb8a13060652746c44c", size = 152563, upload-time = "2026-04-28T08:38:27.37Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/18/19e01dbbaececb75815abb37bc71e10d87a7561829b4eae47ec3b342c94f/plum_dispatch-2.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78987caf558fbdd675a7a4a5c144069f1f9524610195123fb7d0f0234d0af01a", size = 174490, upload-time = "2026-04-28T08:38:28.881Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36662d76ae6d87aaa041fade036d2242f0b88b68c9fb4c96b7ba0026320065d3", size = 204734, upload-time = "2026-04-28T08:38:30.398Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/98/23d19326af0da251bb98a39f517ab6da983e5aad5eb9cc398b60933df2cc/plum_dispatch-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0d16daf09482a6588025e9f133a338d99474e8dd3c3dbbc4c5282a4fffe5a0e", size = 152624, upload-time = "2026-04-28T08:38:31.886Z" },
-    { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d1/10c40a76f0fc3959d73a245e3e63ab576062e2c7db1fb41a4e035a5f4ee0/plum_dispatch-2.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476821e99fe4c747725887021ea09028ff5e013d8732c40c6d44df65815a70ea", size = 285017, upload-time = "2026-09-07T17:38:32.092Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/d0a7d52b1a2e02e883b078e2801cfd544abb05b1a28183e46db43d812667/plum_dispatch-2.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e1a73a06483fffa8f8247bbf6057157075be2f63e76845792eb75d86b11f1188", size = 267393, upload-time = "2026-09-07T17:38:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c3/d8793642ce7d29ea15cc39c10185ef126a27fcb8ea230154978221deb4b2/plum_dispatch-2.10.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5b6a2474f53b23cd07254c2ad286fc8371a3c4ed17dee72794eac9c3a6873db", size = 334557, upload-time = "2026-09-07T17:38:34.857Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c7/3544b2bf05aa9e1a1b45981d21da5e5d5c135fcc2da0ee1040f73512662f/plum_dispatch-2.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae2f76ce97bcbf1d7038e7c352180cbb35c90c23ea0848e2924f35133fb0f223", size = 245830, upload-time = "2026-09-07T17:38:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/16/69/c73f5145dd136158c74295c3f1751062beaf744f508cd04dce61bfe9b059/plum_dispatch-2.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a8cebe7c3380e8cd451008d405fbb3a202626a7da4c140deff36d52dfb05e5aa", size = 283228, upload-time = "2026-09-07T17:38:37.664Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1e/252f11d5443e341cf1a1c4986ec0e5a365bcb605190cfa26410acbe68dc6/plum_dispatch-2.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4e6ffcc378838cffc9f13d67f1ea79585ffea7e04aa00e888941ef63400f175b", size = 265603, upload-time = "2026-09-07T17:38:39.254Z" },
+    { url = "https://files.pythonhosted.org/packages/65/11/6cdfa574f1682840b644527a1644e0740ddb3ddc6e759dcbef4a49091df6/plum_dispatch-2.10.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:131145651d4fa89ee97a026e49545638380a68f71f530ca57b0efaa04dfad1b6", size = 332929, upload-time = "2026-09-07T17:38:40.715Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9a/665b51655fd98196066d042d06af9641d0ac589f9e23ad3e895002c9563b/plum_dispatch-2.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:f75fcfb61c89ca561e3b856d2d9392167d51a283d23c7b9a5d11937a3120cae7", size = 246611, upload-time = "2026-09-07T17:38:42.249Z" },
+    { url = "https://files.pythonhosted.org/packages/55/9f/0adfb5a90d65233b764cb1b07244b72ded1db7cfc66955418544d0da2e38/plum_dispatch-2.10.1-py3-none-any.whl", hash = "sha256:dac63fd5ada8ae8045aefed127dacda0ba02db2635876b12f4e1dfaf6db73f39", size = 49430, upload-time = "2026-09-07T17:38:43.589Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Both follow-ups from plum 2.10.1 shipping [beartype/plum#319](https://github.com/beartype/plum/pull/319).

## 1. The exclusion comment was wrong

#917's comment said to drop `!=2.10.0` "once a release carries it". That guidance would have re-broken users. **2.10.0 stays broken forever**, so `!=` on that one release is exactly right and should stay. Reworded to say so and to name 2.10.1 as the fix.

The constraint itself is unchanged. A `>=2.10.1` floor is not the alternative — that would wrongly exclude 2.7–2.9, which are fine and are what the lock actually used until now.

## 2. The lock moves 2.9.0 → 2.10.1

So CI finally exercises a compiled plum at all.

Worth being precise about what this buys, because 2.9.0 *also* shipped compiled wheels — but `_function.py` was not in its mypyc include list, so the dispatch hot path was interpreted there either way. I confirmed that by building v2.9.0 with `HATCH_BUILD_HOOK_ENABLE_MYPYC=1` and checking: `_resolver` is a `.so`, `_function` is not. (Which is also why neither #317 nor #318 can exist on 2.9.x.)

Measured on py3.13, alternating installs, best-of-N, comparing a locally mypyc-compiled 2.9.0 against released 2.10.1:

| | 2.9.0 | 2.10.1 | |
| --- | --- | --- | --- |
| cached dispatch | 414, 420 ns | 329, 318 ns | **~1.27x** |
| dispatch + return conversion | 3294, 3373 ns | 2641, 2698 ns | **~1.25x** |

At the unxt level, three alternating runs each:

| | 2.9.0 | 2.10.1 | |
| --- | --- | --- | --- |
| `uconvert_value` | 33.9, 37.1, 34.4 µs | 30.9, 29.5, 28.1 µs | **~1.19x** |
| `uconvert(Quantity)` | 286, 278, 249 µs | 170, 147, 145 µs | **~1.75x** |

## Verification

Full suite against 2.10.1: **4301 passed**. The one local failure is the `docs/superpowers/` Sybil artifact, which is git-excluded and absent in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
